### PR TITLE
Make it simple to work with simple parameters 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
   rev: 18.9b0
   hooks:
   - id: black
-    language_version: python3.6
+    language_version: python3.7
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v2.1.0
   hooks:

--- a/paramtools/examples/baseball/defaults.json
+++ b/paramtools/examples/baseball/defaults.json
@@ -6,7 +6,6 @@
         "section_2": "Pitcher",
         "notes": "Make sure the name of the pitcher is correct. A good place to reference this is baseball-reference.com",
         "type": "str",
-        "number_dims": 0,
         "value": [{"value": "Clayton Kershaw"}],
         "validators": {"choice": {"choices": ["Clayton Kershaw", "Julio Teheran", "Max Scherzer"]}}
     },
@@ -17,7 +16,6 @@
         "section_2": "Batter",
         "notes": "Make sure the name of the batter is correct. A good place to reference this is baseball-reference.com",
         "type": "str",
-        "number_dims": 0,
         "value": [{"value": "Freddie Freeman"}],
         "validators": {"choice": {"choices": ["Freddie Freeman", "Bryce Harper", "Mookie Betts"]}}
     },
@@ -28,7 +26,6 @@
         "section_2": "Date",
         "notes": "If using the 2018 dataset, only use dates in 2018.",
         "type": "date",
-        "number_dims": 0,
         "value": [{"value": "2018-01-01"}],
         "validators": {"date_range": {"min": "2008-01-01", "max": "end_date"}}
     },
@@ -39,7 +36,6 @@
         "section_2": "Date",
         "notes": "If using the 2018 dataset, only use dates in 2018.",
         "type": "date",
-        "number_dims": 0,
         "value": [{"value": "2018-11-10"}],
         "validators": {"date_range": {"min": "2008-01-01", "max": "2018-11-10"}}
     }

--- a/paramtools/examples/baseball/schema.json
+++ b/paramtools/examples/baseball/schema.json
@@ -4,7 +4,7 @@
         "use_2018": {"type": "bool", "validators": {}}
     },
     "optional": {
-        "section_1": {"type": "str", "number_dims": 0},
-        "section_2": {"type": "str", "number_dims": 0}
+        "section_1": {"type": "str"},
+        "section_2": {"type": "str"}
     }
 }

--- a/paramtools/examples/behresp/defaults.json
+++ b/paramtools/examples/behresp/defaults.json
@@ -4,7 +4,6 @@
         "description": "Defined as proportional change in taxable income divided by proportional change in marginal net-of-tax rate (1-MTR) on taxpayer earnings caused by the reform.  Must be zero or positive.",
         "notes": "",
         "type": "float",
