### PR TITLE
Extend parameter values along a specified label

### DIFF
--- a/docs/docs/api/extend.md
+++ b/docs/docs/api/extend.md
@@ -1,12 +1,12 @@
 # Extend
 
-The value of a parameter can be extended along a specified label. This is helpful when a parameters' value is the same for different values of a label and there is some inherent order in that label. The extend feature allows you to simply write down the minimum amount of information needed to fill in a parameter's values and ParamTools will fill in the gaps.
+The values of a parameter can be extended along a specified label. This is helpful when a parameter's values are the same for different values of a label and there is some inherent order in that label. The extend feature allows you to simply write down the minimum amount of information needed to fill in a parameter's values and ParamTools will fill in the gaps.
 
 To use the extend feature, set the `label_to_extend` class attribute to the label that should be extended.
 
 ## Example
 
-The standard deduction parameter's values only need to be set when there is a change in the tax law. For the other years, it does not change (unless its indexed to inflation). It would be annoying to have to manually write out each of its values. Instead, we can more concisely write its values in 2017, its new values in 2018 after the TCJA tax reform was passed, and its values after provisions of the TCJA are phased out in 2026.
+The standard deduction parameter's values only need to be specified when there is a change in the tax law. For the other years, it does not change (unless its indexed to inflation). It would be annoying to have to manually write out each of its values. Instead, we can more concisely write its values in 2017, its new values in 2018 after the TCJA tax reform was passed, and its values after provisions of the TCJA are phased out in 2026.
 
 ```python
 import paramtools
@@ -73,9 +73,9 @@ params.standard_deduction
 
 ## Extend behavior by validator
 
-ParamTools uses the label's validator to determine how values should be extended by assuming that there is some order among the range of possible values for the label.
+ParamTools uses the validator associated with `label_to_extend` to determine how values should be extended by assuming that there is some order among the range of possible values for the label.
 
-View the grid of values for any label by inspecting the `label_grid` attribute of a `Parameters` instance.
+Note: You can view the grid of values for any label by inspecting the `label_grid` attribute of a `paramtools.Parameters` derived instance.
 
 ### Range
 
@@ -87,7 +87,7 @@ View the grid of values for any label by inspecting the `label_grid` attribute o
 }
 ```
 
-Extend values:
+*Extend values:*
 
 ```python
 [0, 1, 2, 3, 4, 5]
@@ -101,7 +101,7 @@ Extend values:
 }
 ```
 
-Extend values:
+*Extend values:*
 
 ```python
 [0, 0.5, 1.0, 1.5, 2.0]
@@ -115,7 +115,7 @@ Extend values:
 }
 ```
 
-Extend values:
+*Extend values:*
 
 ```python
 [datetime.date(2019, 1, 1),
@@ -133,7 +133,7 @@ Extend values:
 }
 ```
 
-Extend values:
+*Extend values:*
 
 ```python
 [-1, -2, -3]
@@ -147,7 +147,7 @@ Extend values:
 }
 ```
 
-Extend values:
+*Extend values:*
 
 ```python
 ["january", "february", "march"]

--- a/docs/docs/api/extend.md
+++ b/docs/docs/api/extend.md
@@ -78,18 +78,8 @@ params.standard_deduction
 #        [ 7685., 15369.]])
 ```
 
- Consider thais range validator for an integer type parameter:
 
-{
-    "range": {"min": 0, "max": 5}
-}
-
-This label will take on 6 values, 0, 1, 2, 3, 4, 5, 6 and its direction is positive (increasing with the value of the number).
-
-ParamTools can also do extensions for choice validators, using the list of possible choices and its order to determine how it should be extended.
-
-
-# Extension behavior for each validator:
+## Extend behavior for each validator
 
 ParamTools uses the label's validator to determine how values should be extended by assuming that there is some order among the range of possible values for the label.
 
@@ -139,7 +129,7 @@ Extend values:
 [datetime.date(2019, 1, 1),
  datetime.date(2019, 1, 3),
  datetime.date(2019, 1, 5)]
