### PR TITLE
Original dict should not be modified

### DIFF
--- a/paramtools/build_schema.py
+++ b/paramtools/build_schema.py
@@ -25,8 +25,9 @@ class SchemaBuilder:
     """
 
     def __init__(self, defaults, field_map={}):
-        self.defaults = utils.read_json(defaults)
-        schema = self.defaults.pop("schema", {})
+        defaults = utils.read_json(defaults)
+        schema = defaults.get("schema", {})
+        self.defaults = {k: v for k, v in defaults.items() if k != "schema"}
         (self.BaseParamSchema, self.label_validators) = get_param_schema(
             schema, field_map=field_map
         )

--- a/paramtools/tests/test_parameters.py
+++ b/paramtools/tests/test_parameters.py
@@ -60,7 +60,7 @@ def test_init(TestParams):
     assert params.label_grid == params._stateless_label_grid
 
 
-class TestEmptySchema:
+class TestSchema:
     def test_empty_schema(self):
         class Params(Parameters):
             array_first = True
@@ -120,6 +120,16 @@ class TestEmptySchema:
         params = Params()
         assert params.hello_world == "hello world"
         assert params.label_grid == {}
+
+    def test_schema_not_dropped(self, defaults_spec_path):
+        with open(defaults_spec_path, "r") as f:
+            defaults_ = json.loads(f.read())
+
+        class TestParams(Parameters):
+            defaults = defaults_
+
+        TestParams()
+        assert defaults_["schema"]
 
 
 class TestAccess:


### PR DESCRIPTION
Fix bug where the `defaults` dictionary was modified on initialization. The "schema" member was removed from the original dictionary. Now, a copy of `defaults`, without the "schema" member, is created on initialization.