### PR TITLE
Add ability to delete existing value objects

### DIFF
--- a/paramtools/contrib/validate.py
+++ b/paramtools/contrib/validate.py
@@ -30,6 +30,8 @@ class Range(marshmallow_validate.Range):
         return message.format(input=value, min=self.min, max=self.max)
 
     def __call__(self, value):
+        if value is None:
+            return value
         if not isinstance(value, list):
             value_list = [value]
         else:
@@ -100,6 +102,8 @@ class OneOf(marshmallow_validate.OneOf):
     """
 
     def __call__(self, value):
+        if value is None:
+            return value
         if not isinstance(value, list):
             values = [value]
         else:

--- a/paramtools/parameters.py
+++ b/paramtools/parameters.py
@@ -354,10 +354,14 @@ class Parameters:
                         to_delete.append(j)
                     else:
                         curr_vals[j]["value"] = new_values[i]["value"]
+            if to_delete:
+                # Iterate in reverse so that indices point to the correct
+                # value. If iterating ascending then the values will be shifted
+                # towards the front of the list as items are removed.
+                for ix in sorted(to_delete, reverse=True):
+                    del curr_vals[ix]
             if not matched_at_least_once:
                 curr_vals.append(new_values[i])
-            for ix in to_delete:
-                del curr_vals[ix]
 
     def _parse_errors(self, ve, params):
         """