- ```
+```
 
 ### Choice
 

--- a/docs/docs/api/extend.md
+++ b/docs/docs/api/extend.md
@@ -1,0 +1,172 @@
+# Extend
+
+Parameters can be extended along a single label. This is helpful when a parameter has redundant information stored in its "value" attribute. Paramtools's extend capability allows you to just write down the minimum amount of information needed to fill in parameter's values.
+
+To use the extend capability, set the `label_to_extend` class attribute to the label that should be extended.
+
+## Example
+
+The standard deduction parameter's values only need to be set when there is a change in the tax law. For the other years, it does not change. It would be annoying to have to manually write out each of its values. Instead, we write its values in 2017, its new values in 2018 after the TCJA tax reform was passed, and its values after provisions of the TCJA are phased out in 2026.
+
+```python
+
+class TaxParams(paramtools.Parameters):
+    defaults = {
+        "schema": {
+            "labels": {
+                "year": {
+                    "type": "int",
+                    "validators": {"range": {"min": 2013, "max": 2027}}
+                },
+                "marital_status": {
+                    "type": "str",
+                    "validators": {"choice": {"choices": ["single", "joint"]}}
+                },
+            },
+            "additional_members": {
+                "cpi_inflatable": {"type": "bool", "number_dims": 0},
+                "cpi_inflated": {"type": "bool", "number_dims": 0}
+            }
+        },
+        "standard_deduction": {
+            "title": "Standard deduction amount",
+            "description": "Amount filing unit can use as a standard deduction.",
+            "cpi_inflatable": True,
+            "cpi_inflated": True,
+            "type": "float",
+            "value": [
+                # Standard deduction values before TCJA is passed.
+                {"year": 2017, "marital_status": "single", "value": 6350},
+                {"year": 2017, "marital_status": "joint", "value": 12700},
+                # Standard deduction values after TCJA is passed.
+                {"year": 2018, "marital_status": "single", "value": 12000},
+                {"year": 2018, "marital_status": "joint", "value": 24000},
+                # Standard deduction values after TCJA is phased out.
+                {"year": 2026, "marital_status": "single", "value": 7685},
+                {"year": 2026, "marital_status": "joint", "value": 15369}],
+            "validators": {
+                "range": {
+                    "min": 0,
+                    "max": 9e+99
+                }
+            }
+        },
+    }
+
+    label_to_extend = "year"
+    array_first = True
+
+params = TaxParams()
+
+params.standard_deduction
+
+# output:
+# array([[ 6350., 12700.],
+#        [ 6350., 12700.],
+#        [ 6350., 12700.],
+#        [ 6350., 12700.],
+#        [ 6350., 12700.],
+#        [12000., 24000.],
+#        [12000., 24000.],
+#        [12000., 24000.],
+#        [12000., 24000.],
+#        [12000., 24000.],
+#        [12000., 24000.],
+#        [12000., 24000.],
+#        [12000., 24000.],
+#        [ 7685., 15369.],
+#        [ 7685., 15369.]])
+```
+
+ Consider thais range validator for an integer type parameter:
+
+{
+    "range": {"min": 0, "max": 5}
+}
+
+This label will take on 6 values, 0, 1, 2, 3, 4, 5, 6 and its direction is positive (increasing with the value of the number).
+
+ParamTools can also do extensions for choice validators, using the list of possible choices and its order to determine how it should be extended.
+
+
+# Extension behavior for each validator:
+
+ParamTools uses the label's validator to determine how values should be extended by assuming that there is some order among the range of possible values for the label.
+
+You can view the grid of values for any label by inspecting the `label_grid` attribute of a `Parameters` instance.
+
+### Range
+
+**Type:** `int`
+
+```json
+{
+    "range": {"min": 0, "max": 5}
+}
+```
+
+Extend values:
+
+```python
+[0, 1, 2, 3, 4, 5]
+```
+
+**Type:** `float`
+
+```json
+{
+    "range": {"min": 0, "max": 2, "step": 0.5}
+}
+```
+
+Extend values:
+
+```python
+[0, 0.5, 1.0, 1.5, 2.0]
+```
+
+**Type:** `date`
+
+```json
+{
+    "range": {"min": "2019-01-01", "max": "2019-01-05", "step": {"days": 2}}
+}
+```
+
+Extend values:
+
+```python
+[datetime.date(2019, 1, 1),
+ datetime.date(2019, 1, 3),
+ datetime.date(2019, 1, 5)]
+ ```
+
+### Choice
+
+**Type:** `int`
+
+```json
+{
+    "choice": {"choices": [-1, -2, -3]}
+}
+```
+
+Extend values:
+
+```python
+[-1, -2, -3]
+```
+
+**Type:** `str`
+
+```json
+{
+    "choice": {"choices": ["january", "february", "march"]}
+}
+```
+
+Extend values:
+
+```python
+["january", "february", "march"]
+```

