### PR TITLE
Add a OneOf contrib class to support array params

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,3 +8,4 @@ repos:
   rev: v2.1.0
   hooks:
     - id: flake8
+      args: ["--max-line-length=100"]

--- a/paramtools/contrib/validate.py
+++ b/paramtools/contrib/validate.py
@@ -49,3 +49,18 @@ class DateRange(Range):
         if max is not None and not isinstance(max, datetime.date):
             max = fields.Date()._deserialize(max, None, None)
         super().__init__(min, max, error_min, error_max)
+
+
+class OneOf(marshmallow_validate.OneOf):
+    def __call__(self, value):
+        if not isinstance(value, list):
+            values = [value]
+        else:
+            values = utils.ravel(value)
+        for val in values:
+            try:
+                if val not in self.choices:
+                    raise ValidationError(self._format_error(val))
+            except TypeError:
+                raise ValidationError(self._format_error(val))
+        return value

--- a/paramtools/schema.py
+++ b/paramtools/schema.py
@@ -250,16 +250,23 @@ class BaseValidatorSchema(Schema):
         self, vname, choice_dict, param_name, dims, param_spec, raw_data
     ):
         choices = choice_dict["choices"]
-        error = (
-            '{param_name} "{input}" must be in list of choices '
-            "{choices} for dimensions {dims}"
-        ).format(
+        if len(choices) < 20:
+            error_template = (
+                '{param_name} "{input}" must be in list of choices '
+                "{choices} for dimensions {dims}."
+            )
+        else:
+            error_template = (
+                '{param_name} "{input}" must be in list of choices '
+                "for dimensions {dims}."
+            )
+        error = error_template.format(
             param_name=param_name,
             dims=dims,
             input="{input}",
             choices="{choices}",
         )
-        return validate.OneOf(choices, error=error)
+        return contrib_validate.OneOf(choices, error=error)
 
     def _resolve_op_value(self, op_value, param_name, param_spec, raw_data):
         """

--- a/paramtools/tests/test_all.py
+++ b/paramtools/tests/test_all.py
@@ -110,7 +110,7 @@ def test_errors_choice_param(TestParams):
         params.adjust(adjustment)
     msg = [
         'str_choice_param "not a valid choice" must be in list of choices value0, '
-        "value1 for dimensions "
+        "value1 for dimensions ."
     ]
     assert excinfo.value.messages["str_choice_param"][0] == msg
 

--- a/paramtools/tests/test_validate.py
+++ b/paramtools/tests/test_validate.py
@@ -1,0 +1,23 @@
+import pytest
+from marshmallow import ValidationError
+
+from paramtools.contrib import OneOf
+
+
+def test_OneOf():
+    choices = ["allowed1", "allowed2"]
+
+    oneof = OneOf(choices=choices)
+    assert oneof("allowed1") == "allowed1"
+    assert oneof(choices) == choices
+    assert oneof([choices]) == [choices]
+
+    with pytest.raises(ValidationError):
+        oneof("notallowed")
+
+    with pytest.raises(ValidationError):
+        oneof(["notallowed", "allowed1"])
+
+    # no support for 3-D arrays yet.
+    with pytest.raises(ValidationError):
+        oneof([[choices]])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,5 @@
 [tool.black]
 line-length = 79
+
+[tool.flake8]
+line-length=100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,2 @@
 [tool.black]
 line-length = 79
-
-[tool.flake8]
-line-length=100


### PR DESCRIPTION
This PR:
- Adds support for array parameters that use the choice validator.
- Does not display choices if there are more than 20.
  - Another option for displaying this data is to display the first 10 or 20 choices. I made this change because Matchups uses a list of 20,000 choices (every Major League Baseball player ever). It was absurd to display all of them. I didn't think displaying the first N choices would add more information. However, I'm open to discussing this further:
```python
In [1]: import matchups

In [2]: params = matchups.MatchupsParams()

In [3]: params.adjust({"batter": [{"value": ["not a real better"], "use_2018": False}]})
...
ValidationError: {'batter': ['batter "not a real better" must be in list of choices for dimensions use_2018=False.']}

In [4]: 
```