### PR TITLE
Make NumPy a hard dependency

### DIFF
--- a/paramtools/parameters.py
+++ b/paramtools/parameters.py
@@ -116,8 +116,6 @@ class Parameters:
         Returns: n-dimensional NumPy array.
 
         Raises:
-            NotImplementedError: NumPy must be installed. A pure Python
-                version has not yet been implemented.
             SparseValueObjectsException: Value object does not span the
                 entire space specified by the Order object.
         """

--- a/paramtools/parameters.py
+++ b/paramtools/parameters.py
@@ -4,11 +4,7 @@ import itertools
 from collections import OrderedDict, defaultdict
 from functools import reduce
 
-try:
-    import numpy as np
-except ModuleNotFoundError:
-    np = None
-
+import numpy as np
 from marshmallow import ValidationError as MarshmallowValidationError
 
 from paramtools.build_schema import SchemaBuilder
@@ -125,12 +121,6 @@ class Parameters:
             SparseValueObjectsException: Value object does not span the
                 entire space specified by the Order object.
         """
-        if np is None:
-            # In the future, an alternative method will be implemented in
-            # pure Python.
-            raise NotImplementedError(
-                "Numpy must be installed to use `to_array`."
-            )
         param_meta = getattr(self, param)
         dim_order = param_meta["order"]["dim_order"]
         value_order = param_meta["order"]["value_order"]

--- a/paramtools/schema.py
+++ b/paramtools/schema.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 
+import numpy as np
 from marshmallow import (
     Schema,
     fields,
@@ -10,21 +11,13 @@ from marshmallow import (
 
 from paramtools.contrib import validate as contrib_validate
 
-# only use numpy if its installed
-try:
-    import numpy as np
-
-    fieldfloat, fieldint, fieldbool = np.float64, np.int64, np.bool_
-except ModuleNotFoundError:
-    fieldfloat, fieldint, fieldbool = float, int, bool
-
 
 class Float64(fields.Number):
     """
     Define field to match up with numpy float64 type
     """
 
-    num_type = fieldfloat
+    num_type = np.float64
 
 
 class Int8(fields.Number):
@@ -32,7 +25,7 @@ class Int8(fields.Number):
     Define field to match up with numpy int64 type
     """
 
-    num_type = fieldint
+    num_type = np.int64
 
 
 class Bool_(fields.Boolean):
@@ -40,7 +33,7 @@ class Bool_(fields.Boolean):
     Define field to match up with numpy bool_ type
     """
 
-    num_type = fieldbool
+    num_type = np.bool_
 
 
 class RangeSchema(Schema):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
-numpy
 black
 pre-commit
 pytest

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/hdoupe/ParamTools",
     packages=setuptools.find_packages(),
-    install_requires= ["marshmallow>=3.*"],
+    install_requires= ["marshmallow>=3.*", "numpy"],
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
Prior to this PR, ParamTools could be used without NumPy. However, ParamTools is going to need powerful array manipulation functionality and NumPy provides that.