--- a/docs/docs/api/extend.md
+++ b/docs/docs/api/extend.md
@@ -1,14 +1,16 @@
 # Extend
 
-Parameters can be extended along a single label. This is helpful when a parameter has redundant information stored in its "value" attribute. Paramtools's extend capability allows you to just write down the minimum amount of information needed to fill in parameter's values.
+The value of a parameter can be extended along a specified label. This is helpful when a parameters' value is the same for different values of a label and there is some inherent order in that label. The extend feature allows you to simply write down the minimum amount of information needed to fill in a parameter's values and ParamTools will fill in the gaps.
 
-To use the extend capability, set the `label_to_extend` class attribute to the label that should be extended.
+To use the extend feature, set the `label_to_extend` class attribute to the label that should be extended.
 
 ## Example
 
-The standard deduction parameter's values only need to be set when there is a change in the tax law. For the other years, it does not change. It would be annoying to have to manually write out each of its values. Instead, we write its values in 2017, its new values in 2018 after the TCJA tax reform was passed, and its values after provisions of the TCJA are phased out in 2026.
+The standard deduction parameter's values only need to be set when there is a change in the tax law. For the other years, it does not change (unless its indexed to inflation). It would be annoying to have to manually write out each of its values. Instead, we can more concisely write its values in 2017, its new values in 2018 after the TCJA tax reform was passed, and its values after provisions of the TCJA are phased out in 2026.
 
 ```python
+import paramtools
+
 
 class TaxParams(paramtools.Parameters):
     defaults = {
@@ -22,26 +24,17 @@ class TaxParams(paramtools.Parameters):
                     "type": "str",
                     "validators": {"choice": {"choices": ["single", "joint"]}}
                 },
-            },
-            "additional_members": {
-                "cpi_inflatable": {"type": "bool", "number_dims": 0},
-                "cpi_inflated": {"type": "bool", "number_dims": 0}
             }
         },
         "standard_deduction": {
             "title": "Standard deduction amount",
             "description": "Amount filing unit can use as a standard deduction.",
-            "cpi_inflatable": True,
-            "cpi_inflated": True,
             "type": "float",
             "value": [
-                # Standard deduction values before TCJA is passed.
                 {"year": 2017, "marital_status": "single", "value": 6350},
                 {"year": 2017, "marital_status": "joint", "value": 12700},
-                # Standard deduction values after TCJA is passed.
                 {"year": 2018, "marital_status": "single", "value": 12000},
                 {"year": 2018, "marital_status": "joint", "value": 24000},
-                # Standard deduction values after TCJA is phased out.
                 {"year": 2026, "marital_status": "single", "value": 7685},
                 {"year": 2026, "marital_status": "joint", "value": 15369}],
             "validators": {
@@ -57,7 +50,6 @@ class TaxParams(paramtools.Parameters):
     array_first = True
 
 params = TaxParams()
-
 params.standard_deduction
 
 # output:
@@ -79,11 +71,11 @@ params.standard_deduction
 ```
 
 
