### PR TITLE
Add example with Behresp parameters

### DIFF
--- a/paramtools/examples/behresp/defaults.json
+++ b/paramtools/examples/behresp/defaults.json
@@ -1,0 +1,35 @@
+{
+    "BE_sub": {
+        "title": "Substitution elasticity of taxable income",
+        "description": "Defined as proportional change in taxable income divided by proportional change in marginal net-of-tax rate (1-MTR) on taxpayer earnings caused by the reform.  Must be zero or positive.",
+        "notes": "",
+        "type": "float",
+        "number_dims": 0,
+        "value": [{"value": 0.0}],
+        "validators": {
+            "range": {"min": 0.0, "max": 9e99}
+        }
+    },
+    "BE_inc": {
+        "title": "Income elasticity of taxable income",
+        "description": "Defined as dollar change in taxable income divided by dollar change in after-tax income caused by the reform.  Must be zero or negative.",
+        "notes": "",
+        "type": "float",
+        "number_dims": 0,
+        "value": [{"value": 0.0}],
+        "validators": {
+            "range": {"min": -9e99, "max": 0}
+        }
+    },
+    "BE_cg": {
+        "title": "Semi-elasticity of long-term capital gains",
+        "description": "Defined as change in logarithm of long-term capital gains divided by change in marginal tax rate (MTR) on long-term capital gains caused by the reform.  Must be zero or negative.  Read response function documentation (see below) for discussion of appropriate values.",
+        "notes": "",
+        "type": "float",
+        "number_dims": 0,
+        "value": [{"value": 0.0}],
+        "validators": {
+            "range": {"min": -9e99, "max": 0}
+        }
+    }
+}

--- a/paramtools/examples/behresp/schema.json
+++ b/paramtools/examples/behresp/schema.json
@@ -1,0 +1,5 @@
+{
+    "schema_name": "behresp",
+    "dims": {},
+    "optional": {}
+}

--- a/paramtools/parameters.py
+++ b/paramtools/parameters.py
@@ -37,8 +37,6 @@ class Parameters:
         self.state = initial_state or {}
         if array_first is not None:
             self.array_first = array_first
-        else:
-            self.array_first = array_first
         self.set_state()
 
     def set_state(self, **dims):

--- a/paramtools/schema.py
+++ b/paramtools/schema.py
@@ -195,17 +195,24 @@ class BaseValidatorSchema(Schema):
             max_value = self._resolve_op_value(
                 max_value, param_name, param_spec, raw_data
             )
+        dim_suffix = " for dimensions {dims}" if dims else ""
         min_error = (
-            "{param_name} {input} must be greater than "
-            "{min} for dimensions {dims}"
+            "{param_name} {input} must be greater than " "{min}{dim_suffix}"
         ).format(
-            param_name=param_name, dims=dims, input="{input}", min="{min}"
+            param_name=param_name,
+            dims=dims,
+            input="{input}",
+            min="{min}",
+            dim_suffix=dim_suffix,
         )
         max_error = (
-            "{param_name} {input} must be less than "
-            "{max} for dimensions {dims}"
+            "{param_name} {input} must be less than " "{max}{dim_suffix}"
         ).format(
-            param_name=param_name, dims=dims, input="{input}", max="{max}"
+            param_name=param_name,
+            dims=dims,
+            input="{input}",
+            max="{max}",
+            dim_suffix=dim_suffix,
         )
         return range_class(min_value, max_value, min_error, max_error)
 

--- a/paramtools/schema.py
+++ b/paramtools/schema.py
@@ -183,7 +183,7 @@ class BaseValidatorSchema(Schema):
             range_class = contrib_validate.DateRange
         else:
             raise MarshmallowValidationError(
-                f"{vname} is not an allowed validator"
+                f"{vname} is not an allowed validator."
             )
         min_value = range_dict.get("min", None)
         if min_value is not None:
@@ -195,9 +195,9 @@ class BaseValidatorSchema(Schema):
             max_value = self._resolve_op_value(
                 max_value, param_name, param_spec, raw_data
             )
