### PR TITLE
Refinements to get and specifications methods

### DIFF
--- a/paramtools/parameters.py
+++ b/paramtools/parameters.py
@@ -29,11 +29,13 @@ class Parameters:
         """
         Method to deserialize and validate parameter adjustments.
         `params_or_path` can be a file path or a `dict` that has not been
-        fully deserialized.
+        fully deserialized. The adjusted values replace the current values
+        stored in the correspondig parameter attributes.
 
-        Returns: serialized data.
-
-        Throws: `marshmallow.exceptions.ValidationError` if data is not valid.
+        Raises:
+            marshmallow.exceptions.ValidationError if data is not valid.
+            ParameterUpdateException if dimension values do not match at
+                least one existing value item's corresponding dimension values.
         """
         if isinstance(params_or_path, str) and os.path.exists(params_or_path):
             params = utils.read_json(params_or_path)
@@ -67,10 +69,24 @@ class Parameters:
     def get(self, param, **kwargs):
         """
         Query a parameter's values along dimensions specified in `kwargs`.
+
+        Returns: [{"value": val, "dim0": ..., }]
+
+        Raises:
+            KeyError if queried dimension is not used by this parameter.
+            AttributeError if parameter does not exist.
         """
         return self._get(param, True, **kwargs)
 
     def specification(self, meta_data=False, **kwargs):
+        """
+        Query value(s) of all parameters along dimensions specified in
+        `kwargs`. If `meta_data` is `True`, then parameter attributes
+        are included, too.
+
+        Returns: serialized data of shape
+            {"param_name": [{"value": val, "dim0": ..., }], ...}
+        """
         all_params = OrderedDict()
         for param in self._validator_schema.fields:
             result = self._get(param, False, **kwargs)
@@ -82,6 +98,11 @@ class Parameters:
         return all_params
 
     def format_errors(self, validation_error, compress_errors=True):
+        """
+        Format error messages from ValidationError instance. If
+        `compress_errors` is `True`, all messages are collected and
+        stored in a list.
+        """
         if compress_errors:
             for param, messages in validation_error.messages.items():
                 if param in self.errors:
@@ -97,6 +118,8 @@ class Parameters:
         Private method for querying a parameter along some dimensions. If
         exact_match is True, all values in `kwargs` must be equal to the
         corresponding dimension in the parameter's "value" dictionary.
+
+        Returns: [{"value": val, "dim0": ..., }]
         """
         value = getattr(self, param)["value"]
         ret = []
@@ -108,6 +131,16 @@ class Parameters:
         return ret
 
     def _update_param(self, param, new_values):
+        """
+        Private method for updating the current parameter values with those
+        specified by the adjustment. The values that need to be updated are
+        chosen by finding all value items with dimension values matching
+        the dimension values specified in the adjustment.
+
+        Raises:
+            ParameterUpdateException if dimension values do not match at
+                least one existing value item's corresponding dimension values.
+        """
         curr_vals = getattr(self, param)["value"]
         for i in range(len(new_values)):
             matched_at_least_once = False

--- a/paramtools/tests/test_weather_ex.py
+++ b/paramtools/tests/test_weather_ex.py
@@ -103,7 +103,7 @@ def test_failed_udpate(WeatherParams):
 
 def test_failed_get(WeatherParams):
     params = WeatherParams()
-    with pytest.raises(parameters.ParameterGetException):
+    with pytest.raises(KeyError):
         params.get("average_precipitation", notallowed=1)
 
 


### PR DESCRIPTION
This PR changes the following two methods:

- `get`: This method is used to retrieve the value of a single parameter. The user can filter the "value" list by querying along zero or more allowed dimensions. If the dimension that is queried does not exist in the value list, a `KeyError` exception is thrown. Considering the following parameter:
    ```json
    "min_int_param": {
        "value": [
            {"dim0": "zero", "dim1": 1, "value": 1},
            {"dim0": "one", "dim1": 2, "value": 2}
        ],
    }
    ```

    `params.get('min_int_param', dim0="zero")` returns `[{"dim0": "zero", "dim1": 1, "value": 1}]`, but `params.get('min_int_param', notadim="abc")` throws a `KeyError` because `notadim` is not an allowed dimension.

- `specification`: This method is used to retrieve the value of all parameters. The user can filter these values by querying along zero or more dimensions. However, not all parameters will have every dimension that's in the query. Thus, if the query is `dim0="zero"`, but a parameter doesn't have a `dim0` dimension, then it *will* be included in the result. A slightly more realistic example is the Tax-Calculator data:
```json
{
    "_STD": {
        "value": [
            {"year": 2013, "MARS": "single", "value": 6100.0},
            {"year": 2013, "MARS": "joint", "value": 12200.0},
            {"year": 2013, "MARS": "separate", "value": 6100.0},
            {"year": 2013, "MARS": "headhousehold", "value": 8950.0},
            {"year": 2013, "MARS": "widow", "value": 12200.0}
        ]
    },
    "_cpi_offset": {
        "value": [{"year": 2013, "value": 0.0},
                  {"year": 2014, "value": 0.0},
                  {"year": 2015, "value": 0.0},
                  {"year": 2016, "value": 0.0},
                  {"year": 2017, "value": -0.0025}],
    }
}
```

`params.specification(year=2013, MARS="single")` would return:
```
{'_cpi_offset': [{'year': 2013, 'value': 0.0}],
 '_STD': [{'year': 2013, 'MARS': 'single', 'value': 6100.0}]}
```

Note that the "MARS" component of the query was ignored for the `_cpi_offset` parameter because it does not use that dimension. The previous behavior would have been to exclude `_cpi_offset` from the result.