-## Extend behavior for each validator
+## Extend behavior by validator
 
 ParamTools uses the label's validator to determine how values should be extended by assuming that there is some order among the range of possible values for the label.
 
-You can view the grid of values for any label by inspecting the `label_grid` attribute of a `Parameters` instance.
+View the grid of values for any label by inspecting the `label_grid` attribute of a `Parameters` instance.
 
 ### Range
 

--- a/docs/docs/api/guide.md
+++ b/docs/docs/api/guide.md
@@ -1,0 +1,7 @@
+# Guide
+
+This guide will walk you through the ParamTools API in detail, demonstrating how to use its array manipulation, value querying, and parameter extension functionalities. This guide will also discuss how one can extend `paramtools.Parameters` to meet the custom needs of your modeling project.
+
+Check out the [home page](/) for a quick start guide to get you up and running with ParamTools.
+
+Check out the [parameters spec](/parameters/) to get familiar with the ParamTools JSON schema.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -2,4 +2,8 @@ site_name: ParamTools Docs
 nav:
     - Home: index.md
     - Parameters: parameters.md
+    - API:
+        - Guide: 'api/guide.md'
+        - Extend: 'api/extend.md'
+
 theme: mkdocs

--- a/paramtools/contrib/fields.py
+++ b/paramtools/contrib/fields.py
@@ -94,3 +94,8 @@ class Date(MeshFieldMixin, marshmallow_fields.Date):
     """
 
     np_type = datetime.date
+
+    def _deserialize(self, value, attr, data):
+        if isinstance(value, (datetime.datetime, datetime.date)):
+            return value
+        return super()._deserialize(value, attr, data)

--- a/paramtools/exceptions.py
+++ b/paramtools/exceptions.py
@@ -54,6 +54,8 @@ collision_list = [
     "to_array",
     "validation_error",
     "view_state",
+    "extend",
+    "label_to_extend",
 ]
 
 

--- a/paramtools/parameters.py
+++ b/paramtools/parameters.py
@@ -43,7 +43,6 @@ class Parameters:
 
         if array_first is not None:
             self.array_first = array_first
-
         if self.label_to_extend:
             prev_array_first = self.array_first
             self.array_first = False
@@ -323,7 +322,10 @@ class Parameters:
             }
             if not defined_vals:
                 continue
-            missing_vals = sorted(set(extend_grid) - defined_vals)
+            missing_vals = sorted(
+                set(extend_grid) - defined_vals,
+                key=lambda val: extend_grid.index(val),
+            )
             if not missing_vals:
                 continue
             extended = defaultdict(list)
@@ -340,13 +342,19 @@ class Parameters:
                 )
             for val in missing_vals:
                 eg_ix = extend_grid.index(val)
-                if extend_grid[eg_ix - 1] in extended:
+                if eg_ix == 0:
+                    first_defined_value = min(
+                        defined_vals, key=lambda val: extend_grid.index(val)
+                    )
+                    value_objects = self._select(
+                        param, True, **{label_to_extend: first_defined_value}
+                    )
+                elif extend_grid[eg_ix - 1] in extended:
                     value_objects = extended.pop(extend_grid[eg_ix - 1])
                 else:
+                    prev_defined_value = extend_grid[eg_ix - 1]
                     value_objects = self._select(
-                        param,
-                        True,
-                        **{label_to_extend: extend_grid[eg_ix - 1]},
+                        param, True, **{label_to_extend: prev_defined_value}
                     )
                 for value_object in value_objects:
                     ext = dict(value_object, **{label_to_extend: val})

--- a/paramtools/parameters.py
+++ b/paramtools/parameters.py
@@ -23,6 +23,7 @@ class Parameters:
     defaults = None
     field_map = {}
     array_first = False
+    label_to_extend = None
 
     def __init__(self, initial_state=None, array_first=None):
         schemafactory = SchemaFactory(self.defaults, self.field_map)
@@ -39,9 +40,20 @@ class Parameters:
         self._validator_schema.context["spec"] = self
         self._errors = {}
         self._state = initial_state or {}
+
         if array_first is not None:
             self.array_first = array_first
-        self.set_state()
+
+        if self.label_to_extend:
+            prev_array_first = self.array_first
+            self.array_first = False
+            self.set_state()
+            self.extend()
+            if prev_array_first:
+                self.array_first = True
+                self.set_state()
+        else:
+            self.set_state()
 
     def set_state(self, **labels):
         """
