### PR TITLE
Rename "dimension" to "label"

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,8 @@ params.adjust(adjustment, raise_errors=False)
 params.errors
 # output:
 # {
-#   'standard_deduction': ['standard_deduction -1.0 must be greater than 0 for dimensions marital_status=single , year=2026'],
-#   'ii_bracket_1': ['ii_bracket_1 45958.0 must be less than 45957.0 for dimensions marital_status=single , year=2026']
+#   'standard_deduction': ['standard_deduction -1.0 must be greater than 0 for labels marital_status=single , year=2026'],
+#   'ii_bracket_1': ['ii_bracket_1 45958.0 must be less than 45957.0 for labels marital_status=single , year=2026']
 # }
 
 ```

--- a/docs/markdown/spec.md
+++ b/docs/markdown/spec.md
@@ -295,7 +295,7 @@ JSON Object and Property Definitions
 
 #### Number-Labels property
 
-- "number_dims": The number of labels for the specified value. A scalar (e.g. 10) has zero labels, a list (e.g. [1, 2]) has one label, a nested list (e.g. [[1, 2], [3, 4]]) has two labels, etc.
+- "number_dims": The number of dimensions for the specified value. A scalar (e.g. 10) has zero labels, a list (e.g. [1, 2]) has one label, a nested list (e.g. [[1, 2], [3, 4]]) has two labels, etc.
     - Example:
         Note that "value" is a scalar.
         ```json

--- a/docs/markdown/spec.md
+++ b/docs/markdown/spec.md
@@ -3,16 +3,16 @@
 Specification Schema
 --------------------------------------
 
-Define the dimensions of the parameter space.
+Define the labels of the parameter space.
 
 - "schema_name": Name of the schema.
