### PR TITLE
Move example tests to submodule

### DIFF
--- a/paramtools/tests/test_examples/test_baseball.py
+++ b/paramtools/tests/test_examples/test_baseball.py
@@ -15,12 +15,12 @@ def field_map():
 
 @pytest.fixture
 def schema_def_path():
-    return os.path.join(CURRENT_PATH, "../examples/baseball/schema.json")
+    return os.path.join(CURRENT_PATH, "../../examples/baseball/schema.json")
 
 
 @pytest.fixture
 def defaults_spec_path():
-    return os.path.join(CURRENT_PATH, "../examples/baseball/defaults.json")
+    return os.path.join(CURRENT_PATH, "../../examples/baseball/defaults.json")
 
 
 @pytest.fixture

--- a/paramtools/tests/test_examples/test_tc_ex.py
+++ b/paramtools/tests/test_examples/test_tc_ex.py
@@ -29,12 +29,12 @@ def field_map():
 
 @pytest.fixture
 def schema_def_path():
-    return os.path.join(CURRENT_PATH, "../examples/taxparams/schema.json")
+    return os.path.join(CURRENT_PATH, "../../examples/taxparams/schema.json")
 
 
 @pytest.fixture
 def defaults_spec_path():
-    return os.path.join(CURRENT_PATH, "../examples/taxparams/defaults.json")
+    return os.path.join(CURRENT_PATH, "../../examples/taxparams/defaults.json")
 
 
 @pytest.fixture
@@ -54,13 +54,15 @@ def test_load_schema(TaxcalcParams):
 
 @pytest.fixture
 def demo_schema_def_path():
-    return os.path.join(CURRENT_PATH, "../examples/taxparams-demo/schema.json")
+    return os.path.join(
+        CURRENT_PATH, "../../examples/taxparams-demo/schema.json"
+    )
 
 
 @pytest.fixture
 def demo_defaults_spec_path():
     return os.path.join(
-        CURRENT_PATH, "../examples/taxparams-demo/defaults.json"
+        CURRENT_PATH, "../../examples/taxparams-demo/defaults.json"
     )
 
 

--- a/paramtools/tests/test_examples/test_weather_ex.py
+++ b/paramtools/tests/test_examples/test_weather_ex.py
@@ -15,12 +15,12 @@ def field_map():
 
 @pytest.fixture
 def schema_def_path():
-    return os.path.join(CURRENT_PATH, "../examples/weather/schema.json")
+    return os.path.join(CURRENT_PATH, "../../examples/weather/schema.json")
 
 
 @pytest.fixture
 def defaults_spec_path():
-    return os.path.join(CURRENT_PATH, "../examples/weather/defaults.json")
+    return os.path.join(CURRENT_PATH, "../../examples/weather/defaults.json")
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR moves the tests for the examples config files to a submodule `test_examples`.