@@ -291,6 +303,57 @@ class Parameters:
             value_items.append(vi)
         return value_items
 
+    def extend(self, label_to_extend=None):
+        """
+        Extend parameters along label_to_extend.
+
+        Raises:
+            InconsistentLabelsException: Value objects do not have consistent
+                labels.
+        """
+        if label_to_extend is None:
+            label_to_extend = self.label_to_extend
+        extend_grid = self.label_grid[self.label_to_extend]
+        adjustment = defaultdict(list)
+        for param, data in self.specification(meta_data=True).items():
+            defined_vals = {
+                vo[self.label_to_extend]
+                for vo in data["value"]
+                if label_to_extend in vo
+            }
+            if not defined_vals:
+                continue
+            missing_vals = sorted(set(extend_grid) - defined_vals)
+            if not missing_vals:
+                continue
+            extended = defaultdict(list)
+            cl = utils.consistent_labels(
+                [
+                    {k: v for k, v in vo.items() if k != label_to_extend}
+                    for vo in getattr(self, param)
+                ]
+            )
+            if cl is None:
+                raise InconsistentLabelsException(
+                    f"It is likely that {param} has some labels that "
+                    f"were added or omitted for some value object(s)."
+                )
+            for val in missing_vals:
+                eg_ix = extend_grid.index(val)
+                if extend_grid[eg_ix - 1] in extended:
+                    value_objects = extended.pop(extend_grid[eg_ix - 1])
+                else:
+                    value_objects = self._select(
+                        param,
+                        True,
+                        **{label_to_extend: extend_grid[eg_ix - 1]},
+                    )
+                for value_object in value_objects:
+                    ext = dict(value_object, **{label_to_extend: val})
+                    extended[val].append(ext)
+                    adjustment[param].append(ext)
+        self.adjust(adjustment)
+
     def _resolve_order(self, param):
         """
         Resolve the order of the labels and their values by
@@ -314,7 +377,8 @@ class Parameters:
         used = utils.consistent_labels(value_items)
         if used is None:
             raise InconsistentLabelsException(
-                f"Some labels in {value_items} were added or omitted for some value object(s)."
+                f"It is likely that {param} has some labels that "
+                f"were added or omitted for some value object(s)."
             )
         label_order, value_order = [], {}
         for label_name, label_values in self.label_grid.items():

--- a/paramtools/schema.py
+++ b/paramtools/schema.py
@@ -129,6 +129,9 @@ class BaseValidatorSchema(Schema):
     class.
     """
 
+    class Meta:
+        ordered = True
+
     WRAPPER_MAP = {
         "range": "_get_range_validator",
         "date_range": "_get_range_validator",

--- a/paramtools/tests/defaults.json
+++ b/paramtools/tests/defaults.json
@@ -4,7 +4,7 @@
             "label0": {
                 "type": "str",
                 "validators": {"choice": {"choices": ["zero",
-                                                        "one"]}}
+                                                      "one"]}}
             },
             "label1": {
                 "type": "int",
@@ -156,6 +156,6 @@
             {"label0": "one", "label1": 5, "label2": 2, "value": 36}
 
         ],
-        "validators": {"range": {"min": 1, "max": 9}}
+        "validators": {"range": {"min": 1, "max": 36}}
     }
 }

