### PR TITLE
Use dimension validator information in to/from_array methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ How to use ParamTools
 Subclass the `Parameters` class and set your [specification schema](#specification-schema) and [default specification](#default-specification) files:
 
 ```python
-from paramtools.parameters import Parameters
-from paramtools.utils import get_example_paths
+from paramtools import Parameters
+from paramtools import get_example_paths
 
 schema, defaults = get_example_paths('weather')
 

--- a/paramtools/contrib/__init__.py
+++ b/paramtools/contrib/__init__.py
@@ -1,1 +1,2 @@
 from paramtools.contrib.validate import *
+from paramtools.contrib.fields import *

--- a/paramtools/contrib/fields.py
+++ b/paramtools/contrib/fields.py
@@ -1,0 +1,65 @@
+import numpy as np
+from marshmallow import fields as marshmallow_fields
+
+
+class Float64(marshmallow_fields.Number):
+    """
+    Define field to match up with numpy float64 type
+    """
+
+    num_type = np.float64
+
+
+class Int64(marshmallow_fields.Number):
+    """
+    Define field to match up with numpy int64 type
+    """
+
+    num_type = np.int64
+
+
+class Bool_(marshmallow_fields.Boolean):
+    """
+    Define field to match up with numpy bool_ type
+    """
+
+    num_type = np.bool_
+
+    def _deserialize(self, value, attr, obj, **kwargs):
+        return np.bool_(super()._deserialize(value, attr, obj, **kwargs))
+
+    def _serialize(self, value, attr, obj, **kwargs):
+        return super()._serialize(bool(value), attr, obj, **kwargs)
+
+
+class MeshFieldMixin:
+    """
+    Provides method for accessing contrib.validate
+    validators' mesh methods
+    """
+
+    def mesh(self):
+        if not self.validators:
+            return []
+        assert len(self.validators) == 1
+        return self.validators[0].mesh()
+
+
+class Str(MeshFieldMixin, marshmallow_fields.Str):
+    pass
+
+
+class Integer(MeshFieldMixin, marshmallow_fields.Integer):
+    pass
+
+
+class Float(MeshFieldMixin, marshmallow_fields.Float):
+    pass
+
+
+class Boolean(MeshFieldMixin, marshmallow_fields.Boolean):
+    pass
+
+
+class Date(MeshFieldMixin, marshmallow_fields.Date):
+    pass

--- a/paramtools/contrib/validate.py
+++ b/paramtools/contrib/validate.py
@@ -3,7 +3,7 @@ import datetime
 from marshmallow import (
     validate as marshmallow_validate,
     ValidationError,
-    fields,
+    fields as marshmallow_fields,
 )
 
 from paramtools import utils
@@ -36,6 +36,9 @@ class Range(marshmallow_validate.Range):
 
         return value
 
+    def mesh(self):
+        return list(range(self.min, self.max + 1))
+
 
 class DateRange(Range):
     """
@@ -45,10 +48,13 @@ class DateRange(Range):
 
     def __init__(self, min=None, max=None, error_min=None, error_max=None):
         if min is not None and not isinstance(min, datetime.date):
-            min = fields.Date()._deserialize(min, None, None)
+            min = marshmallow_fields.Date()._deserialize(min, None, None)
         if max is not None and not isinstance(max, datetime.date):
-            max = fields.Date()._deserialize(max, None, None)
+            max = marshmallow_fields.Date()._deserialize(max, None, None)
         super().__init__(min, max, error_min, error_max)
+
+    def mesh(self):
+        return None
 
 
 class OneOf(marshmallow_validate.OneOf):
@@ -64,3 +70,6 @@ class OneOf(marshmallow_validate.OneOf):
             except TypeError:
                 raise ValidationError(self._format_error(val))
         return value
+
+    def mesh(self):
+        return self.choices

--- a/paramtools/exceptions.py
+++ b/paramtools/exceptions.py
@@ -21,3 +21,7 @@ class ValidationError(ParamToolsError):
             param: utils.ravel(msgs) for param, msgs in self.messages.items()
         }
         super().__init__(raveled_messages)
+
+
+class InconsistentDimensionsException(ParamToolsError):
+    pass

--- a/paramtools/parameters.py
+++ b/paramtools/parameters.py
@@ -26,6 +26,9 @@ class Parameters:
         defaults, self._validator_schema = sb.build_schemas()
         for k, v in defaults.items():
             setattr(self, k, v)
+        self.dim_mesh = OrderedDict(
+            [(name, v.mesh()) for name, v in sb.dim_validators.items()]
+        )
         self._validator_schema.context["spec"] = self
         self._errors = {}
 

--- a/paramtools/schema.py
+++ b/paramtools/schema.py
@@ -9,31 +9,10 @@ from marshmallow import (
     ValidationError as MarshmallowValidationError,
 )
 
-from paramtools.contrib import validate as contrib_validate
-
-
-class Float64(fields.Number):
-    """
-    Define field to match up with numpy float64 type
-    """
-
-    num_type = np.float64
-
-
-class Int8(fields.Number):
-    """
-    Define field to match up with numpy int64 type
-    """
-
-    num_type = np.int64
-
-
-class Bool_(fields.Boolean):
-    """
-    Define field to match up with numpy bool_ type
-    """
-
-    num_type = np.bool_
+from paramtools.contrib import (
+    validate as contrib_validate,
+    fields as contrib_fields,
+)
 
 
 class RangeSchema(Schema):
@@ -306,32 +285,36 @@ class BaseValidatorSchema(Schema):
 
 # A few fields that have not been instantiated yet
 CLASS_FIELD_MAP = {
-    "str": fields.Str,
-    "int": fields.Integer,
-    "float": fields.Float,
-    "bool": fields.Boolean,
-    "date": fields.Date,
+    "str": contrib_fields.Str,
+    "int": contrib_fields.Integer,
+    "float": contrib_fields.Float,
+    "bool": contrib_fields.Boolean,
+    "date": contrib_fields.Date,
 }
 
 
 # A few fields that have been instantiated
 FIELD_MAP = {
-    "str": fields.Str(),
-    "int": fields.Integer(),
-    "float": fields.Float(),
-    "bool": fields.Boolean(),
-    "date": fields.Date(),
+    "str": contrib_fields.Str(),
+    "int": contrib_fields.Integer(),
+    "float": contrib_fields.Float(),
+    "bool": contrib_fields.Boolean(),
+    "date": contrib_fields.Date(),
 }
 
 VALIDATOR_MAP = {
-    "range": validate.Range,
+    "range": contrib_validate.Range,
     "date_range": contrib_validate.DateRange,
-    "choice": validate.OneOf,
+    "choice": contrib_validate.OneOf,
 }
 
 
 def get_type(data):
-    numeric_types = {"int": Int8(), "bool": Bool_(), "float": Float64()}
+    numeric_types = {
+        "int": contrib_fields.Int64(),
+        "bool": contrib_fields.Bool_(),
+        "float": contrib_fields.Float64(),
+    }
     types = dict(FIELD_MAP, **numeric_types)
     fieldtype = types[data["type"]]
     dim = data["number_dims"]

--- a/paramtools/tests/defaults.json
+++ b/paramtools/tests/defaults.json
@@ -121,10 +121,10 @@
         "out_of_range_maxmsg": "",
         "out_of_range_action": "stop"
     },
-    "int_dense_array_param": {
+    "int_dense_array_param_with_order": {
         "title": "Integer Dense Array Param",
-        "description": "Example of using an int type param that supports to/from_array.",
-        "notes": "Dense means that the full space is explicitly spanned in the list of Value objects.",
+        "description": "Example of using an int type param that supports to/from_array and specifies order.",
+        "notes": "See int_dense_array_param for an ex without order. Note that vals 3 and 4 were removed from dim1.",
         "opt0": "an option",
         "type": "int",
         "number_dims": 0,
@@ -132,10 +132,50 @@
             "dim_order": ["dim0", "dim1", "dim2"],
             "value_order": {
                 "dim0": ["zero", "one"],
-                "dim1": [0, 1, 2, 3, 4, 5],
+                "dim1": [0, 1, 2, 5],
                 "dim2": [0, 1, 2]
             }
         },
+        "value": [
+            {"dim0": "zero", "dim1": 0, "dim2": 0, "value": 1},
+            {"dim0": "zero", "dim1": 0, "dim2": 1, "value": 2},
+            {"dim0": "zero", "dim1": 0, "dim2": 2, "value": 3},
+            {"dim0": "zero", "dim1": 1, "dim2": 0, "value": 4},
+            {"dim0": "zero", "dim1": 1, "dim2": 1, "value": 5},
+            {"dim0": "zero", "dim1": 1, "dim2": 2, "value": 6},
+            {"dim0": "zero", "dim1": 2, "dim2": 0, "value": 7},
+            {"dim0": "zero", "dim1": 2, "dim2": 1, "value": 8},
+            {"dim0": "zero", "dim1": 2, "dim2": 2, "value": 9},
+            {"dim0": "zero", "dim1": 5, "dim2": 0, "value": 16},
+            {"dim0": "zero", "dim1": 5, "dim2": 1, "value": 17},
+            {"dim0": "zero", "dim1": 5, "dim2": 2, "value": 18},
+
+            {"dim0": "one", "dim1": 0, "dim2": 0, "value": 19},
+            {"dim0": "one", "dim1": 0, "dim2": 1, "value": 20},
+            {"dim0": "one", "dim1": 0, "dim2": 2, "value": 21},
+            {"dim0": "one", "dim1": 1, "dim2": 0, "value": 22},
+            {"dim0": "one", "dim1": 1, "dim2": 1, "value": 23},
+            {"dim0": "one", "dim1": 1, "dim2": 2, "value": 24},
+            {"dim0": "one", "dim1": 2, "dim2": 0, "value": 25},
+            {"dim0": "one", "dim1": 2, "dim2": 1, "value": 26},
+            {"dim0": "one", "dim1": 2, "dim2": 2, "value": 27},
+            {"dim0": "one", "dim1": 5, "dim2": 0, "value": 34},
+            {"dim0": "one", "dim1": 5, "dim2": 1, "value": 35},
+            {"dim0": "one", "dim1": 5, "dim2": 2, "value": 36}
+
+        ],
+        "validators": {"range": {"min": 1, "max": 9}},
+        "out_of_range_minmsg": "",
+        "out_of_range_maxmsg": "",
+        "out_of_range_action": "stop"
+    },
+    "int_dense_array_param": {
+        "title": "Integer Dense Array Param",
+        "description": "Example of using an int type param that supports to/from_array.",
+        "notes": "Dense means that the full space is explicitly spanned in the list of Value objects.",
+        "opt0": "an option",
+        "type": "int",
+        "number_dims": 0,
         "value": [
             {"dim0": "zero", "dim1": 0, "dim2": 0, "value": 1},
             {"dim0": "zero", "dim1": 0, "dim2": 1, "value": 2},

--- a/paramtools/tests/test_fields.py
+++ b/paramtools/tests/test_fields.py
@@ -1,0 +1,42 @@
+import numpy as np
+from marshmallow import ValidationError as MarshmallowVE
+
+from paramtools.contrib import fields, validate
+
+
+def test_np_value_fields():
+    float64 = fields.Float64()
+    res = float64._deserialize("2", None, None)
+    assert res == 2.0
+    assert isinstance(res, np.float64)
+
+    int64 = fields.Int64()
+    res = int64._deserialize("2", None, None)
+    assert res == 2
+    assert isinstance(res, np.int64)
+
+    bool_ = fields.Bool_()
+    res = bool_._deserialize("true", None, None)
+    assert res == True
+    assert isinstance(res, np.bool_)
+    assert bool_._serialize(res, None, None) is True
+
+
+def test_contrib_fields():
+    range_validator = validate.Range(0, 10)
+    daterange_validator = validate.DateRange("2019-01-01", "2019-02-01")
+    choice_validator = validate.OneOf(choices=["one", "two"])
+
+    s = fields.Str(validate=[choice_validator])
+    assert s.mesh() == ["one", "two"]
+    s = fields.Str()
+    assert s.mesh() == []
+
+    s = fields.Integer(validate=[range_validator])
+    assert s.mesh() == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    s = fields.Str()
+    assert s.mesh() == []
+
+    # date will need an interval argument.
+    s = fields.Date(validate=[daterange_validator])
+    assert s.mesh() is None

--- a/paramtools/tests/test_utils.py
+++ b/paramtools/tests/test_utils.py
@@ -1,4 +1,4 @@
-from paramtools import get_leaves, ravel
+from paramtools import get_leaves, ravel, consistent_dims
 
 
 def test_get_leaves():
@@ -41,3 +41,17 @@ def test_ravel():
 
     e = [0, [1, 2, 3], 4, [5, 6, 7], 8]
     assert ravel(e) == [0, 1, 2, 3, 4, 5, 6, 7, 8]
+
+
+def test_consistent_dims():
+    v = [
+        {"dim0": 1, "dim1": 2, "value": 3},
+        {"dim0": 4, "dim1": 5, "value": 6},
+    ]
+    assert consistent_dims(v) == set(["dim0", "dim1"])
+
+    v = [{"dim0": 1, "value": 3}, {"dim0": 4, "dim1": 5, "value": 6}]
+    assert consistent_dims(v) is None
+
+    v = [{"dim0": 1, "dim1": 2, "value": 3}, {"dim0": 4, "value": 6}]
+    assert consistent_dims(v) is None

--- a/paramtools/utils.py
+++ b/paramtools/utils.py
@@ -68,3 +68,16 @@ def ravel(ndim_list):
         else:
             raveled.append(maybe_list)
     return raveled
+
+
+def consistent_dims(value_items):
+    """
+    Get dimensions used consistently across all value objects.
+    Returns None if dimensions are omitted or added for
+    some value object(s).
+    """
+    used = set(k for k in value_items[0] if k != "value")
+    for vo in value_items:
+        if used != set(k for k in vo if k != "value"):
+            return None
+    return used

--- a/paramtools/utils.py
+++ b/paramtools/utils.py
@@ -1,4 +1,5 @@
 import json
+from collections import OrderedDict
 
 
 def read_json(path):
@@ -6,7 +7,7 @@ def read_json(path):
     Read JSON file shortcut
     """
     with open(path, "r") as f:
-        r = json.loads(f.read())
+        r = json.loads(f.read(), object_pairs_hook=OrderedDict)
     return r
 
 


### PR DESCRIPTION
This PR makes it possible to use the `Parameters.to_array` and `Parameters.from_array` methods without specifying an [order object][1]. This is accomplished by inspecting the dimension validators set in `schema.json`. The order of the dimensions is set by the order that the dimensions are specified in `schema.json`. The values that those dimensions can take on are determined by inspecting the validator object. The choice validator's values are set in the "choices" attribute. The range validator's values are determined by generating a list of values from the min to the max value, incrementing by one. In a future PR, a "step" or "increment" value will be added.

For example, consider the weather parameters:

```json
    "dims": {
        "city": {
            "type": "str",
            "validators": {"choice": {"choices": ["Atlanta, GA",
                                                "Washington, D.C."]}}
        },
        "month": {
            "type": "str",
            "validators": {"choice": {"choices": ["January", "February",
                                                "March", "April", "May",
                                                "June", "July", "August",
                                                "September", "October",
                                                "November", "December"]}}
        },
        "dayofmonth": {
            "type": "int",
            "validators": {"range": {"min": 1, "max": 31}}
        }"
    },
```

The order of the dimensions is "city", "day", and then "month". A parameter that used the "city" and "dayofmonth" dimensions would be converted into a 2x31 size matrix.





[1]: https://github.com/PSLmodels/ParamTools/tree/0.2.0#order-object