-        "number_dims": 0,
         "value": [{"value": 0.0}],
         "validators": {
             "range": {"min": 0.0, "max": 9e99}
@@ -15,7 +14,6 @@
         "description": "Defined as dollar change in taxable income divided by dollar change in after-tax income caused by the reform.  Must be zero or negative.",
         "notes": "",
         "type": "float",
-        "number_dims": 0,
         "value": [{"value": 0.0}],
         "validators": {
             "range": {"min": -9e99, "max": 0}
@@ -26,7 +24,6 @@
         "description": "Defined as change in logarithm of long-term capital gains divided by change in marginal tax rate (MTR) on long-term capital gains caused by the reform.  Must be zero or negative.  Read response function documentation (see below) for discussion of appropriate values.",
         "notes": "",
         "type": "float",
-        "number_dims": 0,
         "value": [{"value": 0.0}],
         "validators": {
             "range": {"min": -9e99, "max": 0}

--- a/paramtools/examples/taxparams-demo/defaults.json
+++ b/paramtools/examples/taxparams-demo/defaults.json
@@ -10,7 +10,6 @@
         "cpi_inflatable": true,
         "cpi_inflated": true,
         "type": "float",
-        "number_dims": 0,
         "value": [
             {"year": 2024, "marital_status": "single", "value": 13673.68},
             {"year": 2024, "marital_status": "joint", "value": 27347.36},
@@ -54,7 +53,6 @@
         "out_of_range_minmsg": "",
         "out_of_range_maxmsg": "",
         "out_of_range_action": "stop",
-        "number_dims": 0,
         "title": "Social Security payroll tax rate",
         "type": "float",
         "validators": {
@@ -74,7 +72,6 @@
         "start_year": 2013,
         "cpi_inflatable": true,
         "cpi_inflated": true,
-        "number_dims": 0,
         "type": "float",
         "value": [
             {"year": 2024, "marital_status": "single", "value": 10853.48},
@@ -112,7 +109,6 @@
         "start_year": 2013,
         "cpi_inflatable": true,
         "cpi_inflated": true,
-        "number_dims": 0,
         "type": "float",
         "value":  [
             {"year": 2024, "marital_status": "single", "value": 44097.61},

--- a/paramtools/examples/taxparams/schema.json
+++ b/paramtools/examples/taxparams/schema.json
@@ -23,13 +23,13 @@
         }
     },
     "optional": {
-        "section_1": {"type": "str", "number_dims": 0},
-        "section_2": {"type": "str", "number_dims": 0},
-        "section_3": {"type": "str", "number_dims": 0},
-        "irs_ref": {"type": "str", "number_dims": 0},
-        "start_year": {"type": "int", "number_dims": 0},
-        "cpi_inflatable": {"type": "bool", "number_dims": 0},
-        "cpi_inflated": {"type": "bool", "number_dims": 0},
-        "compatible_data": {"type": "compatible_data", "number_dims": null}
+        "section_1": {"type": "str"},
+        "section_2": {"type": "str"},
+        "section_3": {"type": "str"},
+        "irs_ref": {"type": "str"},
+        "start_year": {"type": "int"},
+        "cpi_inflatable": {"type": "bool"},
+        "cpi_inflated": {"type": "bool"},
+        "compatible_data": {"type": "compatible_data"}
     }
 }

--- a/paramtools/examples/weather/defaults.json
+++ b/paramtools/examples/weather/defaults.json
@@ -6,7 +6,6 @@
         "scale": "fahrenheit",
         "source": "NOAA",
         "type": "int",
-        "number_dims": 0,
         "value": [
             {"city": "Washington, D.C.", "month": "January", "dayofmonth": 1, "value": 43},
             {"city": "Washington, D.C.", "month": "February", "dayofmonth": 1, "value": 47},
@@ -45,7 +44,6 @@
         "scale": "inches",
         "source": "NOAA",
         "type": "float",
-        "number_dims": 0,
         "value": [
             {"city": "Washington, D.C.", "month": "January", "value": 3.1},
             {"city": "Washington, D.C.", "month": "February", "value": 2.6},

--- a/paramtools/examples/weather/schema.json
+++ b/paramtools/examples/weather/schema.json
@@ -20,7 +20,7 @@
         }
     },
     "optional": {
-        "scale": {"type": "str", "number_dims": 0},
-        "source": {"type": "str", "number_dims": 0}
+        "scale": {"type": "str"},
+        "source": {"type": "str"}
     }
 }

--- a/paramtools/schema.py
+++ b/paramtools/schema.py
@@ -51,7 +51,6 @@ class BaseParamSchema(Schema):
         "description": str,
         "notes": str,
         "type": str (limited to 'int', 'float', 'bool', 'str'),
-        "number_dims": int,
         "value": `BaseValidatorSchema`, "value" type depends on "type" key,
         "range": range schema ({"min": ..., "max": ..., "other ops": ...}),
         "out_of_range_minmsg": str,
@@ -74,7 +73,7 @@ class BaseParamSchema(Schema):
         attribute="type",
         data_key="type",
     )
-    number_dims = fields.Integer(required=True)
+    number_dims = fields.Integer(default=0, missing=0)
     value = fields.Field(required=True)  # will be specified later
     validators = fields.Nested(ValueValidatorSchema(), required=True)
     out_of_range_minmsg = fields.Str(required=False)
@@ -317,7 +316,7 @@ def get_type(data):
     }
     types = dict(FIELD_MAP, **numeric_types)
     fieldtype = types[data["type"]]
-    dim = data["number_dims"]
+    dim = data.get("number_dims", 0)
     while dim > 0:
         fieldtype = fields.List(fieldtype, allow_none=True)
         dim -= 1
@@ -338,7 +337,7 @@ def get_param_schema(base_spec, field_map=None):
     optional_fields = {}
     for k, v in base_spec["optional"].items():
         fieldtype = field_map[v["type"]]
-        if v["number_dims"] is not None:
+        if v.get("number_dims", 0) > 0:
             d = v["number_dims"]
             while d > 0:
                 fieldtype = fields.List(fieldtype)

--- a/paramtools/schema.py
+++ b/paramtools/schema.py
@@ -98,9 +98,13 @@ class ValueObject(fields.Nested):
     """
 
     def _deserialize(self, value, attr, data, partial=None, **kwargs):
-        if not isinstance(value, list):
+        if not isinstance(value, list) or (
+            isinstance(value, list) and not isinstance(value[0], dict)
+        ):
             value = [{"value": value}]
-        return super()._deserialize(value, attr, data, partial=partial, **kwargs)
+        return super()._deserialize(
+            value, attr, data, partial=partial, **kwargs
+        )
 
 
 class BaseValidatorSchema(Schema):

--- a/paramtools/schema.py
+++ b/paramtools/schema.py
@@ -92,6 +92,17 @@ class EmptySchema(Schema):
     pass
 
 
+class ValueObject(fields.Nested):
+    """
+    Schema for value objects
+    """
+
+    def _deserialize(self, value, attr, data, partial=None, **kwargs):
+        if not isinstance(value, list):
+            value = [{"value": value}]
+        return super()._deserialize(value, attr, data, partial=partial, **kwargs)
+
+
 class BaseValidatorSchema(Schema):
     """
     Schema that validates parameter adjustments such as:

--- a/paramtools/tests/defaults.json
+++ b/paramtools/tests/defaults.json
@@ -5,7 +5,6 @@
         "notes": "See max_int_param",
         "opt0": "an option",
         "type": "int",
-        "number_dims": 0,
         "value": [
             {"dim0": "zero", "dim1": 1, "value": 1},
             {"dim0": "one", "dim1": 2, "value": 2}
@@ -21,7 +20,6 @@
         "notes": "See min_int_param",
         "opt0": "an option",
         "type": "int",
-        "number_dims": 0,
         "value": [
             {"dim0": "zero", "dim1": 1, "value": 3},
             {"dim0": "one", "dim1": 2, "value": 4}
@@ -37,7 +35,6 @@
         "notes": "",
         "opt0": "another option",
         "type": "str",
-        "number_dims": 0,
         "value": [
             {"value": "value0"}
         ],
@@ -52,7 +49,6 @@
         "notes": "",
         "opt0": "another option",
         "type": "date",
-        "number_dims": 0,
         "value": [
             {"dim0": "zero", "dim1": 1, "value": "2018-01-15"}
         ],
@@ -67,7 +63,6 @@
         "notes": "See date_max_param.",
         "opt0": "an option",
         "type": "date",
-        "number_dims": 0,
         "value": [
             {"dim0": "zero", "dim1": 1, "value": "2018-01-15"}
         ],
@@ -82,7 +77,6 @@
         "notes": "See date_min_param.",
         "opt0": "an option",
         "type": "date",
-        "number_dims": 0,
         "value": [
             {"dim0": "zero", "dim1": 1, "value": "2018-01-15"}
         ],
@@ -112,7 +106,6 @@
         "notes": "",
         "opt0": "an option",
         "type": "int",
-        "number_dims": 0,
         "value": [
             {"value": 2}
         ],
@@ -127,7 +120,6 @@
         "notes": "Dense means that the full space is explicitly spanned in the list of Value objects.",
         "opt0": "an option",
         "type": "int",
-        "number_dims": 0,
         "value": [
             {"dim0": "zero", "dim1": 0, "dim2": 0, "value": 1},
             {"dim0": "zero", "dim1": 0, "dim2": 1, "value": 2},

--- a/paramtools/tests/defaults.json
+++ b/paramtools/tests/defaults.json
@@ -35,9 +35,7 @@
         "notes": "",
         "opt0": "another option",
         "type": "str",
-        "value": [
-            {"value": "value0"}
-        ],
+        "value": "value0",
         "validators": {"choice": {"choices": ["value0", "value1"]}},
         "out_of_range_minmsg": "",
         "out_of_range_maxmsg": "",
@@ -106,9 +104,7 @@
         "notes": "",
         "opt0": "an option",
         "type": "int",
-        "value": [
-            {"value": 2}
-        ],
+        "value": 2,
         "validators": {"range": {"min": "default", "max": 10}},
         "out_of_range_minmsg": "",
         "out_of_range_maxmsg": "",

--- a/paramtools/tests/defaults.json
+++ b/paramtools/tests/defaults.json
@@ -98,6 +98,19 @@
         "out_of_range_maxmsg": "",
         "out_of_range_action": "stop"
     },
+    "simple_int_list_param": {
+        "title": "Simple Int List Param",
+        "description": "Test case where param is simple and a list.",
+        "notes": "",
+        "opt0": "an option",
+        "type": "int",
+        "number_dims": 1,
+        "value": [1, 2, 3, 4],
+        "validators": {"range": {"min": 0, "max": 10}},
+        "out_of_range_minmsg": "",
+        "out_of_range_maxmsg": "",
+        "out_of_range_action": "stop"
+    },
     "int_default_param": {
         "title": "Integer Default Reference Param",
         "description": "Example for a int param using a default reference value",

--- a/paramtools/tests/schema.json
+++ b/paramtools/tests/schema.json
@@ -16,6 +16,6 @@
         }
     },
     "optional": {
-        "opt0": {"type": "str", "number_dims": 0}
+        "opt0": {"type": "str"}
     }
 }

--- a/paramtools/tests/test_parameters.py
+++ b/paramtools/tests/test_parameters.py
@@ -612,7 +612,6 @@ class TestCollisions:
                 "description": "",
                 "notes": "",
                 "type": "int",
-                "number_dims": 0,
                 "value": [{"value": 0}],
                 "validators": {"range": {"min": 0, "max": 10}},
                 "out_of_range_action": "stop",

--- a/paramtools/tests/test_parameters.py
+++ b/paramtools/tests/test_parameters.py
@@ -32,6 +32,7 @@ def array_first_defaults(defaults_spec_path):
     with open(defaults_spec_path) as f:
         r = json.loads(f.read())
     r.pop("float_list_param")
+    r.pop("simple_int_list_param")
     return r
 
 
@@ -154,7 +155,9 @@ class TestAdjust:
             {"dim0": "zero", "dim1": 1, "value": 1}
         ]
 