--- a/paramtools/tests/test_fields.py
+++ b/paramtools/tests/test_fields.py
@@ -45,3 +45,6 @@ def test_contrib_fields():
     # date will need an interval argument.
     s = fields.Date(validate=[daterange_validator])
     assert s.grid() == [datetime.date(2019, 1, i) for i in range(1, 6, 2)]
+
+    s = fields.Date()
+    assert s._deserialize(datetime.date(2015, 1, 1), None, None)

--- a/paramtools/tests/test_parameters.py
+++ b/paramtools/tests/test_parameters.py
@@ -907,3 +907,56 @@ class TestExtend:
 
         with pytest.raises(InconsistentLabelsException):
             AFParams()
+
+    def test_extend_w_array(self):
+        class ExtParams(Parameters):
+            defaults = {
+                "schema": {
+                    "labels": {
+                        "d0": {
+                            "type": "int",
+                            "validators": {"range": {"min": 0, "max": 10}},
+                        },
+                        "d1": {
+                            "type": "str",
+                            "validators": {
+                                "choice": {"choices": ["c1", "c2"]}
+                            },
+                        },
+                    }
+                },
+                "extend_param": {
+                    "title": "extend param",
+                    "description": ".",
+                    "type": "int",
+                    "value": [
+                        {"d0": 2, "d1": "c1", "value": 1},
+                        {"d0": 2, "d1": "c2", "value": 2},
+                        {"d0": 3, "d1": "c1", "value": 3},
+                        {"d0": 3, "d1": "c2", "value": 4},
+                        {"d0": 5, "d1": "c1", "value": 5},
+                        {"d0": 5, "d1": "c2", "value": 6},
+                        {"d0": 7, "d1": "c1", "value": 7},
+                        {"d0": 7, "d1": "c2", "value": 8},
+                    ],
+                },
+            }
+
+            label_to_extend = "d0"
+            array_first = True
+
+        params = ExtParams()
+
+        assert params.extend_param.tolist() == [
+            [1, 2],
+            [1, 2],
+            [1, 2],
+            [3, 4],
+            [3, 4],
+            [5, 6],
+            [5, 6],
+            [7, 8],
+            [7, 8],
+            [7, 8],
+            [7, 8],
+        ]

--- a/paramtools/tests/test_parameters.py
+++ b/paramtools/tests/test_parameters.py
@@ -4,6 +4,7 @@ import datetime
 from collections import OrderedDict
 
 import pytest
+import numpy as np
 
 from paramtools import (
     ValidationError,
@@ -760,3 +761,149 @@ class TestCollisions:
         )
 
         assert excinfo.value.args[0] == exp_msg
