### PR TITLE
Rename schema 'builder' to schema 'factory'

### DIFF
--- a/paramtools/__init__.py
+++ b/paramtools/__init__.py
@@ -1,4 +1,4 @@
-from paramtools.build_schema import SchemaBuilder
+from paramtools.schema_factory import SchemaFactory
 from paramtools.exceptions import (
     ParamToolsError,
     ParameterUpdateException,
@@ -37,7 +37,7 @@ name = "paramtools"
 __version__ = "0.5.2"
 
 __all__ = [
-    "SchemaBuilder",
+    "SchemaFactory",
     "ParamToolsError",
     "ParameterUpdateException",
     "SparseValueObjectsException",

--- a/paramtools/parameters.py
+++ b/paramtools/parameters.py
@@ -8,7 +8,7 @@ from functools import reduce
 import numpy as np
 from marshmallow import ValidationError as MarshmallowValidationError
 
-from paramtools.build_schema import SchemaBuilder
+from paramtools.schema_factory import SchemaFactory
 from paramtools import utils
 from paramtools.exceptions import (
     SparseValueObjectsException,
@@ -25,13 +25,13 @@ class Parameters:
     array_first = False
 
     def __init__(self, initial_state=None, array_first=None):
-        sb = SchemaBuilder(self.defaults, self.field_map)
+        schemafactory = SchemaFactory(self.defaults, self.field_map)
         (
             self._defaults_schema,
             self._validator_schema,
             self._data,
-        ) = sb.build_schemas()
-        self.label_validators = sb.label_validators
+        ) = schemafactory.schemas()
+        self.label_validators = schemafactory.label_validators
         self._stateless_label_grid = OrderedDict(
             [(name, v.grid()) for name, v in self.label_validators.items()]
         )

--- a/paramtools/schema_factory.py
+++ b/paramtools/schema_factory.py
@@ -10,7 +10,7 @@ from paramtools.schema import (
 from paramtools import utils
 
 
-class SchemaBuilder:
+class SchemaFactory:
     """
     Uses data from:
     - a schema definition file
@@ -32,7 +32,7 @@ class SchemaBuilder:
             schema, field_map=field_map
         )
 
-    def build_schemas(self):
+    def schemas(self):
         """
         For each parameter defined in the baseline specification file:
         - define a parameter schema for that specific parameter


### PR DESCRIPTION
Rename `SchemaBuilder` to `SchemaFactory` since the code follows the [factory design pattern](https://realpython.com/factory-method-python/).