-        dim_suffix = " for dimensions {dims}" if dims else ""
+        dim_suffix = f" for dimensions {dims}" if dims else ""
         min_error = (
-            "{param_name} {input} must be greater than " "{min}{dim_suffix}"
+            "{param_name} {input} must be greater than " "{min}{dim_suffix}."
         ).format(
             param_name=param_name,
             dims=dims,
@@ -206,7 +206,7 @@ class BaseValidatorSchema(Schema):
             dim_suffix=dim_suffix,
         )
         max_error = (
-            "{param_name} {input} must be less than " "{max}{dim_suffix}"
+            "{param_name} {input} must be less than " "{max}{dim_suffix}."
         ).format(
             param_name=param_name,
             dims=dims,
@@ -220,21 +220,20 @@ class BaseValidatorSchema(Schema):
         self, vname, choice_dict, param_name, dims, param_spec, raw_data
     ):
         choices = choice_dict["choices"]
+        dim_suffix = f" for dimensions {dims}" if dims else ""
         if len(choices) < 20:
             error_template = (
                 '{param_name} "{input}" must be in list of choices '
-                "{choices} for dimensions {dims}."
+                "{choices}{dim_suffix}."
             )
         else:
-            error_template = (
-                '{param_name} "{input}" must be in list of choices '
-                "for dimensions {dims}."
-            )
+            error_template = '{param_name} "{input}" must be in list of choices{dim_suffix}.'
         error = error_template.format(
             param_name=param_name,
             dims=dims,
             input="{input}",
             choices="{choices}",
+            dim_suffix=dim_suffix,
         )
         return contrib_validate.OneOf(choices, error=error)
 

--- a/paramtools/schema.py
+++ b/paramtools/schema.py
@@ -77,8 +77,8 @@ class BaseParamSchema(Schema):
     number_dims = fields.Integer(required=True)
     value = fields.Field(required=True)  # will be specified later
     validators = fields.Nested(ValueValidatorSchema(), required=True)
-    out_of_range_minmsg = fields.Str()
-    out_of_range_maxmsg = fields.Str()
+    out_of_range_minmsg = fields.Str(required=False)
+    out_of_range_maxmsg = fields.Str(required=False)
     out_of_range_action = fields.Str(
         required=False, validate=validate.OneOf(choices=["stop", "warn"])
     )

--- a/paramtools/tests/test_examples/test_behresp.py
+++ b/paramtools/tests/test_examples/test_behresp.py
@@ -1,0 +1,37 @@
+import os
+
+import pytest
+
+from paramtools import Parameters
+
+CURRENT_PATH = os.path.abspath(os.path.dirname(__file__))
+
+
+@pytest.fixture
+def field_map():
+    # nothing here for now
+    return {}
+
+
+@pytest.fixture
+def schema_def_path():
+    return os.path.join(CURRENT_PATH, "../../examples/behresp/schema.json")
+
+
+@pytest.fixture
+def defaults_spec_path():
+    return os.path.join(CURRENT_PATH, "../../examples/behresp/defaults.json")
+
+
+@pytest.fixture
+def BehrespParams(schema_def_path, defaults_spec_path):
+    class _BehrespParams(Parameters):
+        schema = schema_def_path
+        defaults = defaults_spec_path
+
+    return _BehrespParams
+
+
+def test_load_schema(BehrespParams):
+    params = BehrespParams()
+    assert params

--- a/paramtools/tests/test_parameters.py
+++ b/paramtools/tests/test_parameters.py
@@ -183,7 +183,7 @@ class TestErrors:
             params.adjust(adjustment)
         msg = [
             'str_choice_param "not a valid choice" must be in list of choices value0, '
-            "value1 for dimensions ."
+            "value1."
         ]
         assert excinfo.value.messages["str_choice_param"][0] == msg
 
