### PR TITLE
Add serializable flag to specification method

### DIFF
--- a/paramtools/__init__.py
+++ b/paramtools/__init__.py
@@ -34,7 +34,7 @@ from paramtools.utils import (
 
 
 name = "paramtools"
-__version__ = "0.5.1"
+__version__ = "0.5.2"
 
 __all__ = [
     "SchemaBuilder",

--- a/paramtools/build_schema.py
+++ b/paramtools/build_schema.py
@@ -74,9 +74,8 @@ class SchemaBuilder:
             )
 
         classattrs = {k: fields.Nested(v) for k, v in param_dict.items()}
-        ParamSchema = type("ParamSchema", (EmptySchema,), classattrs)
-        param_schema = ParamSchema()
-        cleaned_defaults = param_schema.load(self.defaults)
+        DefaultsSchema = type("DefaultsSchema", (EmptySchema,), classattrs)
+        defaults_schema = DefaultsSchema()
 
         classattrs = {
             k: ValueObject(v(many=True)) for k, v in validator_dict.items()
@@ -86,4 +85,8 @@ class SchemaBuilder:
         )
         validator_schema = ValidatorSchema()
 
-        return cleaned_defaults, validator_schema
+        return (
+            defaults_schema,
+            validator_schema,
+            defaults_schema.load(self.defaults),
+        )

--- a/paramtools/contrib/fields.py
+++ b/paramtools/contrib/fields.py
@@ -4,7 +4,12 @@ import datetime
 from marshmallow import fields as marshmallow_fields
 
 
-class Float64(marshmallow_fields.Number):
+class NumPySerializeMixin:
+    def _serialize(self, value, attr, obj, **kwargs):
+        return value.tolist()
+
+
+class Float64(NumPySerializeMixin, marshmallow_fields.Number):
     """
     Implements "float" :ref:`spec:Type property` for parameter values.
     Defined as
@@ -14,7 +19,7 @@ class Float64(marshmallow_fields.Number):
     num_type = np_type = np.float64
 
 
-class Int64(marshmallow_fields.Number):
+class Int64(NumPySerializeMixin, marshmallow_fields.Number):
     """
     Implements "int" :ref:`spec:Type property` for parameter values.
     Defined as `numpy.int64 <https://docs.scipy.org/doc/numpy-1.15.0/user/basics.types.html>`__ type
@@ -23,7 +28,7 @@ class Int64(marshmallow_fields.Number):
     num_type = np_type = np.int64
 
 
-class Bool_(marshmallow_fields.Boolean):
+class Bool_(NumPySerializeMixin, marshmallow_fields.Boolean):
     """
     Implements "bool" :ref:`spec:Type property` for parameter values.
     Defined as `numpy.bool_ <https://docs.scipy.org/doc/numpy-1.15.0/user/basics.types.html>`__ type
@@ -33,9 +38,6 @@ class Bool_(marshmallow_fields.Boolean):
 
     def _deserialize(self, value, attr, obj, **kwargs):
         return np.bool_(super()._deserialize(value, attr, obj, **kwargs))
-
-    def _serialize(self, value, attr, obj, **kwargs):
-        return super()._serialize(bool(value), attr, obj, **kwargs)
 
 
 class MeshFieldMixin:

--- a/paramtools/exceptions.py
+++ b/paramtools/exceptions.py
@@ -38,6 +38,7 @@ collision_list = [
     "_stateless_label_grid",
     "_update_param",
     "_validator_schema",
+    "_defaults_schema",
     "adjust",
     "array_first",
     "clear_state",

--- a/paramtools/schema.py
+++ b/paramtools/schema.py
@@ -70,9 +70,11 @@ class BaseParamSchema(Schema):
         attribute="type",
         data_key="type",
     )
-    number_dims = fields.Integer(default=0, missing=0)
+    number_dims = fields.Integer(required=False, missing=0)
     value = fields.Field(required=True)  # will be specified later
-    validators = fields.Nested(ValueValidatorSchema(), default={}, missing={})
+    validators = fields.Nested(
+        ValueValidatorSchema(), required=False, missing={}
+    )
 
 
 class EmptySchema(Schema):

--- a/paramtools/tests/test_fields.py
+++ b/paramtools/tests/test_fields.py
@@ -10,11 +10,13 @@ def test_np_value_fields():
     res = float64._deserialize("2", None, None)
     assert res == 2.0
     assert isinstance(res, np.float64)
+    assert type(float64._serialize(res, None, None)) == float
 
     int64 = fields.Int64()
     res = int64._deserialize("2", None, None)
     assert res == 2
     assert isinstance(res, np.int64)
+    assert type(int64._serialize(res, None, None)) == int
 
     bool_ = fields.Bool_()
     res = bool_._deserialize("true", None, None)

--- a/paramtools/tests/test_parameters.py
+++ b/paramtools/tests/test_parameters.py
@@ -145,6 +145,9 @@ class TestAccess:
 
         assert spec1["min_int_param"] == exp["min_int_param"]["value"]
 
+    def test_specification_query(self, TestParams):
+        params = TestParams()
+        spec1 = params.specification()
         exp = {
             "min_int_param": [{"label0": "one", "label1": 2, "value": 2}],
             "max_int_param": [{"label0": "one", "label1": 2, "value": 4}],
@@ -168,6 +171,28 @@ class TestAccess:
         params._data["str_choice_param"]["value"] = []
         assert "str_choice_param" not in params.specification()
         assert "str_choice_param" in params.specification(include_empty=True)
+
+    def test_serializable(self, TestParams, defaults_spec_path):
+        params = TestParams()
+
+        assert json.dumps(params.specification(serializable=True))
+        assert json.dumps(
+            params.specification(serializable=True, meta_data=True)
+        )
+
+        spec = params.specification(serializable=True)
+        # Make sure "value" is removed when meta_data is False
+        for value in spec.values():
+            assert "value" not in value
+
+        with open(defaults_spec_path) as f:
+            exp = json.loads(f.read())
+        exp.pop("schema")
+
+        spec = params.specification(serializable=True, meta_data=True)
+        assert spec == params._defaults_schema.dump(
+            params._defaults_schema.load(exp)
+        )
 
 
 class TestAdjust:


### PR DESCRIPTION
Adds a `serializable` flag to the `Parameters.specification` method. Some NumPy data types (e.g. `np.bool_`) and types like `datetime`/`date` are not JSON serializable. This functionality is helpful when you want to dump a `Parameters` instance's data to a JSON file or send it over the wire via a web request.

```python
In [1]: import paramtools 
   ...: path = "paramtools/examples/taxparams-demo/defaults.json" 
   ...: class Params(paramtools.Parameters): 
   ...:     defaults = path 
   ...:                                                                                                                       

In [2]: params = Params()                                                                                                     

In [3]: params.specification(serializable=True, meta_data=True)                                                               
Out[3]: 
{'ii_bracket_2': {'number_dims': 0,
  'section_1': 'Personal Income',
  'notes': '',
  'title': 'Personal income (regular/non-AMT/non-pass-through) tax bracket (upper threshold) 2',
  'description': 'Income below this threshold and above tax bracket 1 is taxed at tax rate 2.',
  'validators': {'range': {'min': 'ii_bracket_1', 'max': 9e+99}},
  'type': 'float',
  'section_2': 'Regular: Non-AMT, Non-Pass-Through',
  'value': [{'year': 2024, 'marital_status': 'single', 'value': 44097.61},
   {'year': 2024, 'marital_status': 'joint', 'value': 88195.23},
   {'year': 2024, 'marital_status': 'separate', 'value': 44097.61},
   {'year': 2024, 'marital_status': 'headhousehold', 'value': 59024.71},
   {'year': 2024, 'marital_status': 'widow', 'value': 88195.23},


```