-        assert params.int_default_param == [{"value": adjustment["int_default_param"]}]
+        assert params.int_default_param == [
+            {"value": adjustment["int_default_param"]}
+        ]
         assert params.date_param == [
             {"value": datetime.date(2018, 1, 17), "dim1": 1, "dim0": "zero"}
         ]

--- a/paramtools/tests/test_parameters.py
+++ b/paramtools/tests/test_parameters.py
@@ -142,7 +142,7 @@ class TestAdjust:
         params.set_state(dim0="zero", dim1=1)
         adjustment = {
             "min_int_param": [{"dim0": "one", "dim1": 2, "value": 2}],
-            "int_default_param": [{"value": 5}],
+            "int_default_param": 5,
             "date_param": [{"dim0": "zero", "dim1": 1, "value": "2018-01-17"}],
         }
         params.adjust(adjustment)
@@ -154,7 +154,7 @@ class TestAdjust:
             {"dim0": "zero", "dim1": 1, "value": 1}
         ]
 
-        assert params.int_default_param == adjustment["int_default_param"]
+        assert params.int_default_param == [{"value": adjustment["int_default_param"]}]
         assert params.date_param == [
             {"value": datetime.date(2018, 1, 17), "dim1": 1, "dim0": "zero"}
         ]
@@ -173,7 +173,6 @@ class TestAdjust:
     def test_adjust_none_many_values(self, TestParams):
         params = TestParams()
         adj = {"int_dense_array_param": [{"value": None}]}
-        print(params.int_dense_array_param)
         params.adjust(adj)
         assert len(params._data["int_dense_array_param"]["value"]) == 0
         assert len(params.int_dense_array_param) == 0
@@ -446,7 +445,6 @@ class TestArray:
         params = TestParams()
         # Drop values 3 and 4 from dim1
         params.set_state(dim1=[0, 1, 2, 5])
-        print(len(params.int_dense_array_param))
         res = params.to_array("int_dense_array_param")
 
         # Values 3 and 4 were removed from dim1.


### PR DESCRIPTION
See #43.

With this change, one can do an adjustment via:

```python
In [1]: import paramtools 
   ...: class Params(paramtools.Parameters): 
   ...:     schema = "paramtools/tests/schema.json" 
   ...:     defaults = "paramtools/tests/defaults.json" 
   ...: params = Params() 
   ...:                                                                                                                       

In [2]: params.int_default_param                                                                                              
Out[2]: [{'value': 2}]

In [3]: params.adjust({ 
   ...:     "int_default_param": 4, 
   ...: })                                                                                                                    

In [4]: params.int_default_param                                                                                              
Out[4]: [{'value': 4}]

In [5]:                                                                                                                       
```

The same logic applies for the JSON defaults file.