### PR TITLE
Parameter name collision bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ params = TaxParams(
     array_first=True
 )
 
-print("# output ", params.state_store)
+print("# output ", params.view_state())
 # output  {'year': [2024, 2025, 2026]}
 
 ```

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ params = TaxParams(
     array_first=True
 )
 
-print("# output ", params.state)
+print("# output ", params.state_store)
 # output  {'year': [2024, 2025, 2026]}
 
 ```

--- a/docs/source/readme.rst
+++ b/docs/source/readme.rst
@@ -32,7 +32,7 @@ files:
        array_first=True
    )
 
-   print("# output ", params.state_store)
+   print("# output ", params.view_state())
    # output  {'year': [2024, 2025, 2026]}
 
 Parameters are available via instance attributes:

--- a/docs/source/readme.rst
+++ b/docs/source/readme.rst
@@ -32,7 +32,7 @@ files:
        array_first=True
    )
 
-   print("# output ", params.state)
+   print("# output ", params.state_store)
    # output  {'year': [2024, 2025, 2026]}
 
 Parameters are available via instance attributes:

--- a/paramtools/__init__.py
+++ b/paramtools/__init__.py
@@ -5,6 +5,8 @@ from paramtools.exceptions import (
     SparseValueObjectsException,
     ValidationError,
     InconsistentDimensionsException,
+    collision_list,
+    ParameterNameCollisionException,
 )
 from paramtools.parameters import Parameters
 from paramtools.schema import (
@@ -40,6 +42,8 @@ __all__ = [
     "SparseValueObjectsException",
     "ValidationError",
     "InconsistentDimensionsException",
+    "collision_list",
+    "ParameterNameCollisionException",
     "Parameters",
     "RangeSchema",
     "ChoiceSchema",

--- a/paramtools/exceptions.py
+++ b/paramtools/exceptions.py
@@ -34,6 +34,7 @@ collision_list = [
     "_numpy_type",
     "_parse_errors",
     "_resolve_order",
+    "_state",
     "_stateless_dim_mesh",
     "_update_param",
     "_validator_schema",
@@ -50,9 +51,9 @@ collision_list = [
     "schema",
     "set_state",
     "specification",
-    "state_store",
     "to_array",
     "validation_error",
+    "view_state",
 ]
 
 

--- a/paramtools/exceptions.py
+++ b/paramtools/exceptions.py
@@ -25,3 +25,36 @@ class ValidationError(ParamToolsError):
 
 class InconsistentDimensionsException(ParamToolsError):
     pass
+
+
+collision_list = [
+    "_data",
+    "_errors",
+    "_get",
+    "_numpy_type",
+    "_parse_errors",
+    "_resolve_order",
+    "_stateless_dim_mesh",
+    "_update_param",
+    "_validator_schema",
+    "adjust",
+    "array_first",
+    "clear_state",
+    "defaults",
+    "dim_mesh",
+    "dim_validators",
+    "errors",
+    "field_map",
+    "from_array",
+    "read_params",
+    "schema",
+    "set_state",
+    "specification",
+    "state_store",
+    "to_array",
+    "validation_error",
+]
+
+
+class ParameterNameCollisionException(ParamToolsError):
+    pass

--- a/paramtools/parameters.py
+++ b/paramtools/parameters.py
@@ -14,6 +14,8 @@ from paramtools.exceptions import (
     SparseValueObjectsException,
     ValidationError,
     InconsistentDimensionsException,
+    collision_list,
+    ParameterNameCollisionException,
 )
 
 
@@ -70,6 +72,10 @@ class Parameters:
             self.dim_mesh[dim_name] = dim_value
         spec = self.specification(include_empty=True, **self.state_store)
         for name, value in spec.items():
+            if name in collision_list:
+                raise ParameterNameCollisionException(
+                    f"The paramter name, '{name}', is already used by the Parameters object."
+                )
             if self.array_first:
                 setattr(self, name, self.to_array(name))
             else:

--- a/paramtools/tests/test_parameters.py
+++ b/paramtools/tests/test_parameters.py
@@ -476,19 +476,23 @@ class TestArray:
 class TestState:
     def test_basic_set_state(self, TestParams):
         params = TestParams()
-        assert params.state == {}
+        assert params.state_store == {}
         params.set_state(dim0="zero")
-        assert params.state == {"dim0": "zero"}
+        assert params.state_store == {"dim0": "zero"}
         params.set_state(dim1=0)
-        assert params.state == {"dim0": "zero", "dim1": 0}
+        assert params.state_store == {"dim0": "zero", "dim1": 0}
         params.set_state(dim0="one", dim2=1)
-        assert params.state == {"dim0": "one", "dim1": 0, "dim2": 1}
+        assert params.state_store == {"dim0": "one", "dim1": 0, "dim2": 1}
         params.set_state(**{})
-        assert params.state == {"dim0": "one", "dim1": 0, "dim2": 1}
+        assert params.state_store == {"dim0": "one", "dim1": 0, "dim2": 1}
         params.set_state()
-        assert params.state == {"dim0": "one", "dim1": 0, "dim2": 1}
+        assert params.state_store == {"dim0": "one", "dim1": 0, "dim2": 1}
         params.set_state(dim1=[1, 2, 3])
-        assert params.state == {"dim0": "one", "dim1": [1, 2, 3], "dim2": 1}
+        assert params.state_store == {
+            "dim0": "one",
+            "dim1": [1, 2, 3],
+            "dim2": 1,
+        }
 
     def test_dim_mesh(self, TestParams):
         params = TestParams()
@@ -532,7 +536,7 @@ class TestState:
         assert params.str_choice_param == [{"value": "value0"}]
 
         params.clear_state()
-        assert params.state == {}
+        assert params.state_store == {}
         assert params.min_int_param == defaultexp
         assert params.dim_mesh == params._stateless_dim_mesh
 

--- a/paramtools/tests/test_parameters.py
+++ b/paramtools/tests/test_parameters.py
@@ -478,19 +478,19 @@ class TestArray:
 class TestState:
     def test_basic_set_state(self, TestParams):
         params = TestParams()
-        assert params.state_store == {}
+        assert params.view_state() == {}
         params.set_state(dim0="zero")
-        assert params.state_store == {"dim0": "zero"}
+        assert params.view_state() == {"dim0": "zero"}
         params.set_state(dim1=0)
-        assert params.state_store == {"dim0": "zero", "dim1": 0}
+        assert params.view_state() == {"dim0": "zero", "dim1": 0}
         params.set_state(dim0="one", dim2=1)
-        assert params.state_store == {"dim0": "one", "dim1": 0, "dim2": 1}
+        assert params.view_state() == {"dim0": "one", "dim1": 0, "dim2": 1}
         params.set_state(**{})
-        assert params.state_store == {"dim0": "one", "dim1": 0, "dim2": 1}
+        assert params.view_state() == {"dim0": "one", "dim1": 0, "dim2": 1}
         params.set_state()
-        assert params.state_store == {"dim0": "one", "dim1": 0, "dim2": 1}
+        assert params.view_state() == {"dim0": "one", "dim1": 0, "dim2": 1}
         params.set_state(dim1=[1, 2, 3])
-        assert params.state_store == {
+        assert params.view_state() == {
             "dim0": "one",
             "dim1": [1, 2, 3],
             "dim2": 1,
@@ -538,7 +538,7 @@ class TestState:
         assert params.str_choice_param == [{"value": "value0"}]
 
         params.clear_state()
-        assert params.state_store == {}
+        assert params.view_state() == {}
         assert params.min_int_param == defaultexp
         assert params.dim_mesh == params._stateless_dim_mesh
 
@@ -607,8 +607,8 @@ class TestCollisions:
 
     def test_collision(self):
         defaults_dict = {
-            "state_store": {
-                "title": "Collides with 'state_store'",
+            "errors": {
+                "title": "Collides with 'errors'",
                 "description": "",
                 "notes": "",
                 "type": "int",
@@ -627,7 +627,7 @@ class TestCollisions:
             CollisionParams()
 
         exp_msg = (
-            "The paramter name, 'state_store', is already used by the "
+            "The paramter name, 'errors', is already used by the "
             "Parameters object."
         )
 


### PR DESCRIPTION
This PR resolves a bug reported by @Peter-Metz. He included a variable named "state" in his `defaults.json` file. The `Parameters` class set that variable as the attribute `state`. However, `state` is already used by `ParamTools` to keep track of the dimension state. This PR renames `state` to `_state`. It shouldn't be changed directly by the user anyways. It can still be viewed via the `view_state` and as before, it should be updated through `set_state`. This PR also adds a list of variable names that are used by `Parameters`. An exception is raised when the user tries to use a name that is already used by `Parameters`:

```
In [1]: from paramtools import Parameters                                                                                                                                                                                                                                       

In [2]: defaults_dict = { 
   ...:     "errors": { 
   ...:         "title": "Collides with 'errors'", 
   ...:         "description": "", 
   ...:         "notes": "", 
   ...:         "type": "int", 
   ...:         "number_dims": 0, 
   ...:         "value": [{"value": 0}], 
   ...:         "validators": {"range": {"min": 0, "max": 10}}, 
   ...:         "out_of_range_action": "stop", 
   ...:     } 
   ...: } 
   ...:  
   ...: class CollisionParams(Parameters): 
   ...:     schema = {"dim_name": "test", "dims": {}, "optional": {}} 
   ...:     defaults = defaults_dict 
   ...:  
   ...: params = CollisionParams() 
   ...:                                                                                                                                                                                                                                                                         

---------------------------------------------------------------------------
ParameterNameCollisionException           Traceback (most recent call last)
<ipython-input-2-e17ab2478c43> in <module>
     16     defaults = defaults_dict
     17 
---> 18 params = CollisionParams()

~/Documents/ParamTools/paramtools/parameters.py in __init__(self, initial_state, array_first)
     40         if array_first is not None:
     41             self.array_first = array_first
---> 42         self.set_state()
     43 
     44     def set_state(self, **dims):

~/Documents/ParamTools/paramtools/parameters.py in set_state(self, **dims)
     75             if name in collision_list:
     76                 raise ParameterNameCollisionException(
---> 77                     f"The paramter name, '{name}', is already used by the Parameters object."
     78                 )
     79             if self.array_first:

ParameterNameCollisionException: The paramter name, 'errors', is already used by the Parameters object.

In [3]:                                                                                                                                                                                                                                                                         
```