### PR TITLE
Add methods for converting to and from arrays

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ install:
   - pip install numpy
   - pip install pytest
   - pip install -e .
+  - export `pwd`
 # command to run tests
 script:
   - pytest tests/ -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ python:
   - "3.7"
 # command to install dependencies
 install:
-  - pip install marshmallow>=3.* numpy pytest
+  - pip install numpy
+  - pip install pytest
   - pip install -e .
 # command to run tests
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
+dist: xenial
 language: python
 python:
   - "3.6"
-  - "3.7-dev"
+  - "3.7"
 # command to install dependencies
 install:
   - pip install numpy

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
   - pip install numpy
   - pip install pytest
   - pip install -e .
-  - echo `pwd`
+
 # command to run tests
 script:
-  - pytest tests/ -v
+  - cd paramtools && pytest tests/ -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python:
   - "3.6"
-  - "3.7"
+  - "3.7-dev"
 # command to install dependencies
 install:
   - pip install numpy

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
   - pip install numpy
   - pip install pytest
   - pip install -e .
-  - export `pwd`
+  - echo `pwd`
 # command to run tests
 script:
   - pytest tests/ -v

--- a/README.md
+++ b/README.md
@@ -101,6 +101,22 @@ print(params.errors)
 
 ```
 
+Convert [Value objects](#value-object) to and from arrays:
+```python
+arr = params.to_array("average_precipitation")
+print(arr.tolist())
+
+# output:
+# [[3.1, 2.6, 3.5, 3.3, 4.3, 4.3, 4.6, 3.8, 3.9, 3.7, 3.0, 3.5], [3.6, 3.7, 4.3, 3.5, 3.8, 3.6, 5.0, 3.8, 3.7, 2.8, 3.6, 4.1]]
+
+vi_list = params.from_array("average_precipitation", arr)
+print(vi_list[:2])
+
+# output:
+# [{'city': 'Washington, D.C.', 'month': 'January', 'value': 3.1}, {'city': 'Washington, D.C.', 'month': 'February', 'value': 2.6}]
+
+```
+
 How to install ParamTools
 -----------------------------------------
 
@@ -313,6 +329,26 @@ JSON Object and Property Definitions
     ```
   - Note: [Validator objects](#validator-object) may be defined on this object in the future.
 
+#### Order object
+- Used for converting [Value objects](#value-objects) into n-dimensional arrays.
+  - Arguments:
+    - "dim_order": List specifying the ordering of the dimensions.
+    - "dim_values": Mapping specifying the allowed values for each dimension.
+  - Example:
+    ```json
+    {
+        "dim_order": ["dim0", "dim1", "dim2"],
+        "value_order": {
+            "dim0": ["zero", "one"],
+            "dim1": [0, 1, 2, 3, 4, 5],
+            "dim2": [0, 1, 2]
+        }
+    }
+    ```
+  - Note: The Order object is not required in general, but it must be specified
+    to use the `Parameters.to_array` and `Parameters.from_array` methods.
+
+
 #### Parameter object
 - Used for documenting the parameter and defining the default value of a parameter over the entire parameter space and its validation behavior.
   - Arguments:
@@ -322,6 +358,7 @@ JSON Object and Property Definitions
     - "notes": Additional advice or information.
     - "type": Data type of the parameter. See [Type property](#type-property).
     - "number_dims": Number of dimensions of the parameter. See [Number-Dimensions property](#number-dimensions-property)
+    - "order": An [Order object](#order-object)
     - "value": A list of (Value objects)[#value-object].
     - "validators": A mapping of (Validator objects)[#validator-object]
     - "out_of_range_{min/max/other op}_msg": Extra information to be used in the message(s) that will be displayed if the parameter value is outside of the specified range. Note that this is in the spec but not currently implemented.
@@ -336,6 +373,13 @@ JSON Object and Property Definitions
         "source": "NOAA",
         "type": "float",
         "number_dims": 0,
+        "order": {
+            "dim_order": ["city", "month"],
+            "dim_values": {
+                "city": ["Washington, D.C", "Atlanta, GA"],
+                "month": ["January", "February"],
+            }
+        },
         "value": [
             {"city": "Washington, D.C.", "month": "January", "value": 3.1},
             {"city": "Washington, D.C.", "month": "February", "value": 2.6},

--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ JSON Object and Property Definitions
         "number_dims": 0,
         "order": {
             "dim_order": ["city", "month"],
-            "dim_values": {
+            "value_order": {
                 "city": ["Washington, D.C", "Atlanta, GA"],
                 "month": ["January", "February"],
             }

--- a/examples/weather/defaults.json
+++ b/examples/weather/defaults.json
@@ -46,6 +46,13 @@
         "source": "NOAA",
         "type": "float",
         "number_dims": 0,
+        "order": {
+            "dim_order": ["city", "month"],
+            "value_order": {
+                "city": ["Washington, D.C.", "Atlanta, GA"],
+                "month": ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"]
+            }
+        },
         "value": [
             {"city": "Washington, D.C.", "month": "January", "value": 3.1},
             {"city": "Washington, D.C.", "month": "February", "value": 2.6},

--- a/paramtools/schema.py
+++ b/paramtools/schema.py
@@ -72,6 +72,10 @@ class ValueValidatorSchema(Schema):
     choice = fields.Nested(ChoiceSchema(), required=False)
 
 
+class OrderField(Schema):
+    dim_order = fields.List(fields.Str)
+    value_order = fields.Dict(values=fields.List(fields.Field), keys=fields.Str)
+
 class BaseParamSchema(Schema):
     """
     Defines a base parameter schema. This specifies the required fields and
@@ -105,6 +109,7 @@ class BaseParamSchema(Schema):
         data_key="type",
     )
     number_dims = fields.Integer(required=True)
+    order = fields.Nested(OrderField(), required=False)
     value = fields.Field(required=True)  # will be specified later
     validators = fields.Nested(ValueValidatorSchema(), required=True)
     out_of_range_minmsg = fields.Str()

--- a/paramtools/tests/defaults.json
+++ b/paramtools/tests/defaults.json
@@ -120,5 +120,65 @@
         "out_of_range_minmsg": "",
         "out_of_range_maxmsg": "",
         "out_of_range_action": "stop"
+    },
+    "int_dense_array_param": {
+        "title": "Integer Dense Array Param",
+        "description": "Example of using an int type param that supports to/from_array.",
+        "notes": "Dense means that the full space is explicitly spanned in the list of Value objects.",
+        "opt0": "an option",
+        "type": "int",
+        "number_dims": 0,
+        "order": {
+            "dim_order": ["dim0", "dim1", "dim2"],
+            "value_order": {
+                "dim0": ["zero", "one"],
+                "dim1": [0, 1, 2, 3, 4, 5],
+                "dim2": [0, 1, 2]
+            }
+        },
+        "value": [
+            {"dim0": "zero", "dim1": 0, "dim2": 0, "value": 1},
+            {"dim0": "zero", "dim1": 0, "dim2": 1, "value": 2},
+            {"dim0": "zero", "dim1": 0, "dim2": 2, "value": 3},
+            {"dim0": "zero", "dim1": 1, "dim2": 0, "value": 4},
+            {"dim0": "zero", "dim1": 1, "dim2": 1, "value": 5},
+            {"dim0": "zero", "dim1": 1, "dim2": 2, "value": 6},
+            {"dim0": "zero", "dim1": 2, "dim2": 0, "value": 7},
+            {"dim0": "zero", "dim1": 2, "dim2": 1, "value": 8},
+            {"dim0": "zero", "dim1": 2, "dim2": 2, "value": 9},
+            {"dim0": "zero", "dim1": 3, "dim2": 0, "value": 10},
+            {"dim0": "zero", "dim1": 3, "dim2": 1, "value": 11},
+            {"dim0": "zero", "dim1": 3, "dim2": 2, "value": 12},
+            {"dim0": "zero", "dim1": 4, "dim2": 0, "value": 13},
+            {"dim0": "zero", "dim1": 4, "dim2": 1, "value": 14},
+            {"dim0": "zero", "dim1": 4, "dim2": 2, "value": 15},
+            {"dim0": "zero", "dim1": 5, "dim2": 0, "value": 16},
+            {"dim0": "zero", "dim1": 5, "dim2": 1, "value": 17},
+            {"dim0": "zero", "dim1": 5, "dim2": 2, "value": 18},
+
+            {"dim0": "one", "dim1": 0, "dim2": 0, "value": 19},
+            {"dim0": "one", "dim1": 0, "dim2": 1, "value": 20},
+            {"dim0": "one", "dim1": 0, "dim2": 2, "value": 21},
+            {"dim0": "one", "dim1": 1, "dim2": 0, "value": 22},
+            {"dim0": "one", "dim1": 1, "dim2": 1, "value": 23},
+            {"dim0": "one", "dim1": 1, "dim2": 2, "value": 24},
+            {"dim0": "one", "dim1": 2, "dim2": 0, "value": 25},
+            {"dim0": "one", "dim1": 2, "dim2": 1, "value": 26},
+            {"dim0": "one", "dim1": 2, "dim2": 2, "value": 27},
+            {"dim0": "one", "dim1": 3, "dim2": 0, "value": 28},
+            {"dim0": "one", "dim1": 3, "dim2": 1, "value": 29},
+            {"dim0": "one", "dim1": 3, "dim2": 2, "value": 30},
+            {"dim0": "one", "dim1": 4, "dim2": 0, "value": 31},
+            {"dim0": "one", "dim1": 4, "dim2": 1, "value": 32},
+            {"dim0": "one", "dim1": 4, "dim2": 2, "value": 33},
+            {"dim0": "one", "dim1": 5, "dim2": 0, "value": 34},
+            {"dim0": "one", "dim1": 5, "dim2": 1, "value": 35},
+            {"dim0": "one", "dim1": 5, "dim2": 2, "value": 36}
+
+        ],
+        "validators": {"range": {"min": 1, "max": 9}},
+        "out_of_range_minmsg": "",
+        "out_of_range_maxmsg": "",
+        "out_of_range_action": "stop"
     }
 }

--- a/paramtools/tests/schema.json
+++ b/paramtools/tests/schema.json
@@ -9,6 +9,10 @@
         "dim1": {
             "type": "int",
             "validators": {"range": {"min": 0, "max": 5}}
+        },
+        "dim2": {
+            "type": "int",
+            "validators": {"range": {"min": 0, "max": 2}}
         }
     },
     "optional": {

--- a/paramtools/tests/test_all.py
+++ b/paramtools/tests/test_all.py
@@ -175,3 +175,40 @@ def test_errors_multiple_params(TestParams):
         "date_param": ["Not a valid date."],
     }
     assert params.errors == exp
+
+
+def test_to_array(TestParams):
+    params = TestParams()
+    res = params.to_array("int_dense_array_param")
+
+    exp = [
+        [
+            [ 1,  2,  3],
+            [ 4,  5,  6],
+            [ 7,  8,  9],
+            [10, 11, 12],
+            [13, 14, 15],
+            [16, 17, 18]
+        ],
+
+        [
+            [19, 20, 21],
+            [22, 23, 24],
+            [25, 26, 27],
+            [28, 29, 30],
+            [31, 32, 33],
+            [34, 35, 36]
+        ]
+    ]
+
+    assert res.tolist() == exp
+
+    exp = params.int_dense_array_param["value"]
+    assert (
+        params.from_array("int_dense_array_param", res) == exp
+    )
+
+    params.int_dense_array_param["value"].pop(0)
+
+    with pytest.raises(parameters.SparseValueObjectsException):
+        params.to_array("int_dense_array_param")

--- a/paramtools/tests/test_weather_ex.py
+++ b/paramtools/tests/test_weather_ex.py
@@ -155,3 +155,9 @@ def test_doc_example(schema_def_path, defaults_spec_path):
 
     params.adjust(adjustment, raise_errors=False)
     print(params.errors)
+
+    arr = params.to_array("average_precipitation")
+    print(arr.tolist())
+
+    vi_list = params.from_array("average_precipitation", arr)
+    print(vi_list[:2])


### PR DESCRIPTION
This PR adds `to_array` and `from_array` methods to the `Parameters` class. See the updated README for example usage:

![screen shot 2019-01-22 at 11 05 39 am](https://user-images.githubusercontent.com/9206065/51548135-b6c56300-1e35-11e9-94de-587130175b3c.png)

I went back and forth about what to name the methods. Other options I considered are:

- `array` instead of `to_array`. as in `params.array("some_param")`
- `valueobjects` instead of `from_array`. as in `params.valueobjects("some_param", array)`

I'm interested in hearing feedback on the method names.

An Order object is added to the JSON schema by this PR. It supplies information about the dimension space of a particular parameter:
- "dim_order": order of the axes of the array. 
- "value_order": expected values of the dimensions and the order of those values along the given dimension.

This information is used to construct the shape of the array and its indexing.