+
+
+class TestExtend:
+    def test_extend_num(self, array_first_defaults):
+        array_first_defaults = {
+            "schema": array_first_defaults["schema"],
+            "int_dense_array_param": array_first_defaults[
+                "int_dense_array_param"
+            ],
+        }
+        new_vos = []
+        for vo in array_first_defaults["int_dense_array_param"]["value"]:
+            if vo["label1"] not in (2, 4, 5):
+                new_vos.append(vo)
+
+        array_first_defaults["int_dense_array_param"]["value"] = new_vos
+
+        # Where label 1 is 2, 4, and 5, the value is set to the last
+        # known value, given the value object's label values.
+        exp = [
+            {"label0": "zero", "label1": 0, "label2": 0, "value": 1},
+            {"label0": "zero", "label1": 0, "label2": 1, "value": 2},
+            {"label0": "zero", "label1": 0, "label2": 2, "value": 3},
+            {"label0": "zero", "label1": 1, "label2": 0, "value": 4},
+            {"label0": "zero", "label1": 1, "label2": 1, "value": 5},
+            {"label0": "zero", "label1": 1, "label2": 2, "value": 6},
+            {"label0": "zero", "label1": 2, "label2": 0, "value": 4},
+            {"label0": "zero", "label1": 2, "label2": 1, "value": 5},
+            {"label0": "zero", "label1": 2, "label2": 2, "value": 6},
+            {"label0": "zero", "label1": 3, "label2": 0, "value": 10},
+            {"label0": "zero", "label1": 3, "label2": 1, "value": 11},
+            {"label0": "zero", "label1": 3, "label2": 2, "value": 12},
+            {"label0": "zero", "label1": 4, "label2": 0, "value": 10},
+            {"label0": "zero", "label1": 4, "label2": 1, "value": 11},
+            {"label0": "zero", "label1": 4, "label2": 2, "value": 12},
+            {"label0": "zero", "label1": 5, "label2": 0, "value": 10},
+            {"label0": "zero", "label1": 5, "label2": 1, "value": 11},
+            {"label0": "zero", "label1": 5, "label2": 2, "value": 12},
+            {"label0": "one", "label1": 0, "label2": 0, "value": 19},
+            {"label0": "one", "label1": 0, "label2": 1, "value": 20},
+            {"label0": "one", "label1": 0, "label2": 2, "value": 21},
+            {"label0": "one", "label1": 1, "label2": 0, "value": 22},
+            {"label0": "one", "label1": 1, "label2": 1, "value": 23},
+            {"label0": "one", "label1": 1, "label2": 2, "value": 24},
+            {"label0": "one", "label1": 2, "label2": 0, "value": 22},
+            {"label0": "one", "label1": 2, "label2": 1, "value": 23},
+            {"label0": "one", "label1": 2, "label2": 2, "value": 24},
+            {"label0": "one", "label1": 3, "label2": 0, "value": 28},
+            {"label0": "one", "label1": 3, "label2": 1, "value": 29},
+            {"label0": "one", "label1": 3, "label2": 2, "value": 30},
+            {"label0": "one", "label1": 4, "label2": 0, "value": 28},
+            {"label0": "one", "label1": 4, "label2": 1, "value": 29},
+            {"label0": "one", "label1": 4, "label2": 2, "value": 30},
+            {"label0": "one", "label1": 5, "label2": 0, "value": 28},
+            {"label0": "one", "label1": 5, "label2": 1, "value": 29},
+            {"label0": "one", "label1": 5, "label2": 2, "value": 30},
+        ]
+
+        class AFParams(Parameters):
+            defaults = array_first_defaults
+            label_to_extend = "label1"
+            array_first = True
+
+        params = AFParams()
+        assert isinstance(params.int_dense_array_param, np.ndarray)
+        assert params.from_array("int_dense_array_param") == exp
+
+        class AFParams(Parameters):
+            defaults = array_first_defaults
+            label_to_extend = "label1"
+            array_first = False
+
+        params = AFParams()
+        assert isinstance(params.int_dense_array_param, list)
+
+    def test_extend_categorical(self, array_first_defaults):
+        array_first_defaults = {
+            "schema": array_first_defaults["schema"],
+            "int_dense_array_param": array_first_defaults[
+                "int_dense_array_param"
+            ],
+        }
+        new_vos = []
+        for vo in array_first_defaults["int_dense_array_param"]["value"]:
+            if vo["label0"] == "one":
+                vo.update({"value": vo["value"] - 18})
+                new_vos.append(vo)
+
+        array_first_defaults["int_dense_array_param"]["value"] = new_vos
+
+        class AFParams(Parameters):
+            defaults = array_first_defaults
+            label_to_extend = "label0"
+            array_first = True
+
+        params = AFParams()
+        assert params.int_dense_array_param.tolist()
+        params.set_state(label0="one")
+        exp = [
+            {"label0": "one", "label1": 0, "label2": 0, "value": 1},
+            {"label0": "one", "label1": 0, "label2": 1, "value": 2},
+            {"label0": "one", "label1": 0, "label2": 2, "value": 3},
+            {"label0": "one", "label1": 1, "label2": 0, "value": 4},
+            {"label0": "one", "label1": 1, "label2": 1, "value": 5},
+            {"label0": "one", "label1": 1, "label2": 2, "value": 6},
+            {"label0": "one", "label1": 2, "label2": 0, "value": 7},
+            {"label0": "one", "label1": 2, "label2": 1, "value": 8},
+            {"label0": "one", "label1": 2, "label2": 2, "value": 9},
+            {"label0": "one", "label1": 3, "label2": 0, "value": 10},
+            {"label0": "one", "label1": 3, "label2": 1, "value": 11},
+            {"label0": "one", "label1": 3, "label2": 2, "value": 12},
+            {"label0": "one", "label1": 4, "label2": 0, "value": 13},
+            {"label0": "one", "label1": 4, "label2": 1, "value": 14},
+            {"label0": "one", "label1": 4, "label2": 2, "value": 15},
+            {"label0": "one", "label1": 5, "label2": 0, "value": 16},
+            {"label0": "one", "label1": 5, "label2": 1, "value": 17},
+            {"label0": "one", "label1": 5, "label2": 2, "value": 18},
+        ]
+        assert params.from_array("int_dense_array_param") == exp
+
+    def test_inconsistent_labels(self, array_first_defaults):
+        array_first_defaults = {
+            "schema": array_first_defaults["schema"],
+            "int_dense_array_param": array_first_defaults[
+                "int_dense_array_param"
+            ],
+        }
+        new_vos = []
+        for vo in array_first_defaults["int_dense_array_param"]["value"]:
+            if vo["label0"] == "one":
+                vo.update({"value": vo["value"] - 18})
+                # make labels inconsistent by removing the label2 values
+                # for some value objects.
+                if vo["label2"] == 1:
+                    vo.pop("label2")
+                new_vos.append(vo)
+
+        array_first_defaults["int_dense_array_param"]["value"] = new_vos
+
+        class AFParams(Parameters):
+            defaults = array_first_defaults
+            label_to_extend = "label0"
+            array_first = True
+
+        with pytest.raises(InconsistentLabelsException):
+            AFParams()