--- a/paramtools/parameters.py
+++ b/paramtools/parameters.py
@@ -144,9 +144,11 @@ class Parameters:
     ):
         """
         Query value(s) of all parameters along dimensions specified in
-        `dims`. If `use_state` is `True`, the current state is updated with
-        `dims`. If `meta_data` is `True`, then parameter attributes
-        are included, too.
+        ``dims``. If ``use_state`` is ``True``, the current state is updated with
+        ``dims``. If ``meta_data`` is ``True``, then parameter attributes
+        are included, too. If ``include_empty`` is ``True``, then values that
+        do not match the query dimensions set with ``self.state`` or ``dims``
+        will be included and set to an empty list.
 
         Returns: serialized data of shape
             {"param_name": [{"value": val, "dim0": ..., }], ...}

--- a/paramtools/schema.py
+++ b/paramtools/schema.py
@@ -292,11 +292,11 @@ CLASS_FIELD_MAP = {
 
 # A few fields that have been instantiated
 FIELD_MAP = {
-    "str": contrib_fields.Str(),
-    "int": contrib_fields.Integer(),
-    "float": contrib_fields.Float(),
-    "bool": contrib_fields.Boolean(),
-    "date": contrib_fields.Date(),
+    "str": contrib_fields.Str(allow_none=True),
+    "int": contrib_fields.Integer(allow_none=True),
+    "float": contrib_fields.Float(allow_none=True),
+    "bool": contrib_fields.Boolean(allow_none=True),
+    "date": contrib_fields.Date(allow_none=True),
 }
 
 VALIDATOR_MAP = {
@@ -311,9 +311,9 @@ def get_type(data):
     # (post 0.3.0rc4)
     # error_messages = {"invalid": "Invalid input: {input}"}
     numeric_types = {
-        "int": contrib_fields.Int64(),
-        "bool": contrib_fields.Bool_(),
-        "float": contrib_fields.Float64(),
+        "int": contrib_fields.Int64(allow_none=True),
+        "bool": contrib_fields.Bool_(allow_none=True),
+        "float": contrib_fields.Float64(allow_none=True),
     }
     types = dict(FIELD_MAP, **numeric_types)
     fieldtype = types[data["type"]]

--- a/paramtools/schema.py
+++ b/paramtools/schema.py
@@ -319,7 +319,7 @@ def get_type(data):
     fieldtype = types[data["type"]]
     dim = data["number_dims"]
     while dim > 0:
-        fieldtype = fields.List(fieldtype)
+        fieldtype = fields.List(fieldtype, allow_none=True)
         dim -= 1
     return fieldtype
 

--- a/paramtools/tests/test_parameters.py
+++ b/paramtools/tests/test_parameters.py
@@ -96,6 +96,10 @@ class TestAccess:
             if all("dim0" not in val_item for val_item in data):
                 assert spec2[param] == data
 
+        params._data["str_choice_param"]["value"] = []
+        assert "str_choice_param" not in params.specification()
+        assert "str_choice_param" in params.specification(include_empty=True)
+
 
 class TestAdjust:
     def test_adjust_int_param(self, TestParams):

--- a/paramtools/tests/test_parameters.py
+++ b/paramtools/tests/test_parameters.py
@@ -153,6 +153,17 @@ class TestAdjust:
             {"value": datetime.date(2018, 1, 17), "dim1": 1, "dim0": "zero"}
         ]
 
+    def test_adjust_none(self, TestParams):
+        params = TestParams()
+        adj = {
+            "min_int_param": [{"dim0": "one", "dim1": 2, "value": None}],
+            "str_choice_param": [{"value": None}],
+        }
+        params.adjust(adj)
+
+        assert len(params.min_int_param) == 1
+        assert len(params.str_choice_param) == 0
+
 
 class TestErrors:
     def test_errors_attribute(self, TestParams):

--- a/paramtools/tests/test_parameters.py
+++ b/paramtools/tests/test_parameters.py
@@ -157,7 +157,7 @@ class TestAdjust:
             {"value": datetime.date(2018, 1, 17), "dim1": 1, "dim0": "zero"}
         ]
 
-    def test_adjust_none(self, TestParams):
+    def test_adjust_none_basic(self, TestParams):
         params = TestParams()
         adj = {
             "min_int_param": [{"dim0": "one", "dim1": 2, "value": None}],
@@ -167,6 +167,36 @@ class TestAdjust:
 
         assert len(params.min_int_param) == 1
         assert len(params.str_choice_param) == 0
+
+    def test_adjust_none_many_values(self, TestParams):
+        params = TestParams()
+        adj = {"int_dense_array_param": [{"value": None}]}
+        print(params.int_dense_array_param)
+        params.adjust(adj)
+        assert len(params._data["int_dense_array_param"]["value"]) == 0
+        assert len(params.int_dense_array_param) == 0
+
+        params = TestParams()
+        adj = {"int_dense_array_param": [{"dim0": "zero", "value": None}]}
+        params.adjust(adj)
+        assert len(params._data["int_dense_array_param"]["value"]) == 18
+        assert len(params.int_dense_array_param) == 18
+        assert (
+            len(
+                params.specification(
+                    use_state=False, include_empty=True, dim0="zero"
+                )["int_dense_array_param"]
+            )
+            == 0
+        )
+        assert (
+            len(
+                params.specification(
+                    use_state=False, include_empty=True, dim0="one"
+                )["int_dense_array_param"]
+            )
+            == 18
+        )
 
 
 class TestErrors:


### PR DESCRIPTION
This PR adds the ability to delete existing value objects by setting their value to `None`. For example,

```python
In [1]: from paramtools import Parameters                                                                                                                                                                                                                                       

In [2]: class TaxParams(Parameters): 
   ...:     schema = "taxparams-demo/schema.json" 
   ...:     defaults = "taxparams-demo/defaults.json" 
   ...:                                                                                                                                                                                                                                                                         

In [3]: params = TaxParams()                                                                                                                                                                                                                                                    

In [4]: params.standard_deduction                                                                                                                                                                                                                                               
Out[4]: 
[{'value': 13673.68, 'marital_status': 'single', 'year': 2024},
 {'value': 27347.36, 'marital_status': 'joint', 'year': 2024},
 {'value': 13673.68, 'marital_status': 'separate', 'year': 2024},
 {'value': 20510.52, 'marital_status': 'headhousehold', 'year': 2024},
 {'value': 27347.36, 'marital_status': 'widow', 'year': 2024},
 {'value': 13967.66, 'marital_status': 'single', 'year': 2025},
 {'value': 27935.33, 'marital_status': 'joint', 'year': 2025},
 {'value': 13967.66, 'marital_status': 'separate', 'year': 2025},
 {'value': 20951.49, 'marital_status': 'headhousehold', 'year': 2025},
 {'value': 27935.33, 'marital_status': 'widow', 'year': 2025},
 {'value': 7690.0, 'marital_status': 'single', 'year': 2026},
 {'value': 15380.0, 'marital_status': 'joint', 'year': 2026},
 {'value': 7690.0, 'marital_status': 'separate', 'year': 2026},
 {'value': 11323.0, 'marital_status': 'headhousehold', 'year': 2026},
 {'value': 15380.0, 'marital_status': 'widow', 'year': 2026}]

In [5]: params.adjust({"standard_deduction": [{"year": 2026, "value": None}]})                                                                                                                                                                                                  

In [6]: params.standard_deduction                                                                                                                                                                                                                                               
Out[6]: 
[{'value': 13673.68, 'marital_status': 'single', 'year': 2024},
 {'value': 27347.36, 'marital_status': 'joint', 'year': 2024},
 {'value': 13673.68, 'marital_status': 'separate', 'year': 2024},
 {'value': 20510.52, 'marital_status': 'headhousehold', 'year': 2024},
 {'value': 27347.36, 'marital_status': 'widow', 'year': 2024},
 {'value': 13967.66, 'marital_status': 'single', 'year': 2025},
 {'value': 27935.33, 'marital_status': 'joint', 'year': 2025},
 {'value': 13967.66, 'marital_status': 'separate', 'year': 2025},
 {'value': 20951.49, 'marital_status': 'headhousehold', 'year': 2025},
 {'value': 27935.33, 'marital_status': 'widow', 'year': 2025}]

In [7]:                                                                                                                                                                                                                                                                         
```

A subtle bug was also fixed with this PR. By default, `Parameters.specification` only returns values that are selected by the query or do not contain any of the dimensions specified in the query. `Parameters.set_state` uses `Parameters.specifications` to update the instance attributes of each parameter. If a parameter is not active in the current state (i.e. it does not meet the query dimensions in `state`), then it is not returned by the `specification` call. Therefore, the instance attribute isn't updated. This PR adds an `include_empty` keyword to `specification` that requires it to return all parameters, including ones that are not active in the state.