### PR TITLE
Docs re-organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,9 +181,9 @@ Adjust a given specification.
 JSON Object and Property Definitions
 ---------------------------------------
 
-## Objects
+### Objects
 
-### Dimension object
+#### Dimension object
 - Used for defining the dimensions of the parameter space.
   - "type": Define the datatype of the dimension values. See the [Type property](#type-property).
   - "validators": A mapping of [Validator objects](#validator-object)
@@ -201,7 +201,7 @@ JSON Object and Property Definitions
     }
     ```
 
-### Optional object
+#### Optional object
 - Used for defining optional parameters on the schema. Upstream projects may
   find it value to attach additional information to each parameter that is
   not essential for ParamTools to perform validation.
@@ -216,7 +216,7 @@ JSON Object and Property Definitions
     ```
   - Note: [Validator objects](#validator-object) may be defined on this object in the future.
 
-### Parameter object
+#### Parameter object
 - Used for documenting the parameter and defining the default value of a parameter over the entire parameter space and its validation behavior.
   - Arguments:
     - "param_name": The name of the parameter as it is used in the modeling project.
@@ -252,7 +252,7 @@ JSON Object and Property Definitions
     }
     ```
 
-### Validator object
+#### Validator object
 - Used for validating user input.
 - Available validators:
   - "range": Define a minimum and maximum value for a given parameter.
@@ -275,10 +275,10 @@ JSON Object and Property Definitions
         }
         ```
 
-### Value object
+#### Value object
 - Used to describe the value of a parameter for one or more points in the parameter space.
   - "value": The value of the parameter at this point in space.
-  - Zero or more dimension properties that define which parts of the parameter space this value should be applied to. These dimension properties are defined by [Dimension objects](#dimension-object) in the Specification Schema.
+  - Zero or more dimension properties that define which parts of the parameter space this value should be applied to. These dimension properties are defined by [Dimension objects](#dimension-object) in the [Specification Schema](#specification-schema).
   - Example:
   ```json
         {"city": "Washington, D.C.",
@@ -288,9 +288,9 @@ JSON Object and Property Definitions
   ```
 
 
-## Properties
+### Properties
 
-### Type property
+#### Type property
 - "type": The parameter's data type. Supported types are:
     - "int": Integer.
     - "float": Floating point.
@@ -304,7 +304,7 @@ JSON Object and Property Definitions
         }
         ```
 
-### Number-Dimensions property
+#### Number-Dimensions property
 - "number_dims": The number of dimensions for the specified value. A scalar (e.g. 10) has zero dimensions, a list (e.g. [1, 2]) has one dimension, a nested list (e.g. [[1, 2], [3, 4]]) has two dimensions, etc.
   - Example:
    Note that "value" is a scalar.

--- a/README.md
+++ b/README.md
@@ -14,22 +14,6 @@ Subclass the `Parameters` class and set your [schema](#specification-schema) and
 from paramtools.parameters import Parameters
 from paramtools.utils import get_example_paths
 
-adjustment = {
-    "average_high_temperature": [
-        {
-            "city": "Washington, D.C.",
-            "month": "November",
-            "dayofmonth": 1,
-            "value": 60,
-        },
-        {
-            "city": "Atlanta, GA",
-            "month": "November",
-            "dayofmonth": 1,
-            "value": 63,
-        },
-    ]
-}
 schema, defaults = get_example_paths('weather')
 class WeatherParams(Parameters):
     schema = schema

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ from paramtools.parameters import Parameters
 from paramtools.utils import get_example_paths
 
 schema, defaults = get_example_paths('weather')
+
 class WeatherParams(Parameters):
     schema = schema
     defaults = defaults
@@ -64,7 +65,6 @@ print(params.get("average_high_temperature", month="November"))
 Errors on invalid input:
 ```python
 adjustment["average_high_temperature"][0]["value"] = "HOT"
-# ==> raises error:
 params.adjust(adjustment)
 
 # output: marshmallow.exceptions.ValidationError: {'average_high_temperature': ['Not a valid number.']}
@@ -74,9 +74,10 @@ params.adjust(adjustment)
 Silence the errors by setting `raise_errors` to `False`:
 ```python
 adjustment["average_high_temperature"][0]["value"] = "HOT"
-# ==> raises error:
 params.adjust(adjustment, raise_errors=False)
+
 print(params.errors)
+
 # output: {'average_high_temperature': ['Not a valid number.']}
 
 ```

--- a/README.md
+++ b/README.md
@@ -91,13 +91,13 @@ adjustment["average_high_temperature"][1]["value"] = 3000
 params.adjust(adjustment, raise_errors=False)
 print(params.errors)
 
-ouput:
-{
-    'average_high_temperature': [
-        'average_high_temperature 2000 must be less than 135 for dimensions month=November , city=Washington, D.C. , dayofmonth=1',
-        'average_high_temperature 3000 must be less than 135 for dimensions month=November , city=Atlanta, GA , dayofmonth=1'
-    ]
-}
+# ouput:
+# {
+#     'average_high_temperature': [
+#         'average_high_temperature 2000 must be less than 135 for dimensions month=November , city=Washington, D.C. , dayofmonth=1',
+#         'average_high_temperature 3000 must be less than 135 for dimensions month=November , city=Atlanta, GA , dayofmonth=1'
+#     ]
+# }
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -26,89 +26,212 @@ pip install -e .
 Specification Schema
 --------------------------------------
 
-Define the dimensions of the parameter space
+Define the dimensions of the parameter space.
 
-```json
-{
-    "schema_name": "weather",
-    "dims": {
-        "city": {
-            "type": "str",
-            "validators": {"choice": {"choices": ["Atlanta, GA",
-                                                  "Washington, D.C."]}}
+- "schema_name": Name of the schema.
+- "dims": Mapping of [Dimension objects](#dimension-object).
+- "optional_params": Mapping of [Optional objects](#optional-object).
+- Example:
+    ```json
+    {
+        "schema_name": "weather",
+        "dims": {
+            "city": {
+                "type": "str",
+                "validators": {"choice": {"choices": ["Atlanta, GA",
+                                                    "Washington, D.C."]}}
+            },
+            "month": {
+                "type": "str",
+                "validators": {"choice": {"choices": ["January", "February",
+                                                    "March", "April", "May",
+                                                    "June", "July", "August",
+                                                    "September", "October",
+                                                    "November", "December"]}}
+            },
+            "dayofmonth": {
+                "type": "int",
+                "validators": {"range": {"min": 1, "max": 31}}
+            }
         },
-        "month": {
-            "type": "str",
-            "validators": {"choice": {"choices": ["January", "February",
-                                                  "March", "April", "May",
-                                                  "June", "July", "August",
-                                                  "September", "October",
-                                                  "November", "December"]}}
-        },
-        "dayofmonth": {
-            "type": "int",
-            "validators": {"range": {"min": 1, "max": 31}}
+        "optional": {
+            "scale": {"type": "str", "number_dims": 0},
+            "source": {"type": "str", "number_dims": 0}
         }
-    },
-    "optional_params": {
-        "scale": {"type": "str", "number_dims": 0},
-        "source": {"type": "str", "number_dims": 0}
     }
-}
-```
-
-The "dims" component of the Specification Schema specifies type and validation information for each dimension in the parameter space. `pararmtools` uses this information to check whether the value is the correct type and meets validation requirements, such as a number falling in the correct range. The "dims" component is used to validate the Default Specification and user adjustments to it.
-
-It is likely that the project needs extra information in addition to that required by the minimum parameter definition required by `pararmtools`. This information could add extra documentation or specify parameters for filling out the remaining parts of the default parameter space. It is stored in the "optional_parameters" component of the Parameter Schema.
-
+    ```
 
 Default Specification
 ---------------------------------------------
 
-Define the default values of the project's parameter space
+Define the default values of the project's parameter space.
+- A mapping of [Parameter Objects](#parameter-object).
+- Example:
+    ```json
+    {
+        "average_high_temperature": {
+            "title": "Average High Temperature",
+            "description": "Average high temperature for each day for a selection of cities",
+            "notes": "Data has only been collected for Atlanta and Washington and for only the first of the month.",
+            "scale": "fahrenheit",
+            "source": "NOAA",
+            "type": "int",
+            "number_dims": 0,
+            "value": [
+                {"city": "Washington, D.C.", "month": "January", "dayofmonth": 1, "value": 43},
+                {"city": "Washington, D.C.", "month": "February", "dayofmonth": 1, "value": 47},
+                {"city": "Washington, D.C.", "month": "March", "dayofmonth": 1, "value": 56},
+                {"city": "Washington, D.C.", "month": "April", "dayofmonth": 1, "value": 67},
+                {"city": "Washington, D.C.", "month": "May", "dayofmonth": 1, "value": 76},
+                {"city": "Washington, D.C.", "month": "June", "dayofmonth": 1, "value": 85},
+                {"city": "Washington, D.C.", "month": "July", "dayofmonth": 1, "value": 89},
+                {"city": "Washington, D.C.", "month": "August", "dayofmonth": 1, "value": 87},
+                {"city": "Washington, D.C.", "month": "September", "dayofmonth": 1, "value": 81},
+                {"city": "Washington, D.C.", "month": "October", "dayofmonth": 1, "value": 69},
+                {"city": "Washington, D.C.", "month": "November", "dayofmonth": 1, "value": 59},
+                {"city": "Washington, D.C.", "month": "December", "dayofmonth": 1, "value": 48},
+                {"city": "Atlanta, GA", "month": "January", "dayofmonth": 1, "value": 53},
+                {"city": "Atlanta, GA", "month": "February", "dayofmonth": 1, "value": 58},
+                {"city": "Atlanta, GA", "month": "March", "dayofmonth": 1, "value": 66},
+                {"city": "Atlanta, GA", "month": "April", "dayofmonth": 1, "value": 73},
+                {"city": "Atlanta, GA", "month": "May", "dayofmonth": 1, "value": 80},
+                {"city": "Atlanta, GA", "month": "June", "dayofmonth": 1, "value": 86},
+                {"city": "Atlanta, GA", "month": "July", "dayofmonth": 1, "value": 89},
+                {"city": "Atlanta, GA", "month": "August", "dayofmonth": 1, "value": 88},
+                {"city": "Atlanta, GA", "month": "September", "dayofmonth": 1, "value": 82},
+                {"city": "Atlanta, GA", "month": "October", "dayofmonth": 1, "value": 74},
+                {"city": "Atlanta, GA", "month": "November", "dayofmonth": 1, "value": 64},
+                {"city": "Atlanta, GA", "month": "December", "dayofmonth": 1, "value": 55}
+            ],
+            "validators": {"range": {"min": -130, "max": 135}},
+            "out_of_range_minmsg": "",
+            "out_of_range_maxmsg": "",
+            "out_of_range_action": "warn"
+        },
+        "average_precipitation": {
+            "title": "Average Precipitation",
+            "description": "Average precipitation for a selection of cities by month",
+            "notes": "Data has only been collected for Atlanta and Washington",
+            "scale": "inches",
+            "source": "NOAA",
+            "type": "float",
+            "number_dims": 0,
+            "value": [
+                {"city": "Washington, D.C.", "month": "January", "value": 3.1},
+                {"city": "Washington, D.C.", "month": "February", "value": 2.6},
+                {"city": "Washington, D.C.", "month": "March", "value": 3.5},
+                {"city": "Washington, D.C.", "month": "April", "value": 3.3},
+                {"city": "Washington, D.C.", "month": "May", "value": 4.3},
+                {"city": "Washington, D.C.", "month": "June", "value": 4.3},
+                {"city": "Washington, D.C.", "month": "July", "value": 4.6},
+                {"city": "Washington, D.C.", "month": "August", "value": 3.8},
+                {"city": "Washington, D.C.", "month": "September", "value": 3.9},
+                {"city": "Washington, D.C.", "month": "October", "value": 3.7},
+                {"city": "Washington, D.C.", "month": "November", "value": 3},
+                {"city": "Washington, D.C.", "month": "December", "value": 3.5},
+                {"city": "Atlanta, GA", "month": "January", "value": 3.6},
+                {"city": "Atlanta, GA", "month": "February", "value": 3.7},
+                {"city": "Atlanta, GA", "month": "March", "value": 4.3},
+                {"city": "Atlanta, GA", "month": "April", "value": 3.5},
+                {"city": "Atlanta, GA", "month": "May", "value": 3.8},
+                {"city": "Atlanta, GA", "month": "June", "value": 3.6},
+                {"city": "Atlanta, GA", "month": "July", "value": 5},
+                {"city": "Atlanta, GA", "month": "August", "value": 3.8},
+                {"city": "Atlanta, GA", "month": "September", "value": 3.7},
+                {"city": "Atlanta, GA", "month": "October", "value": 2.8},
+                {"city": "Atlanta, GA", "month": "November", "value": 3.6},
+                {"city": "Atlanta, GA", "month": "December", "value": 4.1}
+            ],
+            "validators": {"range": {"min": 0, "max": 50}},
+            "out_of_range_minmsg": "str",
+            "out_of_range_maxmsg": "str",
+            "out_of_range_action": "stop"
+        }
+    }
+    ```
 
-```json
-{
-    "average_high_temperature": {
-        "title": "Average High Temperature",
-        "description": "Average high temperature for each day for a selection of cities",
-        "notes": "Data has only been collected for Atlanta and Washington and for only the first of the month.",
-        "scale": "fahrenheit",
-        "source": "NOAA",
-        "type": "int",
-        "number_dims": 0,
-        "value": [
-            {"city": "Washington, D.C.", "month": "January", "dayofmonth": 1, "value": 43},
-            {"city": "Washington, D.C.", "month": "February", "dayofmonth": 1, "value": 47},
-            {"city": "Washington, D.C.", "month": "March", "dayofmonth": 1, "value": 56},
-            {"city": "Washington, D.C.", "month": "April", "dayofmonth": 1, "value": 67},
-            {"city": "Washington, D.C.", "month": "May", "dayofmonth": 1, "value": 76},
-            {"city": "Washington, D.C.", "month": "June", "dayofmonth": 1, "value": 85},
-            {"city": "Washington, D.C.", "month": "July", "dayofmonth": 1, "value": 89},
-            {"city": "Washington, D.C.", "month": "August", "dayofmonth": 1, "value": 87},
-            {"city": "Washington, D.C.", "month": "September", "dayofmonth": 1, "value": 81},
-            {"city": "Washington, D.C.", "month": "October", "dayofmonth": 1, "value": 69},
-            {"city": "Washington, D.C.", "month": "November", "dayofmonth": 1, "value": 59},
-            {"city": "Washington, D.C.", "month": "December", "dayofmonth": 1, "value": 48},
-            {"city": "Atlanta, GA", "month": "January", "dayofmonth": 1, "value": 53},
-            {"city": "Atlanta, GA", "month": "February", "dayofmonth": 1, "value": 58},
-            {"city": "Atlanta, GA", "month": "March", "dayofmonth": 1, "value": 66},
-            {"city": "Atlanta, GA", "month": "April", "dayofmonth": 1, "value": 73},
-            {"city": "Atlanta, GA", "month": "May", "dayofmonth": 1, "value": 80},
-            {"city": "Atlanta, GA", "month": "June", "dayofmonth": 1, "value": 86},
-            {"city": "Atlanta, GA", "month": "July", "dayofmonth": 1, "value": 89},
-            {"city": "Atlanta, GA", "month": "August", "dayofmonth": 1, "value": 88},
-            {"city": "Atlanta, GA", "month": "September", "dayofmonth": 1, "value": 82},
-            {"city": "Atlanta, GA", "month": "October", "dayofmonth": 1, "value": 74},
-            {"city": "Atlanta, GA", "month": "November", "dayofmonth": 1, "value": 64},
-            {"city": "Atlanta, GA", "month": "December", "dayofmonth": 1, "value": 55}
+
+Adjustment Schema
+----------------------------
+
+Adjust a given specification.
+- A mapping of parameters and lists of (Value objects)[#value-object].
+- Example:
+    ```json
+    {
+        "average_temperature": [
+            {"city": "Washington, D.C.",
+            "month": "November",
+            "dayofmonth": 1,
+            "value": 60},
+            {"city": "Washington, D.C.",
+            "month": "November",
+            "dayofmonth": 2,
+            "value": 63},
         ],
-        "validators": {"range": {"min": -130, "max": 135}},
-        "out_of_range_minmsg": "",
-        "out_of_range_maxmsg": "",
-        "out_of_range_action": "warn"
-    },
-    "average_precipitation": {
+        "average_precipitation": [
+            {"city": "Washington, D.C.",
+            "month": "November",
+            "dayofmonth": 1,
+            "value": 0.2},
+        ]
+    }
+    ```
+
+JSON Object and Property Definitions
+---------------------------------------
+
+## Objects
+
+### Dimension object
+- Used for defining the dimensions of the parameter space.
+  - "type": Define the datatype of the dimension values. See the [Type property](#type-property).
+  - "validators": A mapping of [Validator objects](#validator-object)
+
+    ```json
+    {
+        "month": {
+            "type": "str",
+            "validators": {"choice": {"choices": ["January", "February",
+                                                    "March", "April", "May",
+                                                    "June", "July", "August",
+                                                    "September", "October",
+                                                    "November", "December"]}}
+        },
+    }
+    ```
+
+### Optional object
+- Used for defining optional parameters on the schema. Upstream projects may
+  find it value to attach additional information to each parameter that is
+  not essential for ParamTools to perform validation.
+  - Arguments:
+    - "type": See [Type property](#type-property).
+    - "number_dims": See [Number-Dimensions Property](#number-dimensions-property).
+  - Example:
+    ```json
+    {
+        "scale": {"type": "str", "number_dims": 0},
+    }
+    ```
+  - Note: [Validator objects](#validator-object) may be defined on this object in the future.
+
+### Parameter object
+- Used for documenting the parameter and defining the default value of a parameter over the entire parameter space and its validation behavior.
+  - Arguments:
+    - "param_name": The name of the parameter as it is used in the modeling project.
+    - "title": "title": A human readable name for the parameter.
+    - "description": Describes the parameter.
+    - "notes": Additional advice or information.
+    - "type": Data type of the parameter. See [Type property](#type-property).
+    - "number_dims": Number of dimensions of the parameter. See [Number-Dimensions property](#number-dimensions-property)
+    - "value": A list of (Value objects)[#value-object].
+    - "validators": A mapping of (Validator objects)[#validator-object]
+    - "out_of_range_{min/max/other op}_msg": Extra information to be used in the message(s) that will be displayed if the parameter value is outside of the specified range. Note that this is in the spec but not currently implemented.
+    - "out_of_range_action": Action to take when specified parameter is outside of the specified range. Options are "stop" or "warn". Note that this is in the spec but only "stop" is currently implemented.
+  - Example:
+    ```json
+    {
         "title": "Average Precipitation",
         "description": "Average precipitation for a selection of cities by month",
         "notes": "Data has only been collected for Atlanta and Washington",
@@ -119,95 +242,86 @@ Define the default values of the project's parameter space
         "value": [
             {"city": "Washington, D.C.", "month": "January", "value": 3.1},
             {"city": "Washington, D.C.", "month": "February", "value": 2.6},
-            {"city": "Washington, D.C.", "month": "March", "value": 3.5},
-            {"city": "Washington, D.C.", "month": "April", "value": 3.3},
-            {"city": "Washington, D.C.", "month": "May", "value": 4.3},
-            {"city": "Washington, D.C.", "month": "June", "value": 4.3},
-            {"city": "Washington, D.C.", "month": "July", "value": 4.6},
-            {"city": "Washington, D.C.", "month": "August", "value": 3.8},
-            {"city": "Washington, D.C.", "month": "September", "value": 3.9},
-            {"city": "Washington, D.C.", "month": "October", "value": 3.7},
-            {"city": "Washington, D.C.", "month": "November", "value": 3},
-            {"city": "Washington, D.C.", "month": "December", "value": 3.5},
             {"city": "Atlanta, GA", "month": "January", "value": 3.6},
-            {"city": "Atlanta, GA", "month": "February", "value": 3.7},
-            {"city": "Atlanta, GA", "month": "March", "value": 4.3},
-            {"city": "Atlanta, GA", "month": "April", "value": 3.5},
-            {"city": "Atlanta, GA", "month": "May", "value": 3.8},
-            {"city": "Atlanta, GA", "month": "June", "value": 3.6},
-            {"city": "Atlanta, GA", "month": "July", "value": 5},
-            {"city": "Atlanta, GA", "month": "August", "value": 3.8},
-            {"city": "Atlanta, GA", "month": "September", "value": 3.7},
-            {"city": "Atlanta, GA", "month": "October", "value": 2.8},
-            {"city": "Atlanta, GA", "month": "November", "value": 3.6},
-            {"city": "Atlanta, GA", "month": "December", "value": 4.1}
+            {"city": "Atlanta, GA", "month": "February", "value": 3.7}
         ],
         "validators": {"range": {"min": 0, "max": 50}},
         "out_of_range_minmsg": "str",
         "out_of_range_maxmsg": "str",
         "out_of_range_action": "stop"
     }
-}
-```
+    ```
 
-- `parameter_name`: Name of the variable where this value will be stored
-- `title`: A "human readable" name that you might use when speaking or writing about this parameter
-- `description`: Describes the parameter
-- `notes`: Advice for the user pertaining to this parameter
-- `type`: Type of the parameter (integer, float, string, boolean, etc)
-- `number_dims`: The number of dimensions for the specified value as in [`numpy.ndim`][]
-  - e.g. `number_dims` is 1 for `"value': {"city": "Washington", "state": "D.C.", "value": [38, -77]}`, that is "value" points to a one dimensional array `[38, -77]`
-- `value`: the default value for this parameter
-  - this describes a default value for all points in the parameter space for this particular parameter
-  - e.g. if describing the default value for the average temperature in a given city on a given day:
+### Validator object
+- Used for validating user input.
+- Available validators:
+  - "range": Define a minimum and maximum value for a given parameter.
+    - Arguments:
+      - "min": Minimum allowed value.
+      - "max": Maximum allowed value.
+    - Example:
+        ```json
+        {
+            "range": {"min": 0, "max": 10}
+        }
+        ```
+  - "choice": Define a set of values that this parameter can take.
+    - Arguments:
+      - "choice": List of allowed values.
+    - Example:
+        ```json
+        {
+            "choice": {"choices": ["allowed choice", "another allowed choice"]}
+        }
+        ```
+
+### Value object
+- Used to describe the value of a parameter for one or more points in the parameter space.
+  - "value": The value of the parameter at this point in space.
+  - Zero or more dimension properties that define which parts of the parameter space this value should be applied to. These dimension properties are defined by [Dimension objects](#dimension-object) in the Specification Schema.
+  - Example:
   ```json
-    "value": [
         {"city": "Washington, D.C.",
          "month": "November",
          "dayofmonth": 1,
          "value": 50},
-        {"city": "Washington, D.C.",
-         "month": "March",
-         "dayofmonth": 1,
-         "value": 49}
-    ]
   ```
-- `validators`: declares the validation methods that should be used for this parameter.
-    - `range`: describes a minimum and maximum value for the parameter
-        - the minimum and maximum can point to either "default" or another parameter by its `parameter_name`
-        - it could be helpful to have a `choices` operation describing a discrete set of valid values for the parameter
-    - `choices`: list of allowed values the parameter's value
-- `out_of_range_{min/max/other op}_msg`: extra information to be used in the message(s) that will be displayed if the parameter value is outside of the specified range
-- `out_of_range_action`: action to take when specified parameter is outside of the specified range. options are `stop` or `warn`
 
 
-Adjustment Schema
-----------------------------
+## Properties
 
-Adjust a specification
+### Type property
+- "type": The parameter's data type. Supported types are:
+    - "int": Integer.
+    - "float": Floating point.
+    - "bool": Boolean. Either True or False.
+    - "str"`: String.
+    - "date": Date. Needs to be of the format "YYYY-MM-DD".
+    - Example:
+        ```json
+        {
+            "type": "int"
+        }
+        ```
 
-```json
-{
-    "average_temperature": [
-        {"city": "Washington, D.C.",
-         "month": "November",
-         "dayofmonth": 1,
-         "value": 60},
-        {"city": "Washington, D.C.",
-         "month": "November",
-         "dayofmonth": 2,
-         "value": 63},
-    ],
-    "average_precipitation": [
-        {"city": "Washington, D.C.",
-         "month": "November",
-         "dayofmonth": 1,
-         "value": 0.2},
-    ]
-}
-```
+### Number-Dimensions property
+- "number_dims": The number of dimensions for the specified value. A scalar (e.g. 10) has zero dimensions, a list (e.g. [1, 2]) has one dimension, a nested list (e.g. [[1, 2], [3, 4]]) has two dimensions, etc.
+  - Example:
+   Note that "value" is a scalar.
+   ```json
+   {
+       "number_dims": 0,
+       "value": [{"city": "Washington", "state": "D.C.", "value": 10}]
+   }
+   ```
 
-The Adjustment Schema defines the data format used for adjusting a given specification.
+   Note that "value" is an one-dimensional list.
+   ```json
+   {
+       "number_dims": 1,
+       "value": [{"city": "Washington", "state": "D.C.", "value": [38, -77]}]
+   }
+   ```
 
 Use `pararmtools`
 -------------------

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ print(params.get("average_high_temperature", month="November"))
 Errors on invalid input:
 ```python
 adjustment["average_high_temperature"][0]["value"] = "HOT"
+# ==> raises error
 params.adjust(adjustment)
 
 # output: marshmallow.exceptions.ValidationError: {'average_high_temperature': ['Not a valid number.']}
@@ -90,10 +91,13 @@ adjustment["average_high_temperature"][1]["value"] = 3000
 params.adjust(adjustment, raise_errors=False)
 print(params.errors)
 
-# ouput:
-# {
-#     'average_high_temperature': ['average_high_temperature 2000 must be less than 135 for dimensions month=November , city=Washington, D.C. , dayofmonth=1', 'average_high_temperature 3000 must be less than 135 for dimensions month=November , city=Atlanta, GA , dayofmonth=1']
-# }
+ouput:
+{
+    'average_high_temperature': [
+        'average_high_temperature 2000 must be less than 135 for dimensions month=November , city=Washington, D.C. , dayofmonth=1',
+        'average_high_temperature 3000 must be less than 135 for dimensions month=November , city=Atlanta, GA , dayofmonth=1'
+    ]
+}
 
 ```
 

--- a/examples/baseball/schema.json
+++ b/examples/baseball/schema.json
@@ -3,7 +3,7 @@
     "dims": {
         "use_2018": {"type": "bool", "validators": {}}
     },
-    "optional_params": {
+    "optional": {
         "section_1": {"type": "str", "number_dims": 0},
         "section_2": {"type": "str", "number_dims": 0}
     }

--- a/examples/taxcalc/schema.json
+++ b/examples/taxcalc/schema.json
@@ -22,7 +22,7 @@
                                                  "2kids", "3+kids"]}}
         }
     },
-    "optional_params": {
+    "optional": {
         "section_1": {"type": "str", "number_dims": 0},
         "section_2": {"type": "str", "number_dims": 0},
         "section_3": {"type": "str", "number_dims": 0},

--- a/examples/weather/schema.json
+++ b/examples/weather/schema.json
@@ -19,7 +19,7 @@
             "validators": {"range": {"min": 1, "max": 31}}
         }
     },
-    "optional_params": {
+    "optional": {
         "scale": {"type": "str", "number_dims": 0},
         "source": {"type": "str", "number_dims": 0}
     }

--- a/paramtools/schema.py
+++ b/paramtools/schema.py
@@ -319,7 +319,7 @@ VALIDATOR_MAP = {
 def get_param_schema(base_spec, field_map=None):
     """
     Read in data from the initializing schema. This will be used to fill in the
-    optional parameters on classes derived from the `BaseParamSchema` class.
+    optional properties on classes derived from the `BaseParamSchema` class.
     This data is also used to build validators for schema for each parameter
     that will be set on the `BaseValidatorSchema` class
     """
@@ -328,7 +328,7 @@ def get_param_schema(base_spec, field_map=None):
     else:
         field_map = FIELD_MAP.copy()
     optional_fields = {}
-    for k, v in base_spec["optional_params"].items():
+    for k, v in base_spec["optional"].items():
         fieldtype = field_map[v["type"]]
         if v["number_dims"] is not None:
             d = v["number_dims"]

--- a/paramtools/tests/schema.json
+++ b/paramtools/tests/schema.json
@@ -11,7 +11,7 @@
             "validators": {"range": {"min": 0, "max": 5}}
         }
     },
-    "optional_params": {
+    "optional": {
         "opt0": {"type": "str", "number_dims": 0}
     }
 }


### PR DESCRIPTION
I recently re-discovered the [Mozilla WOT API][1] spec and was really taken with how clean their JSON schema docs were. They define JSON objects and properties and they link to their definitions when they are used in a given schema. This has the benefit of abstracting away some of the low-level information that you don't need to understand fully right off the bat. 

For example, the `defaults.json` file is a mapping of parameter names to their meta data--that's it. Then, you can dive deeper into the Parameter objects. You find out that they are composed of some properties, a list of Value objects, and a mapping of Validator objects. Then, when it's time, one can take a look at those objects.

This way users can take information in one layer at a time--without being hit by a wall of low-level details.

[1]: https://iot.mozilla.org/wot/