-- "dims": Mapping of [Dimension objects](#dimension-object).
+- "labels": Mapping of [Label objects](#label-object).
 - "optional_params": Mapping of [Optional objects](#optional-object).
 - Example:
     ```json
     {
         "schema_name": "weather",
-        "dims": {
+        "labels": {
             "city": {
                 "type": "str",
                 "validators": {"choice": {"choices": ["Atlanta, GA",
@@ -162,10 +162,10 @@ JSON Object and Property Definitions
 
 ### Objects
 
-#### Dimension object
+#### Label object
 
-- Used for defining the dimensions of the parameter space.
-    - "type": Define the datatype of the dimension values. See the [Type property](#type-property).
+- Used for defining the labels of the parameter space.
+    - "type": Define the datatype of the label values. See the [Type property](#type-property).
     - "validators": A mapping of [Validator objects](#validator-object)
 
     ```json
@@ -188,7 +188,7 @@ JSON Object and Property Definitions
   not essential for ParamTools to perform validation.
     - Arguments:
         - "type": See [Type property](#type-property).
-        - "number_dims": See [Number-Dimensions Property](#number-dimensions-property).
+        - "number_dims": See [Number-Labels Property](#number-labels-property).
     - Example:
         ```json
         {
@@ -207,7 +207,7 @@ JSON Object and Property Definitions
         - "description": Describes the parameter.
         - "notes": Additional advice or information.
         - "type": Data type of the parameter. See [Type property](#type-property).
-        - "number_dims": Number of dimensions of the parameter. See [Number-Dimensions property](#number-dimensions-property)
+        - "number_dims": Number of labels of the parameter. See [Number-Labels property](#number-labels-property)
         - "value": A list of (Value objects)[#value-object].
         - "validators": A mapping of (Validator objects)[#validator-object]
         - "out_of_range_{min/max/other op}_msg": Extra information to be used in the message(s) that will be displayed if the parameter value is outside of the specified range. Note that this is in the spec but not currently implemented.
@@ -263,7 +263,7 @@ JSON Object and Property Definitions
 
 - Used to describe the value of a parameter for one or more points in the parameter space.
     - "value": The value of the parameter at this point in space.
-    - Zero or more dimension properties that define which parts of the parameter space this value should be applied to. These dimension properties are defined by [Dimension objects](#dimension-object) in the [Specification Schema](#specification-schema).
+    - Zero or more label properties that define which parts of the parameter space this value should be applied to. These label properties are defined by [Label objects](#label-object) in the [Specification Schema](#specification-schema).
 
     - Example:
         ```json
@@ -293,9 +293,9 @@ JSON Object and Property Definitions
         }
         ```
 
-#### Number-Dimensions property
+#### Number-Labels property
 
-- "number_dims": The number of dimensions for the specified value. A scalar (e.g. 10) has zero dimensions, a list (e.g. [1, 2]) has one dimension, a nested list (e.g. [[1, 2], [3, 4]]) has two dimensions, etc.
+- "number_dims": The number of labels for the specified value. A scalar (e.g. 10) has zero labels, a list (e.g. [1, 2]) has one label, a nested list (e.g. [[1, 2], [3, 4]]) has two labels, etc.
     - Example:
         Note that "value" is a scalar.
         ```json
@@ -305,7 +305,7 @@ JSON Object and Property Definitions
         }
         ```
 
-        Note that "value" is an one-dimensional list.
+        Note that "value" is an one-labelal list.
         ```json
         {
             "number_dims": 1,
@@ -314,6 +314,6 @@ JSON Object and Property Definitions
         ```
 
 
-[`numpy.ndim`]: https://docs.scipy.org/doc/numpy/reference/generated/numpy.ndarray.ndim.html
+[`numpy.nlabel`]: https://docs.scipy.org/doc/numpy/reference/generated/numpy.ndarray.nlabel.html
 [marshmallow]: https://marshmallow.readthedocs.io/en/3.0/
 [Tax-Calculator's]: https://github.com/open-source-economics/Tax-Calculator

--- a/docs/source/readme.rst
+++ b/docs/source/readme.rst
@@ -126,8 +126,8 @@ Errors on input that’s out of range:
    params.errors
    # output:
    # {
-   #   'standard_deduction': ['standard_deduction -1.0 must be greater than 0 for dimensions marital_status=single , year=2026'],
-   #   'ii_bracket_1': ['ii_bracket_1 45958.0 must be less than 45957.0 for dimensions marital_status=single , year=2026']
+   #   'standard_deduction': ['standard_deduction -1.0 must be greater than 0 for labels marital_status=single , year=2026'],
+   #   'ii_bracket_1': ['ii_bracket_1 45958.0 must be less than 45957.0 for labels marital_status=single , year=2026']
    # }
 
 How to install ParamTools

--- a/docs/source/spec.rst
+++ b/docs/source/spec.rst
@@ -455,7 +455,7 @@ Type property
 Number-Labels property
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
--  "number\_labels": The number of labels for the specified value. A
+-  "number\_labels": The number of dimensions for the specified value. A
    scalar (e.g. 10) has zero labels, a list (e.g. [1, 2]) has one
    label, a nested list (e.g. [[1, 2], [3, 4]]) has two labels,
    etc.

--- a/docs/source/spec.rst
+++ b/docs/source/spec.rst
@@ -4,10 +4,10 @@ JSON Spec
 Specification Schema
 --------------------
 
-Define the dimensions of the parameter space.
+Define the labels of the parameter space.
 
 -  "schema\_name": Name of the schema.
--  "dims": Mapping of `Dimension objects <#dimension-object>`__.
+-  "labels": Mapping of `Label objects <#label-object>`__.
 -  "optional\_params": Mapping of `Optional
    objects <#optional-object>`__.
 -  Example:
@@ -16,7 +16,7 @@ Define the dimensions of the parameter space.
 
         {
             "schema_name": "policy",
-            "dims": {
+            "labels": {
                 "year": {
                     "type": "int",
                     "validators": {"range": {"min": 2013, "max": 2027}}
@@ -232,12 +232,12 @@ JSON Object and Property Definitions
 Objects
 ~~~~~~~
 
-Dimension object
+Label object
 ^^^^^^^^^^^^^^^^
 
--  Used for defining the dimensions of the parameter space.
+-  Used for defining the labels of the parameter space.
 
-   -  "type": Define the datatype of the dimension values. See the `Type
+   -  "type": Define the datatype of the label values. See the `Type
       property <#type-property>`__.
    -  "validators": A mapping of `Validator
       objects <#validator-object>`__
@@ -262,8 +262,8 @@ Optional object
    -  Arguments:
 
       -  "type": See `Type property <#type-property>`__.
-      -  "number\_dims": See `Number-Dimensions
-         Property <#number-dimensions-property>`__.
+      -  "number\_labels": See `Number-Labels
+         Property <#number-labels-property>`__.
 
    -  Example:
 
@@ -292,8 +292,8 @@ Parameter object
       -  "notes": Additional advice or information.
       -  "type": Data type of the parameter. See `Type
          property <#type-property>`__.
-      -  "number\_dims": Number of dimensions of the parameter. See
-         `Number-Dimensions property <#number-dimensions-property>`__
+      -  "number\_labels": Number of labels of the parameter. See
+         `Number-Labels property <#number-labels-property>`__
       -  "value": A list of `Value objects <#value-object>`__.
       -  "validators": A mapping of `Validator
          objects <#validator-object>`__.
@@ -413,10 +413,10 @@ Value object
    the parameter space.
 
    -  "value": The value of the parameter at this point in space.
-   -  Zero or more dimension properties that define which parts of the
-      parameter space this value should be applied to. These dimension
-      properties are defined by `Dimension
-      objects <#dimension-object>`__ in the `Specification
+   -  Zero or more label properties that define which parts of the
+      parameter space this value should be applied to. These label
+      properties are defined by `Label
+      objects <#label-object>`__ in the `Specification
       Schema <#specification-schema>`__.
 
    -  Example:
@@ -452,12 +452,12 @@ Type property
           }
 
 
-Number-Dimensions property
+Number-Labels property
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
--  "number\_dims": The number of dimensions for the specified value. A
-   scalar (e.g. 10) has zero dimensions, a list (e.g. [1, 2]) has one
-   dimension, a nested list (e.g. [[1, 2], [3, 4]]) has two dimensions,
+-  "number\_labels": The number of labels for the specified value. A
+   scalar (e.g. 10) has zero labels, a list (e.g. [1, 2]) has one
+   label, a nested list (e.g. [[1, 2], [3, 4]]) has two labels,
    etc.
 
    -  Example: Note that "value" is a scalar.
@@ -469,7 +469,7 @@ Number-Dimensions property
               "value": [{"year": 2026, "marital_status": "single", "value": 7690.0}]
           }
 
-      Note that "value" is an one-dimensional list.
+      Note that "value" is an one-labelal list.
 
       .. code:: json
 

--- a/paramtools/__init__.py
+++ b/paramtools/__init__.py
@@ -4,7 +4,7 @@ from paramtools.exceptions import (
     ParameterUpdateException,
     SparseValueObjectsException,
     ValidationError,
-    InconsistentDimensionsException,
+    InconsistentLabelsException,
     collision_list,
     ParameterNameCollisionException,
 )
@@ -28,7 +28,7 @@ from paramtools.utils import (
     LeafGetter,
     get_leaves,
     ravel,
-    consistent_dims,
+    consistent_labels,
 )
 
 
@@ -41,7 +41,7 @@ __all__ = [
     "ParameterUpdateException",
     "SparseValueObjectsException",
     "ValidationError",
-    "InconsistentDimensionsException",
+    "InconsistentLabelsException",
     "collision_list",
     "ParameterNameCollisionException",
     "Parameters",
@@ -61,5 +61,5 @@ __all__ = [
     "LeafGetter",
     "get_leaves",
     "ravel",
-    "consistent_dims",
+    "consistent_labels",
 ]

--- a/paramtools/build_schema.py
+++ b/paramtools/build_schema.py
@@ -26,7 +26,7 @@ class SchemaBuilder:
 
     def __init__(self, schema, defaults, field_map={}):
         schema = utils.read_json(schema)
-        (self.BaseParamSchema, self.dim_validators) = get_param_schema(
+        (self.BaseParamSchema, self.label_validators) = get_param_schema(
             schema, field_map=field_map
         )
         self.defaults = utils.read_json(defaults)
@@ -57,7 +57,7 @@ class SchemaBuilder:
         validator_dict = {}
         for k, v in self.defaults.items():
             fieldtype = get_type(v)
-            classattrs = {"value": fieldtype, **self.dim_validators}
+            classattrs = {"value": fieldtype, **self.label_validators}
 
             # TODO: what about case where number_dims > 0
             # if not isinstance(v["value"], list):

--- a/paramtools/contrib/fields.py
+++ b/paramtools/contrib/fields.py
@@ -41,14 +41,14 @@ class Bool_(marshmallow_fields.Boolean):
 class MeshFieldMixin:
     """
     Provides method for accessing ``contrib.validate``
-    validators' mesh methods
+    validators' grid methods
     """
 
-    def mesh(self):
+    def grid(self):
         if not self.validators:
             return []
         assert len(self.validators) == 1
-        return self.validators[0].mesh()
+        return self.validators[0].grid()
 
 
 class Str(MeshFieldMixin, marshmallow_fields.Str):

--- a/paramtools/contrib/validate.py
+++ b/paramtools/contrib/validate.py
@@ -48,7 +48,7 @@ class Range(marshmallow_validate.Range):
 
         return value
 
-    def mesh(self):
+    def grid(self):
         # make np.arange inclusive.
         max_ = self.max + self.step
         arr = np.arange(self.min, max_, self.step)
@@ -59,7 +59,7 @@ class DateRange(Range):
     """
     Implements "date_range" :ref:`spec:Validator object`.
     Behaves like ``Range``, except values are ensured to be
-    ``datetime.date`` type and ``mesh`` has special logic for dates.
+    ``datetime.date`` type and ``grid`` has special logic for dates.
     """
 
     def __init__(
@@ -89,7 +89,7 @@ class DateRange(Range):
         assert len(set(step.keys()) - timedelta_args) == 0
         self.step = datetime.timedelta(**step)
 
-    def mesh(self):
+    def grid(self):
         # make np.arange inclusive.
         max_ = self.max + self.step
         arr = np.arange(self.min, max_, self.step, dtype=datetime.date)
@@ -116,5 +116,5 @@ class OneOf(marshmallow_validate.OneOf):
                 raise ValidationError(self._format_error(val))
         return value
 
-    def mesh(self):
+    def grid(self):
         return self.choices

--- a/paramtools/examples/baseball/schema.json
+++ b/paramtools/examples/baseball/schema.json
@@ -1,6 +1,6 @@
 {
     "schema_name": "baseball",
-    "dims": {
+    "labels": {
         "use_2018": {"type": "bool", "validators": {}}
     },
     "optional": {

--- a/paramtools/examples/behresp/schema.json
+++ b/paramtools/examples/behresp/schema.json
@@ -1,5 +1,5 @@
 {
     "schema_name": "behresp",
-    "dims": {},
+    "labels": {},
     "optional": {}
 }

--- a/paramtools/examples/taxparams-demo/schema.json
+++ b/paramtools/examples/taxparams-demo/schema.json
@@ -1,6 +1,6 @@
 {
     "schema_name": "policy",
-    "dims": {
+    "labels": {
         "year": {
             "type": "int",
             "validators": {"range": {"min": 2013, "max": 2027}}

--- a/paramtools/examples/taxparams/schema.json
+++ b/paramtools/examples/taxparams/schema.json
@@ -1,6 +1,6 @@
 {
     "schema_name": "policy",
-    "dims": {
+    "labels": {
         "year": {
             "type": "int",
             "validators": {"range": {"min": 2013, "max": 2027}}

--- a/paramtools/examples/weather/schema.json
+++ b/paramtools/examples/weather/schema.json
@@ -1,6 +1,6 @@
 {
     "schema_name": "weather",
-    "dims": {
+    "labels": {
         "city": {
             "type": "str",
             "validators": {"choice": {"choices": ["Atlanta, GA",

--- a/paramtools/exceptions.py
+++ b/paramtools/exceptions.py
@@ -30,7 +30,7 @@ class InconsistentLabelsException(ParamToolsError):
 collision_list = [
     "_data",
     "_errors",
-    "_get",
+    "_select",
     "_numpy_type",
     "_parse_errors",
     "_resolve_order",

--- a/paramtools/exceptions.py
+++ b/paramtools/exceptions.py
@@ -14,16 +14,16 @@ class SparseValueObjectsException(ParamToolsError):
 
 
 class ValidationError(ParamToolsError):
-    def __init__(self, messages, dims):
+    def __init__(self, messages, labels):
         self.messages = messages
-        self.dims = dims
+        self.labels = labels
         raveled_messages = {
             param: utils.ravel(msgs) for param, msgs in self.messages.items()
         }
         super().__init__(raveled_messages)
 
 
-class InconsistentDimensionsException(ParamToolsError):
+class InconsistentLabelsException(ParamToolsError):
     pass
 
 
@@ -35,15 +35,15 @@ collision_list = [
     "_parse_errors",
     "_resolve_order",
     "_state",
-    "_stateless_dim_mesh",
+    "_stateless_label_grid",
     "_update_param",
     "_validator_schema",
     "adjust",
     "array_first",
     "clear_state",
     "defaults",
-    "dim_mesh",
-    "dim_validators",
+    "label_grid",
+    "label_validators",
     "errors",
     "field_map",
     "from_array",

--- a/paramtools/parameters.py
+++ b/paramtools/parameters.py
@@ -172,7 +172,7 @@ class Parameters:
 
         all_params = OrderedDict()
         for param in self._validator_schema.fields:
-            result = self._get(param, False, **labels)
+            result = self._select(param, False, **labels)
             if result or include_empty:
                 if meta_data:
                     param_data = self._data[param]
@@ -195,7 +195,7 @@ class Parameters:
             SparseValueObjectsException: Value object does not span the
                 entire space specified by the Order object.
         """
-        value_items = self._get(param, False, **self._state)
+        value_items = self._select(param, False, **self._state)
         label_order, value_order = self._resolve_order(param)
         shape = []
         for label in label_order:
@@ -290,7 +290,7 @@ class Parameters:
             InconsistentLabelsException: Value objects do not have consistent
                 labels.
         """
-        value_items = self._get(param, False, **self._state)
+        value_items = self._select(param, False, **self._state)
         used = utils.consistent_labels(value_items)
         if used is None:
             raise InconsistentLabelsException(
@@ -311,7 +311,7 @@ class Parameters:
             self._validator_schema.fields[param].nested.fields["value"].np_type
         )
 
-    def _get(self, param, exact_match, **labels):
+    def _select(self, param, exact_match, **labels):
         """
         Query a parameter along some labels. If exact_match is True,
         all values in `labels` must be equal to the corresponding label

--- a/paramtools/parameters.py
+++ b/paramtools/parameters.py
@@ -13,7 +13,7 @@ from paramtools import utils
 from paramtools.exceptions import (
     SparseValueObjectsException,
     ValidationError,
-    InconsistentDimensionsException,
+    InconsistentLabelsException,
     collision_list,
     ParameterNameCollisionException,
 )
@@ -28,11 +28,11 @@ class Parameters:
     def __init__(self, initial_state=None, array_first=None):
         sb = SchemaBuilder(self.schema, self.defaults, self.field_map)
         defaults, self._validator_schema = sb.build_schemas()
-        self.dim_validators = sb.dim_validators
-        self._stateless_dim_mesh = OrderedDict(
-            [(name, v.mesh()) for name, v in self.dim_validators.items()]
+        self.label_validators = sb.label_validators
+        self._stateless_label_grid = OrderedDict(
+            [(name, v.grid()) for name, v in self.label_validators.items()]
         )
-        self.dim_mesh = copy.deepcopy(self._stateless_dim_mesh)
+        self.label_grid = copy.deepcopy(self._stateless_label_grid)
         self._data = defaults
         self._validator_schema.context["spec"] = self
         self._errors = {}
@@ -41,35 +41,35 @@ class Parameters:
             self.array_first = array_first
         self.set_state()
 
-    def set_state(self, **dims):
+    def set_state(self, **labels):
         """
-        Sets state for the Parameters instance. The state, dim_mesh, and
+        Sets state for the Parameters instance. The state, label_grid, and
         parameter attributes are all updated with the new state.
 
         Raises:
-            ValidationError if the dims kwargs contain dimensions that are not
-                specified in schema.json or if the dimension values fail the
-                validator set for the corresponding dimension in schema.json.
+            ValidationError if the labels kwargs contain labels that are not
+                specified in schema.json or if the label values fail the
+                validator set for the corresponding label in schema.json.
         """
         messages = {}
-        for name, values in dims.items():
-            if name not in self.dim_validators:
-                messages[name] = f"{name} is not a valid dimension."
+        for name, values in labels.items():
+            if name not in self.label_validators:
+                messages[name] = f"{name} is not a valid label."
                 continue
             if not isinstance(values, list):
                 values = [values]
             for value in values:
                 try:
-                    self.dim_validators[name].deserialize(value)
+                    self.label_validators[name].deserialize(value)
                 except MarshmallowValidationError as ve:
                     messages[name] = str(ve)
         if messages:
-            raise ValidationError(messages, dims=None)
-        self._state.update(dims)
-        for dim_name, dim_value in self._state.items():
-            if not isinstance(dim_value, list):
-                dim_value = [dim_value]
-            self.dim_mesh[dim_name] = dim_value
+            raise ValidationError(messages, labels=None)
+        self._state.update(labels)
+        for label_name, label_value in self._state.items():
+            if not isinstance(label_value, list):
+                label_value = [label_value]
+            self.label_grid[label_name] = label_value
         spec = self.specification(include_empty=True, **self._state)
         for name, value in spec.items():
             if name in collision_list:
@@ -86,12 +86,12 @@ class Parameters:
         Reset the state of the Parameters instance.
         """
         self._state = {}
-        self.dim_mesh = copy.deepcopy(self._stateless_dim_mesh)
+        self.label_grid = copy.deepcopy(self._stateless_label_grid)
         self.set_state()
 
     def view_state(self):
         """
-        Access the dimension state of the ``Parameters`` instance.
+        Access the label state of the ``Parameters`` instance.
         """
         return self._state
 
@@ -116,8 +116,8 @@ class Parameters:
         Raises:
             marshmallow.exceptions.ValidationError if data is not valid.
 
-            ParameterUpdateException if dimension values do not match at
-                least one existing value item's corresponding dimension values.
+            ParameterUpdateException if label values do not match at
+                least one existing value item's corresponding label values.
         """
         params = self.read_params(params_or_path)
 
@@ -149,28 +149,30 @@ class Parameters:
 
     @property
     def validation_error(self):
-        return ValidationError(self._errors["messages"], self._errors["dims"])
+        return ValidationError(
+            self._errors["messages"], self._errors["labels"]
+        )
 
     def specification(
-        self, use_state=True, meta_data=False, include_empty=False, **dims
+        self, use_state=True, meta_data=False, include_empty=False, **labels
     ):
         """
-        Query value(s) of all parameters along dimensions specified in
-        ``dims``. If ``use_state`` is ``True``, the current state is updated with
-        ``dims``. If ``meta_data`` is ``True``, then parameter attributes
+        Query value(s) of all parameters along labels specified in
+        ``labels``. If ``use_state`` is ``True``, the current state is updated with
+        ``labels``. If ``meta_data`` is ``True``, then parameter attributes
         are included, too. If ``include_empty`` is ``True``, then values that
-        do not match the query dimensions set with ``self._state`` or
-        ``dims`` will be included and set to an empty list.
+        do not match the query labels set with ``self._state`` or
+        ``labels`` will be included and set to an empty list.
 
         Returns: serialized data of shape
-            {"param_name": [{"value": val, "dim0": ..., }], ...}
+            {"param_name": [{"value": val, "label0": ..., }], ...}
         """
         if use_state:
-            dims.update(self._state)
+            labels.update(self._state)
 
         all_params = OrderedDict()
         for param in self._validator_schema.fields:
-            result = self._get(param, False, **dims)
+            result = self._get(param, False, **labels)
             if result or include_empty:
                 if meta_data:
                     param_data = self._data[param]
@@ -180,43 +182,43 @@ class Parameters:
 
     def to_array(self, param):
         """
-        Convert a Value object to an n-dimensional array. The list of Value
+        Convert a Value object to an n-labelal array. The list of Value
         objects must span the specified parameter space. The parameter space
-        is defined by inspecting the dimension validators in schema.json
+        is defined by inspecting the label validators in schema.json
         and the state attribute of the Parameters instance.
 
-        Returns: n-dimensional NumPy array.
+        Returns: n-labelal NumPy array.
 
         Raises:
-            InconsistentDimensionsException: Value objects do not have consistent
-                dimensions.
+            InconsistentLabelsException: Value objects do not have consistent
+                labels.
             SparseValueObjectsException: Value object does not span the
                 entire space specified by the Order object.
         """
         value_items = self._get(param, False, **self._state)
-        dim_order, value_order = self._resolve_order(param)
+        label_order, value_order = self._resolve_order(param)
         shape = []
-        for dim in dim_order:
-            shape.append(len(value_order[dim]))
+        for label in label_order:
+            shape.append(len(value_order[label]))
         shape = tuple(shape)
         arr = np.empty(shape, dtype=self._numpy_type(param))
         # Compare len value items with the expected length if they are full.
         # In the futute, sparse objects should be supported by filling in the
-        # unspecified dimensions.
+        # unspecified labels.
         if not shape:
             exp_full_shape = 1
         else:
             exp_full_shape = reduce(lambda x, y: x * y, shape)
         if len(value_items) != exp_full_shape:
-            # maintains dimension value order over value objects.
-            exp_mesh = list(itertools.product(*value_order.values()))
-            # preserve dimension value order for each value object by
-            # iterating over dim_order.
+            # maintains label value order over value objects.
+            exp_grid = list(itertools.product(*value_order.values()))
+            # preserve label value order for each value object by
+            # iterating over label_order.
             actual = set(
-                [tuple(vo[d] for d in dim_order) for vo in value_items]
+                [tuple(vo[d] for d in label_order) for vo in value_items]
             )
             missing = "\n\t".join(
-                [str(d) for d in exp_mesh if d not in actual]
+                [str(d) for d in exp_grid if d not in actual]
             )
             raise SparseValueObjectsException(
                 f"The Value objects for {param} do not span the specified "
@@ -228,11 +230,13 @@ class Parameters:
 
         for vi in value_items:
             # ix stores the indices of `arr` that need to be filled in.
-            ix = [[] for i in range(len(dim_order))]
-            for dim_pos, dim_name in enumerate(dim_order):
+            ix = [[] for i in range(len(label_order))]
+            for label_pos, label_name in enumerate(label_order):
                 # assume value_items is dense in the sense that it spans
-                # the dimension space.
-                ix[dim_pos].append(value_order[dim_name].index(vi[dim_name]))
+                # the label space.
+                ix[label_pos].append(
+                    value_order[label_name].index(vi[label_name])
+                )
             ix = tuple(map(list_2_tuple, ix))
             arr[ix] = vi["value"]
         return arr
@@ -242,11 +246,11 @@ class Parameters:
         Convert NumPy array to a Value object.
 
         Returns:
-            Value object (shape: [{"value": val, dims:...}])
+            Value object (shape: [{"value": val, labels:...}])
 
         Raises:
-            InconsistentDimensionsException: Value objects do not have consistent
-                dimensions.
+            InconsistentLabelsException: Value objects do not have consistent
+                labels.
         """
         if array is None:
             array = getattr(self, param)
@@ -255,49 +259,49 @@ class Parameters:
                     "A NumPy Ndarray should be passed to this method "
                     "or the instance attribute should be an array."
                 )
-        dim_order, value_order = self._resolve_order(param)
-        dim_values = itertools.product(*value_order.values())
-        dim_indices = itertools.product(
+        label_order, value_order = self._resolve_order(param)
+        label_values = itertools.product(*value_order.values())
+        label_indices = itertools.product(
             *map(lambda x: range(len(x)), value_order.values())
         )
         value_items = []
-        for dv, di in zip(dim_values, dim_indices):
-            vi = {dim_order[j]: dv[j] for j in range(len(dv))}
+        for dv, di in zip(label_values, label_indices):
+            vi = {label_order[j]: dv[j] for j in range(len(dv))}
             vi["value"] = array[di]
             value_items.append(vi)
         return value_items
 
     def _resolve_order(self, param):
         """
-        Resolve the order of the dimensions and their values by
-        inspecting data in the dimension mesh values.
+        Resolve the order of the labels and their values by
+        inspecting data in the label grid values.
 
-        The dimension mesh for all dimensions is stored in the dim_mesh
-        attribute. The dimensions to be used are the ones that are specified
-        for each value object. Note that the dimensions must be specified
+        The label grid for all labels is stored in the label_grid
+        attribute. The labels to be used are the ones that are specified
+        for each value object. Note that the labels must be specified
         _consistently_ for all value objects, i.e. none can be added or omitted
         for any value object in the list.
 
         Returns:
-            dim_order: The dimension order.
-            value_order: The values, in order, for each dimension.
+            label_order: The label order.
+            value_order: The values, in order, for each label.
 
         Raises:
-            InconsistentDimensionsException: Value objects do not have consistent
-                dimensions.
+            InconsistentLabelsException: Value objects do not have consistent
+                labels.
         """
         value_items = self._get(param, False, **self._state)
-        used = utils.consistent_dims(value_items)
+        used = utils.consistent_labels(value_items)
         if used is None:
-            raise InconsistentDimensionsException(
-                f"Some dimensions in {value_items} were added or omitted for some value object(s)."
+            raise InconsistentLabelsException(
+                f"Some labels in {value_items} were added or omitted for some value object(s)."
             )
-        dim_order, value_order = [], {}
-        for dim_name, dim_values in self.dim_mesh.items():
-            if dim_name in used:
-                dim_order.append(dim_name)
-                value_order[dim_name] = dim_values
-        return dim_order, value_order
+        label_order, value_order = [], {}
+        for label_name, label_values in self.label_grid.items():
+            if label_name in used:
+                label_order.append(label_name)
+                value_order[label_name] = label_values
+        return label_order, value_order
 
     def _numpy_type(self, param):
         """
@@ -307,26 +311,26 @@ class Parameters:
             self._validator_schema.fields[param].nested.fields["value"].np_type
         )
 
-    def _get(self, param, exact_match, **dims):
+    def _get(self, param, exact_match, **labels):
         """
-        Query a parameter along some dimensions. If exact_match is True,
-        all values in `dims` must be equal to the corresponding dimension
+        Query a parameter along some labels. If exact_match is True,
+        all values in `labels` must be equal to the corresponding label
         in the parameter's "value" dictionary.
 
         Ignores state.
 
-        Returns: [{"value": val, "dim0": ..., }]
+        Returns: [{"value": val, "label0": ..., }]
         """
         value_objects = self._data[param]["value"]
         ret = []
         for value_object in value_objects:
             matches = []
-            for dim_name, dim_value in dims.items():
-                if dim_name in value_object or exact_match:
-                    if isinstance(dim_value, list):
-                        match = value_object[dim_name] in dim_value
+            for label_name, label_value in labels.items():
+                if label_name in value_object or exact_match:
+                    if isinstance(label_value, list):
+                        match = value_object[label_name] in label_value
                     else:
-                        match = value_object[dim_name] == dim_value
+                        match = value_object[label_name] == label_value
                     matches.append(match)
             if all(matches):
                 ret.append(value_object)
@@ -336,15 +340,15 @@ class Parameters:
         """
         Update the current parameter values with those specified by
         the adjustment. The values that need to be updated are chosen
-        by finding all value items with dimension values matching the
-        dimension values specified in the adjustment. If the value is
+        by finding all value items with label values matching the
+        label values specified in the adjustment. If the value is
         set to None, then that value object will be removed.
 
         Note: _update_param used to raise a ParameterUpdateException if one of the new
             values did not match at least one of the current value objects. However,
             this was dropped to better support the case where the parameters are being
-            extended along some dimension to fill the parameter space. An exception could
-            be raised if a new value object contains a dimension that is not used in the
+            extended along some label to fill the parameter space. An exception could
+            be raised if a new value object contains a label that is not used in the
             current value objects for the parameter. However, it seems like it could be
             expensive to check this case, especially when a project is extending parameters.
             For now, no exceptions are raised by this method.
@@ -353,11 +357,12 @@ class Parameters:
         curr_vals = self._data[param]["value"]
         for i in range(len(new_values)):
             matched_at_least_once = False
-            dims_to_check = tuple(k for k in new_values[i] if k != "value")
+            labels_to_check = tuple(k for k in new_values[i] if k != "value")
             to_delete = []
             for j in range(len(curr_vals)):
                 match = all(
-                    curr_vals[j][k] == new_values[i][k] for k in dims_to_check
+                    curr_vals[j][k] == new_values[i][k]
+                    for k in labels_to_check
                 )
                 if match:
                     matched_at_least_once = True
@@ -408,13 +413,13 @@ class Parameters:
             "messages": {
                 "param": [
                     ["value": {0: [msg0, msg1, ...], other_bad_ix: ...},
-                     "dim0": {0: msg, ...} // if errors on dimension values.
+                     "label0": {0: msg, ...} // if errors on label values.
                 ],
                 ...
             },
-            "dim": {
+            "label": {
                 "param": [
-                    {dim_name: dim_value, other_dim_name: other_dim_value},
+                    {label_name: label_value, other_label_name: other_label_value},
                     ...
                     // list indices correspond to the error messages' indices
                     // of the error messages caused by the value of this value
@@ -424,7 +429,10 @@ class Parameters:
         }
 
         """
-        error_info = {"messages": defaultdict(dict), "dims": defaultdict(dict)}
+        error_info = {
+            "messages": defaultdict(dict),
+            "labels": defaultdict(dict),
+        }
 
         def to_list(value, messages, formatted_errors):
             for message in messages:
@@ -437,10 +445,10 @@ class Parameters:
                     formatted_errors_ix.append(message)
 
         for pname, data in ve.messages.items():
-            error_dims = []
+            error_labels = []
             formatted_errors = []
             for ix, marshmessages in data.items():
-                error_dims.append(
+                error_labels.append(
                     {
                         k: v
                         for k, v in params[pname][ix].items()
@@ -459,6 +467,6 @@ class Parameters:
                             )
                 formatted_errors.append(formatted_errors_ix)
             error_info["messages"][pname] = formatted_errors
-            error_info["dims"][pname] = error_dims
+            error_info["labels"][pname] = error_labels
 
         self._errors.update(dict(error_info))

--- a/paramtools/schema.py
+++ b/paramtools/schema.py
@@ -323,10 +323,10 @@ def get_type(data):
     }
     types = dict(FIELD_MAP, **numeric_types)
     fieldtype = types[data["type"]]
-    label = data.get("number_dims", 0)
-    while label > 0:
+    dim = data.get("number_dims", 0)
+    while dim > 0:
         fieldtype = fields.List(fieldtype, allow_none=True)
-        label -= 1
+        dim -= 1
     return fieldtype
 
 

--- a/paramtools/tests/defaults.json
+++ b/paramtools/tests/defaults.json
@@ -6,8 +6,8 @@
         "opt0": "an option",
         "type": "int",
         "value": [
-            {"dim0": "zero", "dim1": 1, "value": 1},
-            {"dim0": "one", "dim1": 2, "value": 2}
+            {"label0": "zero", "label1": 1, "value": 1},
+            {"label0": "one", "label1": 2, "value": 2}
         ],
         "validators": {"range": {"min": 0, "max": "max_int_param"}}
     },
@@ -18,8 +18,8 @@
         "opt0": "an option",
         "type": "int",
         "value": [
-            {"dim0": "zero", "dim1": 1, "value": 3},
-            {"dim0": "one", "dim1": 2, "value": 4}
+            {"label0": "zero", "label1": 1, "value": 3},
+            {"label0": "one", "label1": 2, "value": 4}
         ],
         "validators": {"range": {"min": "min_int_param", "max": 10}}
     },
@@ -37,7 +37,7 @@
         "opt0": "another option",
         "type": "date",
         "value": [
-            {"dim0": "zero", "dim1": 1, "value": "2018-01-15"}
+            {"label0": "zero", "label1": 1, "value": "2018-01-15"}
         ],
         "validators": {"date_range": {"min": "2018-01-01", "max": "2018-12-31"}}
     },
@@ -48,7 +48,7 @@
         "opt0": "an option",
         "type": "date",
         "value": [
-            {"dim0": "zero", "dim1": 1, "value": "2018-01-15"}
+            {"label0": "zero", "label1": 1, "value": "2018-01-15"}
         ],
         "validators": {"date_range": {"min": "2018-01-01", "max": "date_max_param"}}
     },
@@ -59,7 +59,7 @@
         "opt0": "an option",
         "type": "date",
         "value": [
-            {"dim0": "zero", "dim1": 1, "value": "2018-01-15"}
+            {"label0": "zero", "label1": 1, "value": "2018-01-15"}
         ],
         "validators": {"date_range": {"min": "date_min_param", "max": "2018-12-31"}}
     },
@@ -70,7 +70,7 @@
         "type": "float",
         "number_dims": 1,
         "value": [
-            {"dim0": "zero", "dim1": 1, "value": [1, 2.0, 3.5, 4.6]}
+            {"label0": "zero", "label1": 1, "value": [1, 2.0, 3.5, 4.6]}
         ],
         "validators": {"range": {"min": 0, "max": 10}}
     },
@@ -97,43 +97,43 @@
         "opt0": "an option",
         "type": "int",
         "value": [
-            {"dim0": "zero", "dim1": 0, "dim2": 0, "value": 1},
-            {"dim0": "zero", "dim1": 0, "dim2": 1, "value": 2},
-            {"dim0": "zero", "dim1": 0, "dim2": 2, "value": 3},
-            {"dim0": "zero", "dim1": 1, "dim2": 0, "value": 4},
-            {"dim0": "zero", "dim1": 1, "dim2": 1, "value": 5},
-            {"dim0": "zero", "dim1": 1, "dim2": 2, "value": 6},
-            {"dim0": "zero", "dim1": 2, "dim2": 0, "value": 7},
-            {"dim0": "zero", "dim1": 2, "dim2": 1, "value": 8},
-            {"dim0": "zero", "dim1": 2, "dim2": 2, "value": 9},
-            {"dim0": "zero", "dim1": 3, "dim2": 0, "value": 10},
-            {"dim0": "zero", "dim1": 3, "dim2": 1, "value": 11},
-            {"dim0": "zero", "dim1": 3, "dim2": 2, "value": 12},
-            {"dim0": "zero", "dim1": 4, "dim2": 0, "value": 13},
-            {"dim0": "zero", "dim1": 4, "dim2": 1, "value": 14},
-            {"dim0": "zero", "dim1": 4, "dim2": 2, "value": 15},
-            {"dim0": "zero", "dim1": 5, "dim2": 0, "value": 16},
-            {"dim0": "zero", "dim1": 5, "dim2": 1, "value": 17},
-            {"dim0": "zero", "dim1": 5, "dim2": 2, "value": 18},
+            {"label0": "zero", "label1": 0, "label2": 0, "value": 1},
+            {"label0": "zero", "label1": 0, "label2": 1, "value": 2},
+            {"label0": "zero", "label1": 0, "label2": 2, "value": 3},
+            {"label0": "zero", "label1": 1, "label2": 0, "value": 4},
+            {"label0": "zero", "label1": 1, "label2": 1, "value": 5},
+            {"label0": "zero", "label1": 1, "label2": 2, "value": 6},
+            {"label0": "zero", "label1": 2, "label2": 0, "value": 7},
+            {"label0": "zero", "label1": 2, "label2": 1, "value": 8},
+            {"label0": "zero", "label1": 2, "label2": 2, "value": 9},
+            {"label0": "zero", "label1": 3, "label2": 0, "value": 10},
+            {"label0": "zero", "label1": 3, "label2": 1, "value": 11},
+            {"label0": "zero", "label1": 3, "label2": 2, "value": 12},
+            {"label0": "zero", "label1": 4, "label2": 0, "value": 13},
+            {"label0": "zero", "label1": 4, "label2": 1, "value": 14},
+            {"label0": "zero", "label1": 4, "label2": 2, "value": 15},
+            {"label0": "zero", "label1": 5, "label2": 0, "value": 16},
+            {"label0": "zero", "label1": 5, "label2": 1, "value": 17},
+            {"label0": "zero", "label1": 5, "label2": 2, "value": 18},
 
-            {"dim0": "one", "dim1": 0, "dim2": 0, "value": 19},
-            {"dim0": "one", "dim1": 0, "dim2": 1, "value": 20},
-            {"dim0": "one", "dim1": 0, "dim2": 2, "value": 21},
-            {"dim0": "one", "dim1": 1, "dim2": 0, "value": 22},
-            {"dim0": "one", "dim1": 1, "dim2": 1, "value": 23},
-            {"dim0": "one", "dim1": 1, "dim2": 2, "value": 24},
-            {"dim0": "one", "dim1": 2, "dim2": 0, "value": 25},
-            {"dim0": "one", "dim1": 2, "dim2": 1, "value": 26},
-            {"dim0": "one", "dim1": 2, "dim2": 2, "value": 27},
-            {"dim0": "one", "dim1": 3, "dim2": 0, "value": 28},
-            {"dim0": "one", "dim1": 3, "dim2": 1, "value": 29},
-            {"dim0": "one", "dim1": 3, "dim2": 2, "value": 30},
-            {"dim0": "one", "dim1": 4, "dim2": 0, "value": 31},
-            {"dim0": "one", "dim1": 4, "dim2": 1, "value": 32},
-            {"dim0": "one", "dim1": 4, "dim2": 2, "value": 33},
-            {"dim0": "one", "dim1": 5, "dim2": 0, "value": 34},
-            {"dim0": "one", "dim1": 5, "dim2": 1, "value": 35},
-            {"dim0": "one", "dim1": 5, "dim2": 2, "value": 36}
+            {"label0": "one", "label1": 0, "label2": 0, "value": 19},
+            {"label0": "one", "label1": 0, "label2": 1, "value": 20},
+            {"label0": "one", "label1": 0, "label2": 2, "value": 21},
+            {"label0": "one", "label1": 1, "label2": 0, "value": 22},
+            {"label0": "one", "label1": 1, "label2": 1, "value": 23},
+            {"label0": "one", "label1": 1, "label2": 2, "value": 24},
+            {"label0": "one", "label1": 2, "label2": 0, "value": 25},
+            {"label0": "one", "label1": 2, "label2": 1, "value": 26},
+            {"label0": "one", "label1": 2, "label2": 2, "value": 27},
+            {"label0": "one", "label1": 3, "label2": 0, "value": 28},
+            {"label0": "one", "label1": 3, "label2": 1, "value": 29},
+            {"label0": "one", "label1": 3, "label2": 2, "value": 30},
+            {"label0": "one", "label1": 4, "label2": 0, "value": 31},
+            {"label0": "one", "label1": 4, "label2": 1, "value": 32},
+            {"label0": "one", "label1": 4, "label2": 2, "value": 33},
+            {"label0": "one", "label1": 5, "label2": 0, "value": 34},
+            {"label0": "one", "label1": 5, "label2": 1, "value": 35},
+            {"label0": "one", "label1": 5, "label2": 2, "value": 36}
 
         ],
         "validators": {"range": {"min": 1, "max": 9}}

--- a/paramtools/tests/schema.json
+++ b/paramtools/tests/schema.json
@@ -1,16 +1,16 @@
 {
     "schema_name": "test",
-    "dims": {
-        "dim0": {
+    "labels": {
+        "label0": {
             "type": "str",
             "validators": {"choice": {"choices": ["zero",
                                                   "one"]}}
         },
-        "dim1": {
+        "label1": {
             "type": "int",
             "validators": {"range": {"min": 0, "max": 5}}
         },
-        "dim2": {
+        "label2": {
             "type": "int",
             "validators": {"range": {"min": 0, "max": 2}}
         }

--- a/paramtools/tests/test_fields.py
+++ b/paramtools/tests/test_fields.py
@@ -31,15 +31,15 @@ def test_contrib_fields():
     choice_validator = validate.OneOf(choices=["one", "two"])
 
     s = fields.Str(validate=[choice_validator])
-    assert s.mesh() == ["one", "two"]
+    assert s.grid() == ["one", "two"]
     s = fields.Str()
-    assert s.mesh() == []
+    assert s.grid() == []
 
     s = fields.Integer(validate=[range_validator])
-    assert s.mesh() == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    assert s.grid() == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     s = fields.Str()
-    assert s.mesh() == []
+    assert s.grid() == []
 
     # date will need an interval argument.
     s = fields.Date(validate=[daterange_validator])
-    assert s.mesh() == [datetime.date(2019, 1, i) for i in range(1, 6, 2)]
+    assert s.grid() == [datetime.date(2019, 1, i) for i in range(1, 6, 2)]

--- a/paramtools/tests/test_parameters.py
+++ b/paramtools/tests/test_parameters.py
@@ -7,7 +7,7 @@ import pytest
 from paramtools import (
     ValidationError,
     SparseValueObjectsException,
-    InconsistentDimensionsException,
+    InconsistentLabelsException,
     collision_list,
     ParameterNameCollisionException,
 )
@@ -52,7 +52,7 @@ def af_params(schema_def_path, array_first_defaults):
         defaults = array_first_defaults
 
     _af_params = AFParams(
-        initial_state={"dim0": "zero", "dim1": 1}, array_first=True
+        initial_state={"label0": "zero", "label1": 1}, array_first=True
     )
     return _af_params
 
@@ -63,8 +63,8 @@ def test_init(TestParams):
     assert params._data
     for param in params._data:
         assert getattr(params, param)
-    assert params.dim_mesh
-    assert params.dim_mesh == params._stateless_dim_mesh
+    assert params.label_grid
+    assert params.label_grid == params._stateless_label_grid
 
 
 class TestAccess:
@@ -80,23 +80,23 @@ class TestAccess:
         assert spec1["min_int_param"] == exp["min_int_param"]["value"]
 
         exp = {
-            "min_int_param": [{"dim0": "one", "dim1": 2, "value": 2}],
-            "max_int_param": [{"dim0": "one", "dim1": 2, "value": 4}],
+            "min_int_param": [{"label0": "one", "label1": 2, "value": 2}],
+            "max_int_param": [{"label0": "one", "label1": 2, "value": 4}],
         }
-        spec2 = params.specification(dim0="one")
-        # check that specification method got only the value item with dim0="one"
+        spec2 = params.specification(label0="one")
+        # check that specification method got only the value item with label0="one"
         assert spec2["min_int_param"] == exp["min_int_param"]
         assert spec2["max_int_param"] == exp["max_int_param"]
 
-        # check that get method got only value item with dim0="one"
-        params.set_state(dim0="one")
+        # check that get method got only value item with label0="one"
+        params.set_state(label0="one")
         assert params.min_int_param == exp["min_int_param"]
         assert params.max_int_param == exp["max_int_param"]
 
-        # check that specification method gets other data, not containing a dim0
-        # dimension.
+        # check that specification method gets other data, not containing a label0
+        # label.
         for param, data in spec1.items():
-            if all("dim0" not in val_item for val_item in data):
+            if all("label0" not in val_item for val_item in data):
                 assert spec2[param] == data
 
         params._data["str_choice_param"]["value"] = []
@@ -107,10 +107,10 @@ class TestAccess:
 class TestAdjust:
     def test_adjust_int_param(self, TestParams):
         params = TestParams()
-        params.set_state(dim0="one", dim1=2)
+        params.set_state(label0="one", label1=2)
 
         adjustment = {
-            "min_int_param": [{"dim0": "one", "dim1": 2, "value": 3}]
+            "min_int_param": [{"label0": "one", "label1": 2, "value": 3}]
         }
         params.adjust(adjustment)
         assert params.min_int_param == adjustment["min_int_param"]
@@ -123,16 +123,16 @@ class TestAdjust:
         specified.
         """
         params = TestParams()
-        params.set_state(dim0="zero", dim1=1)
+        params.set_state(label0="zero", label1=1)
         adjustment = {
-            "min_int_param": [{"dim0": "zero", "dim1": 1, "value": 4}],
-            "max_int_param": [{"dim0": "zero", "dim1": 1, "value": 5}],
+            "min_int_param": [{"label0": "zero", "label1": 1, "value": 4}],
+            "max_int_param": [{"label0": "zero", "label1": 1, "value": 5}],
         }
         params.adjust(adjustment)
         assert params.min_int_param == adjustment["min_int_param"]
         assert params.max_int_param == adjustment["max_int_param"]
 
-    def test_adjust_many_dimensions(self, TestParams):
+    def test_adjust_many_labels(self, TestParams):
         """
         Adjust min_int_param above original max_int_param value at same time as
         max_int_param value is adjusted up. This tests that the new param is
@@ -140,32 +140,38 @@ class TestAdjust:
         specified.
         """
         params = TestParams()
-        params.set_state(dim0="zero", dim1=1)
+        params.set_state(label0="zero", label1=1)
         adjustment = {
-            "min_int_param": [{"dim0": "one", "dim1": 2, "value": 2}],
+            "min_int_param": [{"label0": "one", "label1": 2, "value": 2}],
             "int_default_param": 5,
-            "date_param": [{"dim0": "zero", "dim1": 1, "value": "2018-01-17"}],
+            "date_param": [
+                {"label0": "zero", "label1": 1, "value": "2018-01-17"}
+            ],
         }
         params.adjust(adjustment)
         # min_int_param is adjusted in the _data attribute but the instance
         # attribute min_int_param is not.
-        spec = params.specification(use_state=False, dim0="one", dim1=2)
+        spec = params.specification(use_state=False, label0="one", label1=2)
         assert spec["min_int_param"] == adjustment["min_int_param"]
         assert params.min_int_param == [
-            {"dim0": "zero", "dim1": 1, "value": 1}
+            {"label0": "zero", "label1": 1, "value": 1}
         ]
 
         assert params.int_default_param == [
             {"value": adjustment["int_default_param"]}
         ]
         assert params.date_param == [
-            {"value": datetime.date(2018, 1, 17), "dim1": 1, "dim0": "zero"}
+            {
+                "value": datetime.date(2018, 1, 17),
+                "label1": 1,
+                "label0": "zero",
+            }
         ]
 
     def test_adjust_none_basic(self, TestParams):
         params = TestParams()
         adj = {
-            "min_int_param": [{"dim0": "one", "dim1": 2, "value": None}],
+            "min_int_param": [{"label0": "one", "label1": 2, "value": None}],
             "str_choice_param": [{"value": None}],
         }
         params.adjust(adj)
@@ -181,14 +187,14 @@ class TestAdjust:
         assert len(params.int_dense_array_param) == 0
 
         params = TestParams()
-        adj = {"int_dense_array_param": [{"dim0": "zero", "value": None}]}
+        adj = {"int_dense_array_param": [{"label0": "zero", "value": None}]}
         params.adjust(adj)
         assert len(params._data["int_dense_array_param"]["value"]) == 18
         assert len(params.int_dense_array_param) == 18
         assert (
             len(
                 params.specification(
-                    use_state=False, include_empty=True, dim0="zero"
+                    use_state=False, include_empty=True, label0="zero"
                 )["int_dense_array_param"]
             )
             == 0
@@ -196,7 +202,7 @@ class TestAdjust:
         assert (
             len(
                 params.specification(
-                    use_state=False, include_empty=True, dim0="one"
+                    use_state=False, include_empty=True, label0="one"
                 )["int_dense_array_param"]
             )
             == 18
@@ -222,8 +228,8 @@ class TestErrors:
         }
         assert excinfo.value.messages == exp_internal_message
 
-        exp_dims = {"min_int_param": [{}]}
-        assert excinfo.value.dims == exp_dims
+        exp_labels = {"min_int_param": [{}]}
+        assert excinfo.value.labels == exp_labels
 
     def test_errors_choice_param(self, TestParams):
         params = TestParams()
@@ -262,7 +268,7 @@ class TestErrors:
 
     def test_errors_default_reference_param(self, TestParams):
         params = TestParams()
-        params.set_state(dim0="zero", dim1=1)
+        params.set_state(label0="zero", label1=1)
         # value under the default.
         curr = params.int_default_param[0]["value"]
         adjustment = {"int_default_param": [{"value": curr - 1}]}
@@ -274,7 +280,7 @@ class TestErrors:
         params = TestParams()
         adjustment = {
             "min_int_param": [
-                {"dim0": "zero", "dim1": 1, "value": "not a number"}
+                {"label0": "zero", "label1": 1, "value": "not a number"}
             ]
         }
 
@@ -286,10 +292,12 @@ class TestErrors:
         params = TestParams()
         adjustment = {
             "min_int_param": [
-                {"dim0": "zero", "dim1": 1, "value": "not a number"},
-                {"dim0": "one", "dim1": 2, "value": "still not a number"},
+                {"label0": "zero", "label1": 1, "value": "not a number"},
+                {"label0": "one", "label1": 2, "value": "still not a number"},
             ],
-            "date_param": [{"dim0": "zero", "dim1": 1, "value": "not a date"}],
+            "date_param": [
+                {"label0": "zero", "label1": 1, "value": "not a date"}
+            ],
         }
 
         params.adjust(adjustment, raise_errors=False)
@@ -307,8 +315,8 @@ class TestErrors:
 
         adj = {
             "float_list_param": [
-                {"value": ["abc", 0, "def", 1], "dim0": "zero", "dim1": 1},
-                {"value": [-1, "ijk"], "dim0": "one", "dim1": 2},
+                {"value": ["abc", 0, "def", 1], "label0": "zero", "label1": 1},
+                {"value": [-1, "ijk"], "label0": "one", "label1": 2},
             ]
         }
         with pytest.raises(ValidationError) as excinfo:
@@ -330,22 +338,24 @@ class TestErrors:
         }
         assert excinfo.value.messages == exp_internal_message
 
-        exp_dims = {
+        exp_labels = {
             "float_list_param": [
-                {"dim0": "zero", "dim1": 1},
-                {"dim0": "one", "dim1": 2},
+                {"label0": "zero", "label1": 1},
+                {"label0": "one", "label1": 2},
             ]
         }
-        assert excinfo.value.dims == exp_dims
+        assert excinfo.value.labels == exp_labels
 
     def test_range_validation_on_list_param(self, TestParams):
         params = TestParams()
         adj = {
-            "float_list_param": [{"value": [-1, 1], "dim0": "zero", "dim1": 1}]
+            "float_list_param": [
+                {"value": [-1, 1], "label0": "zero", "label1": 1}
+            ]
         }
         params.adjust(adj, raise_errors=False)
         exp = [
-            "float_list_param [-1.0, 1.0] must be greater than 0 for dimensions dim0=zero , dim1=1."
+            "float_list_param [-1.0, 1.0] must be greater than 0 for labels label0=zero , label1=1."
         ]
 
         assert params.errors["float_list_param"] == exp
@@ -391,15 +401,15 @@ class TestArray:
             params.from_array("min_int_param")
 
     def test_resolve_order(self, TestParams):
-        exp_dim_order = ["dim0", "dim2"]
-        exp_value_order = {"dim0": ["zero", "one"], "dim2": [0, 1, 2]}
+        exp_label_order = ["label0", "label2"]
+        exp_value_order = {"label0": ["zero", "one"], "label2": [0, 1, 2]}
         vi = [
-            {"dim0": "zero", "dim2": 0, "value": None},
-            {"dim0": "zero", "dim2": 1, "value": None},
-            {"dim0": "zero", "dim2": 2, "value": None},
-            {"dim0": "one", "dim2": 0, "value": None},
-            {"dim0": "one", "dim2": 1, "value": None},
-            {"dim0": "one", "dim2": 2, "value": None},
+            {"label0": "zero", "label2": 0, "value": None},
+            {"label0": "zero", "label2": 1, "value": None},
+            {"label0": "zero", "label2": 2, "value": None},
+            {"label0": "one", "label2": 0, "value": None},
+            {"label0": "one", "label2": 1, "value": None},
+            {"label0": "one", "label2": 2, "value": None},
         ]
 
         params = TestParams()
@@ -407,25 +417,25 @@ class TestArray:
         params._data["madeup"] = {"value": vi}
 
         assert params._resolve_order("madeup") == (
-            exp_dim_order,
+            exp_label_order,
             exp_value_order,
         )
 
         # test with specified state.
-        exp_value_order = {"dim0": ["zero", "one"], "dim2": [0, 1]}
-        params.set_state(dim2=[0, 1])
+        exp_value_order = {"label0": ["zero", "one"], "label2": [0, 1]}
+        params.set_state(label2=[0, 1])
         assert params._resolve_order("madeup") == (
-            exp_dim_order,
+            exp_label_order,
             exp_value_order,
         )
 
-        params.madeup[0]["dim1"] = 0
-        with pytest.raises(InconsistentDimensionsException):
+        params.madeup[0]["label1"] = 0
+        with pytest.raises(InconsistentLabelsException):
             params._resolve_order("madeup")
 
     def test_to_array_with_state1(self, TestParams):
         params = TestParams()
-        params.set_state(dim0="zero")
+        params.set_state(label0="zero")
         res = params.to_array("int_dense_array_param")
 
         exp = [
@@ -446,11 +456,11 @@ class TestArray:
 
     def test_to_array_with_state2(self, TestParams):
         params = TestParams()
-        # Drop values 3 and 4 from dim1
-        params.set_state(dim1=[0, 1, 2, 5])
+        # Drop values 3 and 4 from label1
+        params.set_state(label1=[0, 1, 2, 5])
         res = params.to_array("int_dense_array_param")
 
-        # Values 3 and 4 were removed from dim1.
+        # Values 3 and 4 were removed from label1.
         exp = [
             [
                 [1, 2, 3],
@@ -480,88 +490,104 @@ class TestState:
     def test_basic_set_state(self, TestParams):
         params = TestParams()
         assert params.view_state() == {}
-        params.set_state(dim0="zero")
-        assert params.view_state() == {"dim0": "zero"}
-        params.set_state(dim1=0)
-        assert params.view_state() == {"dim0": "zero", "dim1": 0}
-        params.set_state(dim0="one", dim2=1)
-        assert params.view_state() == {"dim0": "one", "dim1": 0, "dim2": 1}
-        params.set_state(**{})
-        assert params.view_state() == {"dim0": "one", "dim1": 0, "dim2": 1}
-        params.set_state()
-        assert params.view_state() == {"dim0": "one", "dim1": 0, "dim2": 1}
-        params.set_state(dim1=[1, 2, 3])
+        params.set_state(label0="zero")
+        assert params.view_state() == {"label0": "zero"}
+        params.set_state(label1=0)
+        assert params.view_state() == {"label0": "zero", "label1": 0}
+        params.set_state(label0="one", label2=1)
         assert params.view_state() == {
-            "dim0": "one",
-            "dim1": [1, 2, 3],
-            "dim2": 1,
+            "label0": "one",
+            "label1": 0,
+            "label2": 1,
+        }
+        params.set_state(**{})
+        assert params.view_state() == {
+            "label0": "one",
+            "label1": 0,
+            "label2": 1,
+        }
+        params.set_state()
+        assert params.view_state() == {
+            "label0": "one",
+            "label1": 0,
+            "label2": 1,
+        }
+        params.set_state(label1=[1, 2, 3])
+        assert params.view_state() == {
+            "label0": "one",
+            "label1": [1, 2, 3],
+            "label2": 1,
         }
 
-    def test_dim_mesh(self, TestParams):
+    def test_label_grid(self, TestParams):
         params = TestParams()
         exp = {
-            "dim0": ["zero", "one"],
-            "dim1": [0, 1, 2, 3, 4, 5],
-            "dim2": [0, 1, 2],
+            "label0": ["zero", "one"],
+            "label1": [0, 1, 2, 3, 4, 5],
+            "label2": [0, 1, 2],
         }
-        assert params.dim_mesh == exp
+        assert params.label_grid == exp
 
-        params.set_state(dim0="one")
-        exp = {"dim0": ["one"], "dim1": [0, 1, 2, 3, 4, 5], "dim2": [0, 1, 2]}
-        assert params.dim_mesh == exp
+        params.set_state(label0="one")
+        exp = {
+            "label0": ["one"],
+            "label1": [0, 1, 2, 3, 4, 5],
+            "label2": [0, 1, 2],
+        }
+        assert params.label_grid == exp
 
-        params.set_state(dim0="one", dim2=1)
-        exp = {"dim0": ["one"], "dim1": [0, 1, 2, 3, 4, 5], "dim2": [1]}
-        assert params.dim_mesh == exp
+        params.set_state(label0="one", label2=1)
+        exp = {"label0": ["one"], "label1": [0, 1, 2, 3, 4, 5], "label2": [1]}
+        assert params.label_grid == exp
 
-        params.set_state(dim1=[0, 1, 2, 5])
-        exp = {"dim0": ["one"], "dim1": [0, 1, 2, 5], "dim2": [1]}
-        assert params.dim_mesh == {
-            "dim0": ["one"],
-            "dim1": [0, 1, 2, 5],
-            "dim2": [1],
+        params.set_state(label1=[0, 1, 2, 5])
+        exp = {"label0": ["one"], "label1": [0, 1, 2, 5], "label2": [1]}
+        assert params.label_grid == {
+            "label0": ["one"],
+            "label1": [0, 1, 2, 5],
+            "label2": [1],
         }
 
     def test_set_state_updates_values(self, TestParams):
         params = TestParams()
         defaultexp = [
-            {"dim0": "zero", "dim1": 1, "value": 1},
-            {"dim0": "one", "dim1": 2, "value": 2},
+            {"label0": "zero", "label1": 1, "value": 1},
+            {"label0": "one", "label1": 2, "value": 2},
         ]
         assert params.min_int_param == defaultexp
 
-        params.set_state(dim0="zero")
+        params.set_state(label0="zero")
         assert params.min_int_param == [
-            {"dim0": "zero", "dim1": 1, "value": 1}
+            {"label0": "zero", "label1": 1, "value": 1}
         ]
 
-        # makes sure parameter that doesn't use dim0 is unaffected
+        # makes sure parameter that doesn't use label0 is unaffected
         assert params.str_choice_param == [{"value": "value0"}]
 
         params.clear_state()
         assert params.view_state() == {}
         assert params.min_int_param == defaultexp
-        assert params.dim_mesh == params._stateless_dim_mesh
+        assert params.label_grid == params._stateless_label_grid
 
     def test_set_state_errors(self, TestParams):
         params = TestParams()
         with pytest.raises(ValidationError):
-            params.set_state(dim0="notadim")
+            params.set_state(label0="notalabel")
 
         params = TestParams()
         with pytest.raises(ValidationError):
-            params.set_state(notadim="notadim")
+            params.set_state(notalabel="notalabel")
 
     def test_state_with_list(self, TestParams):
         params = TestParams()
-        params.set_state(dim0="zero", dim1=[0, 1])
+        params.set_state(label0="zero", label1=[0, 1])
         exp = [
-            {"dim0": "zero", "dim1": 0, "dim2": 0, "value": 1},
-            {"dim0": "zero", "dim1": 0, "dim2": 1, "value": 2},
-            {"dim0": "zero", "dim1": 0, "dim2": 2, "value": 3},
-            {"dim0": "zero", "dim1": 1, "dim2": 0, "value": 4},
-            {"dim0": "zero", "dim1": 1, "dim2": 1, "value": 5},
-            {"dim0": "zero", "dim1": 1, "dim2": 2, "value": 6},
+            {"label0": "zero", "label1": 0, "label2": 0, "value": 1},
+            {"label0": "zero", "label1": 0, "label2": 1, "value": 2},
+            {"label0": "zero", "label1": 0, "label2": 2, "value": 3},
+            {"label0": "zero", "label1": 1, "label2": 0, "value": 4},
+            {"label0": "zero", "label1": 1, "label2": 1, "value": 5},
+            {"label0": "zero", "label1": 1, "label2": 2, "value": 6},
         ]
         assert params.int_dense_array_param == exp
 
@@ -578,9 +604,9 @@ class TestArrayFirst:
 
     def test_from_array(self, af_params):
         exp = [
-            {"dim0": "zero", "dim1": 1, "dim2": 0, "value": 4},
-            {"dim0": "zero", "dim1": 1, "dim2": 1, "value": 5},
-            {"dim0": "zero", "dim1": 1, "dim2": 2, "value": 6},
+            {"label0": "zero", "label1": 1, "label2": 0, "value": 4},
+            {"label0": "zero", "label1": 1, "label2": 1, "value": 5},
+            {"label0": "zero", "label1": 1, "label2": 2, "value": 6},
         ]
         assert af_params.from_array("int_dense_array_param") == exp
 
@@ -595,16 +621,16 @@ class TestArrayFirst:
 class TestCollisions:
     def test_collision_list(self):
         class CollisionParams(Parameters):
-            schema = {"dim_name": "test", "dims": {}, "optional": {}}
+            schema = {"label_name": "test", "labels": {}, "optional": {}}
             defaults = {}
 
         params = CollisionParams()
 
         # check to make sure that the collisionlist does not need to be updated.
         # Note: dir(obj) lists out all class or instance attributes and methods.
-        assert collision_list == [
+        assert set(collision_list) == {
             name for name in dir(params) if not name.startswith("__")
-        ]
+        }
 
     def test_collision(self):
         defaults_dict = {
@@ -619,7 +645,7 @@ class TestCollisions:
         }
 
         class CollisionParams(Parameters):
-            schema = {"dim_name": "test", "dims": {}, "optional": {}}
+            schema = {"label_name": "test", "labels": {}, "optional": {}}
             defaults = defaults_dict
 
         with pytest.raises(ParameterNameCollisionException) as excinfo:

--- a/paramtools/tests/test_utils.py
+++ b/paramtools/tests/test_utils.py
@@ -1,4 +1,4 @@
-from paramtools import get_leaves, ravel, consistent_dims
+from paramtools import get_leaves, ravel, consistent_labels
 
 
 def test_get_leaves():
@@ -43,15 +43,15 @@ def test_ravel():
     assert ravel(e) == [0, 1, 2, 3, 4, 5, 6, 7, 8]
 
 
-def test_consistent_dims():
+def test_consistent_labels():
     v = [
-        {"dim0": 1, "dim1": 2, "value": 3},
-        {"dim0": 4, "dim1": 5, "value": 6},
+        {"label0": 1, "label1": 2, "value": 3},
+        {"label0": 4, "label1": 5, "value": 6},
     ]
-    assert consistent_dims(v) == set(["dim0", "dim1"])
+    assert consistent_labels(v) == set(["label0", "label1"])
 
-    v = [{"dim0": 1, "value": 3}, {"dim0": 4, "dim1": 5, "value": 6}]
-    assert consistent_dims(v) is None
+    v = [{"label0": 1, "value": 3}, {"label0": 4, "label1": 5, "value": 6}]
+    assert consistent_labels(v) is None
 
-    v = [{"dim0": 1, "dim1": 2, "value": 3}, {"dim0": 4, "value": 6}]
-    assert consistent_dims(v) is None
+    v = [{"label0": 1, "label1": 2, "value": 3}, {"label0": 4, "value": 6}]
+    assert consistent_labels(v) is None

--- a/paramtools/tests/test_validate.py
+++ b/paramtools/tests/test_validate.py
@@ -27,21 +27,21 @@ def test_OneOf():
 
 def test_Range():
     range_ = Range(0, 10)
-    assert range_.mesh() == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    assert range_.grid() == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 
     range_ = Range(0, 10, step=3)
-    assert range_.mesh() == [0, 3, 6, 9]
+    assert range_.grid() == [0, 3, 6, 9]
 
 
 def test_DateRange():
     drange = DateRange("2019-01-01", "2019-01-10", step={"days": 1})
     exp = [datetime.date(2019, 1, i) for i in range(1, 10 + 1)]
-    assert drange.mesh() == exp
+    assert drange.grid() == exp
 
     drange = DateRange("2019-01-01", "2019-01-10")
     exp = [datetime.date(2019, 1, i) for i in range(1, 10 + 1)]
-    assert drange.mesh() == exp
+    assert drange.grid() == exp
 
     drange = DateRange("2019-01-01", "2019-01-10", step={"days": 3})
     exp = [datetime.date(2019, 1, i) for i in range(1, 10 + 1, 3)]
-    assert drange.mesh() == exp
+    assert drange.grid() == exp

--- a/paramtools/utils.py
+++ b/paramtools/utils.py
@@ -60,12 +60,12 @@ def get_leaves(item):
     return gl.leaves
 
 
-def ravel(ndim_list):
+def ravel(nlabel_list):
     """ only up to 2D for now. """
-    if not isinstance(ndim_list, list):
-        return ndim_list
+    if not isinstance(nlabel_list, list):
+        return nlabel_list
     raveled = []
-    for maybe_list in ndim_list:
+    for maybe_list in nlabel_list:
         if isinstance(maybe_list, list):
             for item in maybe_list:
                 raveled.append(item)
@@ -74,10 +74,10 @@ def ravel(ndim_list):
     return raveled
 
 
-def consistent_dims(value_items):
+def consistent_labels(value_items):
     """
-    Get dimensions used consistently across all value objects.
-    Returns None if dimensions are omitted or added for
+    Get labels used consistently across all value objects.
+    Returns None if labels are omitted or added for
     some value object(s).
     """
     used = set(k for k in value_items[0] if k != "value")


### PR DESCRIPTION
See #43. This PR renames "dimension" to "label." Label was chosen instead of "selector" because labels--not selectors--are used to describe an entity. Entities are then *selected* based off of their *labels*.