### PR DESCRIPTION
Partially resolves #56. Parameters can be extended along one label. This is helpful for filling out a parameter's values without having to specify redundant data in `defaults.json`. ParamTools uses label validation data to create a discrete list of values for each label. This is used to figure out which values of `label_to_extend` are missing and the direction in which the values need to be extended.

```python
import paramtools

class Parameters(paramtools.Parameters):
    defaults = "converted.json"
    # extend parameters along "year" label
    label_to_extend = "year"
    # access parameter values as arrays by default
    array_first = True


params = Parameters()
```

Parameter values will be extended along the "year" label with these values:

```python
params.label_grid["year"]

# [2013,
#  2014,
#  2015,
#  2016,
#  2017,
#  2018,
#  2019,
#  2020,
#  2021,
#  2022,
#  2023,
#  2024,
#  2025,
#  2026,
#  2027,
#  2028,
#  2029]

```

Check that EITC_c was extended:

```python
params.EITC_c

# array([[ 487., 3250., 5372., 6044.],
#        [ 496., 3305., 5460., 6143.],
#        [ 503., 3359., 5548., 6242.],
#        [ 506., 3373., 5572., 6269.],
#        [ 510., 3400., 5616., 6318.],
#        [ 519., 3461., 5716., 6431.],
#        [ 519., 3461., 5716., 6431.],
#        [ 519., 3461., 5716., 6431.],
#        [ 519., 3461., 5716., 6431.],
#        [ 519., 3461., 5716., 6431.],
#        [ 519., 3461., 5716., 6431.],
#        [ 519., 3461., 5716., 6431.],
#        [ 519., 3461., 5716., 6431.],
#        [ 519., 3461., 5716., 6431.],
#        [ 519., 3461., 5716., 6431.],
#        [ 519., 3461., 5716., 6431.],
#        [ 519., 3461., 5716., 6431.]])

```

Documentation for this feature will be added to this PR over the next couple days.

cc @jdebacker @martinholmer 