### PR TITLE
Improve development/user experience

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+- repo: https://github.com/ambv/black
+  rev: 18.9b0
+  hooks:
+  - id: black
+    language_version: python3.6
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v2.1.0
+  hooks:
+    - id: flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,7 @@ python:
   - "3.7"
 # command to install dependencies
 install:
-  - pip install numpy
-  - pip install pytest
+  - pip install -r requirements-dev.txt
   - pip install -e .
 
 # command to run tests

--- a/paramtools/__init__.py
+++ b/paramtools/__init__.py
@@ -1,1 +1,7 @@
 name = "paramtools"
+
+from paramtools.build_schema import *
+from paramtools.exceptions import *
+from paramtools.parameters import *
+from paramtools.schema import *
+from paramtools.utils import *

--- a/paramtools/contrib/__init__.py
+++ b/paramtools/contrib/__init__.py
@@ -1,0 +1,1 @@
+from paramtools.contrib.validate import *

--- a/paramtools/contrib/validate.py
+++ b/paramtools/contrib/validate.py
@@ -1,11 +1,15 @@
 import datetime
 
-from marshmallow import validate, ValidationError, fields
+from marshmallow import (
+    validate as marshmallow_validate,
+    ValidationError,
+    fields,
+)
 
 from paramtools import utils
 
 
-class Range(validate.Range):
+class Range(marshmallow_validate.Range):
     def __init__(self, min=None, max=None, error_min=None, error_max=None):
         self.min = min
         self.max = max

--- a/paramtools/schema.py
+++ b/paramtools/schema.py
@@ -5,8 +5,7 @@ from marshmallow import (
     fields,
     validate,
     validates_schema,
-    exceptions,
-    ValidationError,
+    ValidationError as MarshmallowValidationError,
 )
 
 from paramtools.contrib import validate as contrib_validate
@@ -173,7 +172,7 @@ class BaseValidatorSchema(Schema):
                     errors_exist = True
                     errors[name][i] = {"value": iserrors}
         if errors_exist:
-            raise exceptions.ValidationError(dict(errors))
+            raise MarshmallowValidationError(dict(errors))
 
     def validate_param(self, param_name, param_spec, raw_data):
         """
@@ -207,7 +206,7 @@ class BaseValidatorSchema(Schema):
         for validator in validators:
             try:
                 validator(value)
-            except ValidationError as ve:
+            except MarshmallowValidationError as ve:
                 errors.append(str(ve))
 
         return errors
@@ -220,7 +219,9 @@ class BaseValidatorSchema(Schema):
         elif vname == "date_range":
             range_class = contrib_validate.DateRange
         else:
-            raise ValidationError(f"{vname} is not an allowed validator")
+            raise MarshmallowValidationError(
+                f"{vname} is not an allowed validator"
+            )
         min_value = range_dict.get("min", None)
         if min_value is not None:
             min_value = self._resolve_op_value(

--- a/paramtools/tests/test_all.py
+++ b/paramtools/tests/test_all.py
@@ -3,9 +3,9 @@ import json
 
 import pytest
 
-from paramtools.exceptions import ValidationError, SparseValueObjectsException
+from paramtools import ValidationError, SparseValueObjectsException
 
-from paramtools import parameters
+from paramtools import Parameters
 
 CURRENT_PATH = os.path.abspath(os.path.dirname(__file__))
 
@@ -22,7 +22,7 @@ def defaults_spec_path():
 
 @pytest.fixture
 def TestParams(schema_def_path, defaults_spec_path):
-    class _TestParams(parameters.Parameters):
+    class _TestParams(Parameters):
         schema = schema_def_path
         defaults = defaults_spec_path
 

--- a/paramtools/tests/test_baseball.py
+++ b/paramtools/tests/test_baseball.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 
-from paramtools.exceptions import ValidationError
+from paramtools import ValidationError
 from paramtools import parameters
 
 CURRENT_PATH = os.path.abspath(os.path.dirname(__file__))

--- a/paramtools/tests/test_tc_ex.py
+++ b/paramtools/tests/test_tc_ex.py
@@ -4,8 +4,8 @@ import pytest
 
 from marshmallow import fields, Schema
 
-from paramtools.parameters import Parameters
-from paramtools.exceptions import ValidationError
+from paramtools import Parameters
+from paramtools import ValidationError
 
 CURRENT_PATH = os.path.abspath(os.path.dirname(__file__))
 

--- a/paramtools/tests/test_utils.py
+++ b/paramtools/tests/test_utils.py
@@ -1,4 +1,4 @@
-from paramtools import utils
+from paramtools import get_leaves, ravel
 
 
 def test_get_leaves():
@@ -10,34 +10,34 @@ def test_get_leaves():
         },
     }
 
-    leaves = utils.get_leaves(t)
+    leaves = get_leaves(t)
     assert leaves == [f"leaf{i}" for i in range(1, 9)]
 
-    leaves = utils.get_leaves([t])
+    leaves = get_leaves([t])
     assert leaves == [f"leaf{i}" for i in range(1, 9)]
 
-    leaves = utils.get_leaves({})
+    leaves = get_leaves({})
     assert leaves == []
 
-    leaves = utils.get_leaves([])
+    leaves = get_leaves([])
     assert leaves == []
 
-    leaves = utils.get_leaves("leaf")
+    leaves = get_leaves("leaf")
     assert leaves == ["leaf"]
 
 
 def test_ravel():
     a = 1
-    assert utils.ravel(a) == 1
+    assert ravel(a) == 1
 
     b = [1, 2, 3]
-    assert utils.ravel(b) == [1, 2, 3]
+    assert ravel(b) == [1, 2, 3]
 
     c = [[1], 2, 3]
-    assert utils.ravel(c) == [1, 2, 3]
+    assert ravel(c) == [1, 2, 3]
 
     d = [[1, 2, 3], [4, 5, 6]]
-    assert utils.ravel(d) == [1, 2, 3, 4, 5, 6]
+    assert ravel(d) == [1, 2, 3, 4, 5, 6]
 
     e = [0, [1, 2, 3], 4, [5, 6, 7], 8]
-    assert utils.ravel(e) == [0, 1, 2, 3, 4, 5, 6, 7, 8]
+    assert ravel(e) == [0, 1, 2, 3, 4, 5, 6, 7, 8]

--- a/paramtools/tests/test_weather_ex.py
+++ b/paramtools/tests/test_weather_ex.py
@@ -3,8 +3,8 @@ import json
 
 import pytest
 
-from paramtools import parameters
-from paramtools.exceptions import ValidationError, ParameterUpdateException
+from paramtools import Parameters
+from paramtools import ValidationError, ParameterUpdateException
 
 CURRENT_PATH = os.path.abspath(os.path.dirname(__file__))
 
@@ -27,7 +27,7 @@ def defaults_spec_path():
 
 @pytest.fixture
 def WeatherParams(schema_def_path, defaults_spec_path):
-    class _WeatherParams(parameters.Parameters):
+    class _WeatherParams(Parameters):
         schema = schema_def_path
         defaults = defaults_spec_path
 
@@ -107,8 +107,8 @@ def test_failed_get(WeatherParams):
 
 
 def test_doc_example(schema_def_path, defaults_spec_path):
-    from paramtools.parameters import Parameters
-    from paramtools.utils import get_example_paths
+    from paramtools import Parameters
+    from paramtools import get_example_paths
 
     adjustment = {
         "average_high_temperature": [
@@ -127,7 +127,7 @@ def test_doc_example(schema_def_path, defaults_spec_path):
         ]
     }
     # project_schema, baseline_parameters = get_example_paths('weather')
-    class WeatherParams(parameters.Parameters):
+    class WeatherParams(Parameters):
         schema = schema_def_path
         defaults = defaults_spec_path
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+line-length = 79

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+pre-commit
+pytest
+numpy

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+numpy
+black
 pre-commit
 pytest
-numpy


### PR DESCRIPTION
This PR adds:
- `requirements-dev.txt`: installs black, pre-commit, numpy, and pytest.
  - numpy is still not absolutely required, but users who do not install numpy will not have access to the `to_array`/`from_array` methods. 
- Use pre-commit to automatically re-format code on commit. i.e. black formats your code so *you* don't have to.
- Import all packages to `__init__.py` modules. This allows the user to do:

```python
from paramtools import Parameters
```

whereas they had to do this before:
```python
from paramtools.parameters import Parameters
```