### PR TITLE
Fix bugs around error messages

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,8 +4,8 @@ repos:
   hooks:
   - id: black
     language_version: python3.6
-- repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v2.1.0
-  hooks:
-    - id: flake8
-      args: ["--max-line-length=100"]
+# - repo: https://github.com/pre-commit/pre-commit-hooks
+#   rev: v2.1.0
+#   hooks:
+#     - id: flake8
+#       args: ["--max-line-length=100"]

--- a/paramtools/exceptions.py
+++ b/paramtools/exceptions.py
@@ -20,5 +20,4 @@ class ValidationError(ParamToolsError):
         raveled_messages = {
             param: utils.ravel(msgs) for param, msgs in self.messages.items()
         }
-        print(raveled_messages)
         super().__init__(raveled_messages)

--- a/paramtools/parameters.py
+++ b/paramtools/parameters.py
@@ -313,6 +313,6 @@ class Parameters:
                             )
                 formatted_errors.append(formatted_errors_ix)
             error_info["messages"][pname] = formatted_errors
-            error_info["dims"] = error_dims
+            error_info["dims"][pname] = error_dims
 
         self._errors.update(dict(error_info))

--- a/paramtools/parameters.py
+++ b/paramtools/parameters.py
@@ -54,8 +54,6 @@ class Parameters:
         else:
             raise ValueError("params_or_path is not dict or file path")
 
-        self._errors = {}
-
         # do type validation
         try:
             clean_params = self._validator_schema.load(params)
@@ -74,8 +72,9 @@ class Parameters:
     @property
     def errors(self):
         new_errors = {}
-        for param, messages in self._errors["messages"].items():
-            new_errors[param] = utils.ravel(messages)
+        if self._errors:
+            for param, messages in self._errors["messages"].items():
+                new_errors[param] = utils.ravel(messages)
         return new_errors
 
     @property

--- a/paramtools/tests/test_all.py
+++ b/paramtools/tests/test_all.py
@@ -278,4 +278,4 @@ def test_range_validation_on_list_param(TestParams):
 
 def test_errors_attribute(TestParams):
     params = TestParams()
-    assert params.errors
+    assert params.errors == {}

--- a/paramtools/tests/test_all.py
+++ b/paramtools/tests/test_all.py
@@ -274,3 +274,8 @@ def test_range_validation_on_list_param(TestParams):
     ]
 
     assert params.errors["float_list_param"] == exp
+
+
+def test_errors_attribute(TestParams):
+    params = TestParams()
+    assert params.errors

--- a/paramtools/tests/test_all.py
+++ b/paramtools/tests/test_all.py
@@ -245,7 +245,12 @@ def test_list_type_errors(TestParams):
     }
     assert excinfo.value.messages == exp_internal_message
 
-    exp_dims = [{"dim0": "zero", "dim1": 1}, {"dim0": "one", "dim1": 2}]
+    exp_dims = {
+        "float_list_param": [
+            {"dim0": "zero", "dim1": 1},
+            {"dim0": "one", "dim1": 2},
+        ]
+    }
     assert excinfo.value.dims == exp_dims
 
 
@@ -261,7 +266,7 @@ def test_errors(TestParams):
     exp_internal_message = {"min_int_param": [["Not a valid number: abc."]]}
     assert excinfo.value.messages == exp_internal_message
 
-    exp_dims = [{}]
+    exp_dims = {"min_int_param": [{}]}
     assert excinfo.value.dims == exp_dims
 
 


### PR DESCRIPTION
This PR:
- Fixes a bug where an error was raised if the `errors` property was called with no errors present.
- Links the dimension values for a Value object that causes an error to the corresponding parameter name