@@ -218,9 +218,7 @@ class TestErrors:
         curr = params.int_default_param[0]["value"]
         adjustment = {"int_default_param": [{"value": curr - 1}]}
         params.adjust(adjustment, raise_errors=False)
-        exp = [
-            f"int_default_param {curr-1} must be greater than 2 for dimensions "
-        ]
+        exp = [f"int_default_param {curr-1} must be greater than 2."]
         assert params.errors["int_default_param"] == exp
 
     def test_errors_int_param(self, TestParams):
@@ -298,7 +296,7 @@ class TestErrors:
         }
         params.adjust(adj, raise_errors=False)
         exp = [
-            "float_list_param [-1.0, 1.0] must be greater than 0 for dimensions dim0=zero , dim1=1"
+            "float_list_param [-1.0, 1.0] must be greater than 0 for dimensions dim0=zero , dim1=1."
         ]
 
         assert params.errors["float_list_param"] == exp

--- a/paramtools/utils.py
+++ b/paramtools/utils.py
@@ -18,7 +18,7 @@ def read_json(path):
 
 
 def get_example_paths(name):
-    assert name in ("taxparams", "weather", "taxparams-demo")
+    assert name in ("taxparams", "weather", "taxparams-demo", "behresp")
     current_path = os.path.abspath(os.path.dirname(__file__))
     schema_def_path = os.path.join(
         current_path, f"examples/{name}/schema.json"


### PR DESCRIPTION
This PR adds example parameters for the Behavior-Responses package per @martinholmer's suggestion in #34. I also made a couple minor changes to clean things up while I was testing out this example.

```
(paramtools-dev) henrydoupe@henry-mac:~/Documents/ParamTools$ cd paramtools/examples/behresp/
(paramtools-dev) henrydoupe@henry-mac:~/Documents/ParamTools/paramtools/examples/behresp$ ipython
Python 3.7.2 (default, Dec 29 2018, 06:19:36) 
Type 'copyright', 'credits' or 'license' for more information
IPython 7.2.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from paramtools import Parameters 
   ...:  
   ...: class BehrespParams(Parameters): 
   ...:     schema = "schema.json" 
   ...:     defaults = "defaults.json" 
   ...:     array_first = True 
   ...:                                                                                                  

In [2]: params = BehrespParams()                                                                         

In [3]: params.BE_sub                                                                                    
Out[3]: array(0.)

In [4]: params.from_array("BE_sub")                                                                      
Out[4]: [{'value': 0.0}]

In [5]: params.adjust({"BE_sub": [{"value": 0.4}]})                                                      

In [6]: params.BE_sub                                                                                    
Out[6]: array(0.4)

In [7]: params.adjust({"BE_sub": [{"value": -0.4}]})                                                     
---------------------------------------------------------------------------
ValidationError                           Traceback (most recent call last)
<ipython-input-7-46d26022a0da> in <module>
----> 1 params.adjust({"BE_sub": [{"value": -0.4}]})

~/Documents/ParamTools/paramtools/parameters.py in adjust(self, params_or_path, raise_errors)
    119 
    120         if raise_errors and self._errors:
--> 121             raise self.validation_error
    122 
    123         # Update attrs.

ValidationError: {'BE_sub': ['BE_sub -0.4 must be greater than 0.0']}

In [8]: params.BE_sub                                                                                    
Out[8]: array(0.4)

In [9]: params.adjust({"BE_sub": [{"value": "elasticity"}]})                                             
---------------------------------------------------------------------------
ValidationError                           Traceback (most recent call last)
<ipython-input-9-25ba7962e1aa> in <module>
----> 1 params.adjust({"BE_sub": [{"value": "elasticity"}]})

~/Documents/ParamTools/paramtools/parameters.py in adjust(self, params_or_path, raise_errors)
    119 
    120         if raise_errors and self._errors:
--> 121             raise self.validation_error
    122 
    123         # Update attrs.

ValidationError: {'BE_sub': ['Not a valid number: elasticity.']}

In [10]:                                                                                                 
```