### PR TITLE
Make extend method more granular

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,4 +8,4 @@ repos:
   rev: v2.1.0
   hooks:
     - id: flake8
-      args: ["--max-line-length=100"]
+      args: ["--max-line-length=100", "--ignore=E203,W503"]

--- a/README.md
+++ b/README.md
@@ -153,25 +153,32 @@ params.adjust(adjustment)
 ```
 
 Errors on input that's out of range:
+
 ```python
-adjustment["standard_deduction"] = -1
-params.adjust(adjustment)
+adjustment["standard_deduction"] = [
+    {"marital_status": "single", "year": 2025, "value": -1}
+]
 params.adjust(adjustment)
 
+# output:
 # ---------------------------------------------------------------------------
 # ValidationError                           Traceback (most recent call last)
-# <ipython-input-8-8ea95339bb9b> in <module>
-#       1 adjustment["standard_deduction"] = -1
+# <ipython-input-14-208948dfbd1d> in <module>
+#       1 adjustment["standard_deduction"] = [{"marital_status": "single", "year": 2025, "value": -1}]
 # ----> 2 params.adjust(adjustment)
 
-# ~/Documents/ParamTools/paramtools/parameters.py in adjust(self, params_or_path, raise_errors)
-#     134
-#     135         if raise_errors and self._errors:
-# --> 136             raise self.validation_error
-#     137
-#     138         # Update attrs.
+# ~/Documents/ParamTools/paramtools/parameters.py in adjust(self, params_or_path, raise_errors, extend_adj)
+#     183
+#     184         if raise_errors and self._errors:
+# --> 185             raise self.validation_error
+#     186
+#     187         if self.label_to_extend is not None and extend_adj:
 
-# ValidationError: {'standard_deduction': ['standard_deduction -1.0 must be greater than 0.']}
+# ValidationError: {
+#     "standard_deduction": [
+#         "standard_deduction[marital_status=single, year=2025] -1.0 < min 0 "
+#     ]
+# }
 
 ```
 

--- a/docs/Extend example.ipynb
+++ b/docs/Extend example.ipynb
@@ -1,0 +1,152 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[ 6350., 12700.],\n",
+       "       [ 6350., 12700.],\n",
+       "       [ 6350., 12700.],\n",
+       "       [ 6350., 12700.],\n",
+       "       [ 6350., 12700.],\n",
+       "       [12000., 24000.],\n",
+       "       [12000., 24000.],\n",
+       "       [12000., 24000.],\n",
+       "       [12000., 24000.],\n",
+       "       [12000., 24000.],\n",
+       "       [12000., 24000.],\n",
+       "       [12000., 24000.],\n",
+       "       [12000., 24000.],\n",
+       "       [ 7685., 15369.],\n",
+       "       [ 7685., 15369.]])"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import paramtools\n",
+    "\n",
+    "\n",
+    "class TaxParams(paramtools.Parameters):\n",
+    "    defaults = {\n",
+    "        \"schema\": {\n",
+    "            \"labels\": {\n",
+    "                \"year\": {\n",
+    "                    \"type\": \"int\",\n",
+    "                    \"validators\": {\"range\": {\"min\": 2013, \"max\": 2027}}\n",
+    "                },\n",
+    "                \"marital_status\": {\n",
+    "                    \"type\": \"str\",\n",
+    "                    \"validators\": {\"choice\": {\"choices\": [\"single\", \"joint\"]}}\n",
+    "                },\n",
+    "            }\n",
+    "        },\n",
+    "        \"standard_deduction\": {\n",
+    "            \"title\": \"Standard deduction amount\",\n",
+    "            \"description\": \"Amount filing unit can use as a standard deduction.\",\n",
+    "            \"type\": \"float\",\n",
+    "            \"value\": [\n",
+    "                {\"year\": 2017, \"marital_status\": \"single\", \"value\": 6350},\n",
+    "                {\"year\": 2017, \"marital_status\": \"joint\", \"value\": 12700},\n",
+    "                {\"year\": 2018, \"marital_status\": \"single\", \"value\": 12000},\n",
+    "                {\"year\": 2018, \"marital_status\": \"joint\", \"value\": 24000},\n",
+    "                {\"year\": 2026, \"marital_status\": \"single\", \"value\": 7685},\n",
+    "                {\"year\": 2026, \"marital_status\": \"joint\", \"value\": 15369}],\n",
+    "            \"validators\": {\n",
+    "                \"range\": {\n",
+    "                    \"min\": 0,\n",
+    "                    \"max\": 9e+99\n",
+    "                }\n",
+    "            }\n",
+    "        },\n",
+    "    }\n",
+    "\n",
+    "    label_to_extend = \"year\"\n",
+    "    array_first = True\n",
+    "\n",
+    "params = TaxParams()\n",
+    "\n",
+    "params.standard_deduction"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[ 6350., 12700.],\n",
+       "       [ 6350., 12700.],\n",
+       "       [ 6350., 12700.],\n",
+       "       [ 6350., 12700.],\n",
+       "       [10000., 10000.],\n",
+       "       [10000., 10000.],\n",
+       "       [10000., 10000.],\n",
+       "       [15000., 10000.],\n",
+       "       [15000., 20000.],\n",
+       "       [15000., 20000.],\n",
+       "       [15000., 20000.],\n",
+       "       [15000., 20000.],\n",
+       "       [15000., 20000.],\n",
+       "       [15000., 20000.],\n",
+       "       [15000., 20000.]])"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "params.adjust(\n",
+    "    {\n",
+    "        \"standard_deduction\": [\n",
+    "            {\"year\": 2017, \"value\": 10000},\n",
+    "            {\"year\": 2020, \"marital_status\": \"single\", \"value\": 15000},\n",
+    "            {\"year\": 2021, \"marital_status\": \"joint\", \"value\": 20000}\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "params.standard_deduction"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/docs/README Example.ipynb
+++ b/docs/README Example.ipynb
@@ -124,17 +124,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "OrderedDict([('standard_deduction',\n",
-       "              [{'value': 0.0, 'year': 2026, 'marital_status': 'single'}])])"
+       "              [OrderedDict([('marital_status', 'single'),\n",
+       "                            ('year', 2026),\n",
+       "                            ('value', 7690.0)])])])"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -146,7 +148,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -157,7 +159,7 @@
        "       [10000.  , 15380.  ]])"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -174,7 +176,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -185,7 +187,7 @@
        "       [0., 0.]])"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -200,19 +202,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "ename": "ValidationError",
-     "evalue": "{'standard_deduction': ['Not a valid number: higher.']}",
+     "evalue": "{\n    \"standard_deduction\": [\n        \"Not a valid number: higher.\"\n    ]\n}",
      "output_type": "error",
      "traceback": [
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
       "\u001b[0;31mValidationError\u001b[0m                           Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-7-d9ad03cf54d8>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0madjustment\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m\"standard_deduction\"\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m\"higher\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mparams\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0madjust\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0madjustment\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;32m~/Documents/ParamTools/paramtools/parameters.py\u001b[0m in \u001b[0;36madjust\u001b[0;34m(self, params_or_path, raise_errors)\u001b[0m\n\u001b[1;32m    134\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    135\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mraise_errors\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_errors\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 136\u001b[0;31m             \u001b[0;32mraise\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mvalidation_error\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    137\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    138\u001b[0m         \u001b[0;31m# Update attrs.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mValidationError\u001b[0m: {'standard_deduction': ['Not a valid number: higher.']}"
+      "\u001b[0;32m<ipython-input-8-d9ad03cf54d8>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0madjustment\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m\"standard_deduction\"\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m\"higher\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mparams\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0madjust\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0madjustment\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m~/Documents/ParamTools/paramtools/parameters.py\u001b[0m in \u001b[0;36madjust\u001b[0;34m(self, params_or_path, raise_errors, extend_adj)\u001b[0m\n\u001b[1;32m    183\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    184\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mraise_errors\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_errors\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 185\u001b[0;31m             \u001b[0;32mraise\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mvalidation_error\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    186\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    187\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mlabel_to_extend\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0;32mNone\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mextend_adj\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mValidationError\u001b[0m: {\n    \"standard_deduction\": [\n        \"Not a valid number: higher.\"\n    ]\n}"
      ]
     }
    ],
@@ -223,30 +225,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
      "ename": "ValidationError",
-     "evalue": "{'standard_deduction': ['standard_deduction -1.0 must be greater than 0.']}",
+     "evalue": "{\n    \"standard_deduction\": [\n        \"standard_deduction[marital_status=single, year=2025] -1.0 < min 0 \"\n    ]\n}",
      "output_type": "error",
      "traceback": [
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
       "\u001b[0;31mValidationError\u001b[0m                           Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-8-8ea95339bb9b>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0madjustment\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m\"standard_deduction\"\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m-\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mparams\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0madjust\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0madjustment\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;32m~/Documents/ParamTools/paramtools/parameters.py\u001b[0m in \u001b[0;36madjust\u001b[0;34m(self, params_or_path, raise_errors)\u001b[0m\n\u001b[1;32m    134\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    135\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mraise_errors\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_errors\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 136\u001b[0;31m             \u001b[0;32mraise\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mvalidation_error\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    137\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    138\u001b[0m         \u001b[0;31m# Update attrs.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mValidationError\u001b[0m: {'standard_deduction': ['standard_deduction -1.0 must be greater than 0.']}"
+      "\u001b[0;32m<ipython-input-14-208948dfbd1d>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0madjustment\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m\"standard_deduction\"\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0;34m{\u001b[0m\u001b[0;34m\"marital_status\"\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0;34m\"single\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m\"year\"\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0;36m2025\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m\"value\"\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0;34m-\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m}\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mparams\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0madjust\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0madjustment\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m~/Documents/ParamTools/paramtools/parameters.py\u001b[0m in \u001b[0;36madjust\u001b[0;34m(self, params_or_path, raise_errors, extend_adj)\u001b[0m\n\u001b[1;32m    183\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    184\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mraise_errors\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_errors\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 185\u001b[0;31m             \u001b[0;32mraise\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mvalidation_error\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    186\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    187\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mlabel_to_extend\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0;32mNone\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mextend_adj\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mValidationError\u001b[0m: {\n    \"standard_deduction\": [\n        \"standard_deduction[marital_status=single, year=2025] -1.0 < min 0 \"\n    ]\n}"
      ]
     }
    ],
    "source": [
-    "adjustment[\"standard_deduction\"] = -1\n",
+    "adjustment[\"standard_deduction\"] = [{\"marital_status\": \"single\", \"year\": 2025, \"value\": -1}]\n",
     "params.adjust(adjustment)\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -314,7 +316,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -324,16 +326,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[{'value': 0.0}]"
+       "[OrderedDict([('value', 0.0)])]"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -352,9 +354,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python (paramtools-dev)",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "paramtools-dev"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -366,7 +368,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/docs/docs/api/extend.md
+++ b/docs/docs/api/extend.md
@@ -70,6 +70,40 @@ params.standard_deduction
 #        [ 7685., 15369.]])
 ```
 
+Adjustments are also extended along `label_to_extend`. In the example below, `standard_deduction` is set to 10,000 in 2017, increased to 15,000 for single tax units in 2020, and increased to 20,000 for joint tax units in 2021:
+
+```python
+params.adjust(
+    {
+        "standard_deduction": [
+            {"year": 2017, "value": 10000},
+            {"year": 2020, "marital_status": "single", "value": 15000},
+            {"year": 2021, "marital_status": "joint", "value": 20000}
+        ]
+    }
+)
+
+params.standard_deduction
+
+# output
+# array([[ 6350., 12700.],
+#        [ 6350., 12700.],
+#        [ 6350., 12700.],
+#        [ 6350., 12700.],
+#        [10000., 10000.],
+#        [10000., 10000.],
+#        [10000., 10000.],
+#        [15000., 10000.],
+#        [15000., 20000.],
+#        [15000., 20000.],
+#        [15000., 20000.],
+#        [15000., 20000.],
+#        [15000., 20000.],
+#        [15000., 20000.],
+#        [15000., 20000.]])
+
+```
+
 
 ## Extend behavior by validator
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -153,25 +153,32 @@ params.adjust(adjustment)
 ```
 
 Errors on input that's out of range:
+
 ```python
-adjustment["standard_deduction"] = -1
-params.adjust(adjustment)
+adjustment["standard_deduction"] = [
+    {"marital_status": "single", "year": 2025, "value": -1}
+]
 params.adjust(adjustment)
 
+# output:
 # ---------------------------------------------------------------------------
 # ValidationError                           Traceback (most recent call last)
-# <ipython-input-8-8ea95339bb9b> in <module>
-#       1 adjustment["standard_deduction"] = -1
+# <ipython-input-14-208948dfbd1d> in <module>
+#       1 adjustment["standard_deduction"] = [{"marital_status": "single", "year": 2025, "value": -1}]
 # ----> 2 params.adjust(adjustment)
 
-# ~/Documents/ParamTools/paramtools/parameters.py in adjust(self, params_or_path, raise_errors)
-#     134
-#     135         if raise_errors and self._errors:
-# --> 136             raise self.validation_error
-#     137
-#     138         # Update attrs.
+# ~/Documents/ParamTools/paramtools/parameters.py in adjust(self, params_or_path, raise_errors, extend_adj)
+#     183
+#     184         if raise_errors and self._errors:
+# --> 185             raise self.validation_error
+#     186
+#     187         if self.label_to_extend is not None and extend_adj:
 
-# ValidationError: {'standard_deduction': ['standard_deduction -1.0 must be greater than 0.']}
+# ValidationError: {
+#     "standard_deduction": [
+#         "standard_deduction[marital_status=single, year=2025] -1.0 < min 0 "
+#     ]
+# }
 
 ```
 

--- a/paramtools/__init__.py
+++ b/paramtools/__init__.py
@@ -22,6 +22,13 @@ from paramtools.schema import (
     get_type,
     get_param_schema,
 )
+from paramtools.select import (
+    select,
+    select_eq,
+    select_gt,
+    select_gt_ix,
+    select_ne,
+)
 from paramtools.typing import ValueObject
 from paramtools.utils import (
     read_json,
@@ -61,6 +68,11 @@ __all__ = [
     "VALIDATOR_MAP",
     "get_type",
     "get_param_schema",
+    "select",
+    "select_eq",
+    "select_gt",
+    "select_gt_ix",
+    "select_ne",
     "read_json",
     "get_example_paths",
     "LeafGetter",

--- a/paramtools/__init__.py
+++ b/paramtools/__init__.py
@@ -22,6 +22,7 @@ from paramtools.schema import (
     get_type,
     get_param_schema,
 )
+from paramtools.typing import ValueObject
 from paramtools.utils import (
     read_json,
     get_example_paths,
@@ -30,6 +31,9 @@ from paramtools.utils import (
     ravel,
     consistent_labels,
     ensure_value_object,
+    hashable_value_object,
+    filter_labels,
+    make_label_str,
 )
 
 
@@ -64,4 +68,8 @@ __all__ = [
     "ravel",
     "consistent_labels",
     "ensure_value_object",
+    "hashable_value_object",
+    "filter_labels",
+    "make_label_str",
+    "ValueObject",
 ]

--- a/paramtools/contrib/fields.py
+++ b/paramtools/contrib/fields.py
@@ -94,6 +94,10 @@ class Date(MeshFieldMixin, marshmallow_fields.Date):
     """
 
     np_type = datetime.date
+    default_error_messages = {
+        "invalid": "Not a valid {obj_type}: {input}",
+        "format": '"{input}" cannot be formatted as a {obj_type}.',
+    }
 
     def _deserialize(self, value, attr, data):
         if isinstance(value, (datetime.datetime, datetime.date)):

--- a/paramtools/contrib/validate.py
+++ b/paramtools/contrib/validate.py
@@ -40,14 +40,14 @@ class Range(marshmallow_validate.Range):
         self.error_max = error_max
         self.step = step or 1  # default to 1
 
-    def __call__(self, value, custom=False):
+    def __call__(self, value, is_value_object=False):
         """
-        This is the method that marshmallow calls by default. Custom
+        This is the method that marshmallow calls by default. is_value_object
         validation goes straight to validate_value_objects.
         """
         if value is None:
             return value
-        if not custom:
+        if not is_value_object:
             value = {"value": value}
         return self.validate_value_objects(value)
 
@@ -167,10 +167,10 @@ class OneOf(marshmallow_validate.OneOf):
 
     default_message = "Input {input} must be one of {choices}"
 
-    def __call__(self, value, custom=False):
+    def __call__(self, value, is_value_object=False):
         if value is None:
             return value
-        if not custom:
+        if not is_value_object:
             vo = {"value": value}
         else:
             vo = value

--- a/paramtools/exceptions.py
+++ b/paramtools/exceptions.py
@@ -30,7 +30,8 @@ class InconsistentLabelsException(ParamToolsError):
 collision_list = [
     "_data",
     "_errors",
-    "_select",
+    "select_eq",
+    "select_ne",
     "_numpy_type",
     "_parse_errors",
     "_resolve_order",

--- a/paramtools/exceptions.py
+++ b/paramtools/exceptions.py
@@ -1,3 +1,5 @@
+import json
+
 from paramtools import utils
 
 
@@ -20,7 +22,7 @@ class ValidationError(ParamToolsError):
         raveled_messages = {
             param: utils.ravel(msgs) for param, msgs in self.messages.items()
         }
-        super().__init__(raveled_messages)
+        super().__init__(json.dumps(raveled_messages, indent=4))
 
 
 class InconsistentLabelsException(ParamToolsError):

--- a/paramtools/exceptions.py
+++ b/paramtools/exceptions.py
@@ -32,6 +32,7 @@ collision_list = [
     "_errors",
     "select_eq",
     "select_ne",
+    "select_gt",
     "_numpy_type",
     "_parse_errors",
     "_resolve_order",

--- a/paramtools/parameters.py
+++ b/paramtools/parameters.py
@@ -164,8 +164,8 @@ class Parameters:
                         eq = select.select_eq(
                             gt,
                             True,
-                            utils.filter_out_labels(
-                                vo, labels=[self.label_to_extend, "value"]
+                            utils.filter_labels(
+                                vo, drop=[self.label_to_extend, "value"]
                             ),
                         )
                         to_delete += eq
@@ -384,9 +384,7 @@ class Parameters:
                 eq = select.select_eq(
                     gt,
                     True,
-                    utils.filter_out_labels(
-                        vo, labels=["value", label_to_extend]
-                    ),
+                    utils.filter_labels(vo, drop=["value", label_to_extend]),
                 )
                 extended_vos.update(map(utils.hashable_value_object, eq))
                 eq += [vo]
@@ -605,7 +603,7 @@ class Parameters:
             formatted_errors = []
             for ix, marshmessages in data.items():
                 error_labels.append(
-                    {k: v for k, v in param_data[ix].items() if k != "value"}
+                    utils.filter_labels(param_data[ix], drop=["value"])
                 )
                 formatted_errors_ix = []
                 for _, messages in marshmessages.items():

--- a/paramtools/parameters.py
+++ b/paramtools/parameters.py
@@ -592,6 +592,14 @@ class Parameters:
         }
 
         for pname, data in ve.messages.items():
+            if pname == "_schema":
+                error_info["messages"]["schema"] = [
+                    f"Data format error: {data}"
+                ]
+                continue
+            if data == ["Unknown field."]:
+                error_info["messages"]["schema"] = [f"Unknown field: {pname}"]
+                continue
             param_data = utils.ensure_value_object(params[pname])
             error_labels = []
             formatted_errors = []

--- a/paramtools/schema.py
+++ b/paramtools/schema.py
@@ -102,7 +102,9 @@ class ValueObject(fields.Nested):
 
     def _deserialize(self, value, attr, data, partial=None, **kwargs):
         if not isinstance(value, list) or (
-            isinstance(value, list) and not isinstance(value[0], dict)
+            isinstance(value, list)
+            and value
+            and not isinstance(value[0], dict)
         ):
             value = [{"value": value}]
         return super()._deserialize(

--- a/paramtools/schema.py
+++ b/paramtools/schema.py
@@ -181,7 +181,7 @@ class BaseValidatorSchema(Schema):
         errors = []
         for validator in validators:
             try:
-                validator(param_spec, custom=True)
+                validator(param_spec, is_value_object=True)
             except MarshmallowValidationError as ve:
                 errors += ve.messages
 

--- a/paramtools/select.py
+++ b/paramtools/select.py
@@ -31,9 +31,17 @@ def ne_func(x, y):
     return x not in y
 
 
+def gt_func(x, y):
+    return all(x > item for item in y)
+
+
 def select_eq(value_objects, exact_match, labels):
     return select(value_objects, exact_match, eq_func, all, labels)
 
 
 def select_ne(value_objects, exact_match, labels):
     return select(value_objects, exact_match, ne_func, any, labels)
+
+
+def select_gt(value_objects, exact_match, labels):
+    return select(value_objects, exact_match, gt_func, all, labels)

--- a/paramtools/select.py
+++ b/paramtools/select.py
@@ -1,0 +1,39 @@
+def select(value_objects, exact_match, cmp_func, agg_cmp_func, labels):
+    """
+    Query a parameter along some labels. If exact_match is True,
+    all values in `labels` must be equal to the corresponding label
+    in the parameter's "value" dictionary.
+
+    Ignores state.
+
+    Returns: [{"value": val, "label0": ..., }]
+    """
+    ret = []
+    for value_object in value_objects:
+        matches = []
+        for label_name, label_value in labels.items():
+            if label_name in value_object or exact_match:
+                if isinstance(label_value, list):
+                    match = cmp_func(value_object[label_name], label_value)
+                else:
+                    match = cmp_func(value_object[label_name], (label_value,))
+                matches.append(match)
+        if agg_cmp_func(matches):
+            ret.append(value_object)
+    return ret
+
+
+def eq_func(x, y):
+    return x in y
+
+
+def ne_func(x, y):
+    return x not in y
+
+
+def select_eq(value_objects, exact_match, labels):
+    return select(value_objects, exact_match, eq_func, all, labels)
+
+
+def select_ne(value_objects, exact_match, labels):
+    return select(value_objects, exact_match, ne_func, any, labels)

--- a/paramtools/select.py
+++ b/paramtools/select.py
@@ -35,6 +35,11 @@ def gt_func(x, y):
     return all(x > item for item in y)
 
 
+def gt_ix_func(cmp_list, x, y):
+    x_val = cmp_list.index(x)
+    return all(x_val > cmp_list.index(item) for item in y)
+
+
 def select_eq(value_objects, exact_match, labels):
     return select(value_objects, exact_match, eq_func, all, labels)
 
@@ -45,3 +50,13 @@ def select_ne(value_objects, exact_match, labels):
 
 def select_gt(value_objects, exact_match, labels):
     return select(value_objects, exact_match, gt_func, all, labels)
+
+
+def select_gt_ix(value_objects, exact_match, labels, cmp_list):
+    return select(
+        value_objects,
+        exact_match,
+        lambda x, y: gt_ix_func(cmp_list, x, y),
+        all,
+        labels,
+    )

--- a/paramtools/tests/extend_ex.json
+++ b/paramtools/tests/extend_ex.json
@@ -26,6 +26,22 @@
             {"d0": 5, "d1": "c2", "value": 6},
             {"d0": 7, "d1": "c1", "value": 7},
             {"d0": 7, "d1": "c2", "value": 8}
+        ],
+        "validators": {
+            "range": {
+                "min": -100, "max": "related_param"
+            }
+        }
+    },
+    "related_param": {
+        "title": "extend param",
+        "description": "Test error on adjustment extension.",
+        "type": "int",
+        "value": [
+            {"d0": 0, "d1": "c1", "value": 100},
+            {"d0": 0, "d1": "c2", "value": 101},
+            {"d0": 7, "d1": "c1", "value": 50},
+            {"d0": 7, "d1": "c2", "value": 51}
         ]
     }
 }

--- a/paramtools/tests/extend_ex.json
+++ b/paramtools/tests/extend_ex.json
@@ -1,0 +1,31 @@
+{
+    "schema": {
+        "labels": {
+            "d0": {
+                "type": "int",
+                "validators": {"range": {"min": 0, "max": 10}}
+            },
+            "d1": {
+                "type": "str",
+                "validators": {
+                    "choice": {"choices": ["c1", "c2"]}
+                }
+            }
+        }
+    },
+    "extend_param": {
+        "title": "extend param",
+        "description": ".",
+        "type": "int",
+        "value": [
+            {"d0": 2, "d1": "c1", "value": 1},
+            {"d0": 2, "d1": "c2", "value": 2},
+            {"d0": 3, "d1": "c1", "value": 3},
+            {"d0": 3, "d1": "c2", "value": 4},
+            {"d0": 5, "d1": "c1", "value": 5},
+            {"d0": 5, "d1": "c2", "value": 6},
+            {"d0": 7, "d1": "c1", "value": 7},
+            {"d0": 7, "d1": "c2", "value": 8}
+        ]
+    }
+}

--- a/paramtools/tests/test_parameters.py
+++ b/paramtools/tests/test_parameters.py
@@ -1006,26 +1006,53 @@ class TestExtend:
             [-1, 1],
         ]
 
-        # params = ExtParams()
-        # params.adjust(
-        #     {
-        #         "extend_param": [
-        #             {"d0": 3, "value": -1},
-        #             {"d0": 5, "d1": "c1", "value": 0},
-        #             {"d0": 6, "d1": "c2", "value": 1},
-        #         ]
-        #     }
-        # )
-        # assert params.extend_param.tolist() == [
-        #     [1, 2],
-        #     [1, 2],
-        #     [1, 2],
-        #     [-1, -1],
-        #     [-1, -1],
-        #     [-1, -1],
-        #     [-1,-1],
-        #     [0, -1],
-        #     [0, 1],
-        #     [0, 1],
-        #     [0, 1],
-        # ]
+        params = ExtParams()
+        params.adjust(
+            {
+                "extend_param": [
+                    {"d0": 3, "value": -1},
+                    {"d0": 5, "d1": "c1", "value": 0},
+                    {"d0": 6, "d1": "c2", "value": 1},
+                ]
+            }
+        )
+        assert params.extend_param.tolist() == [
+            [1, 2],
+            [1, 2],
+            [1, 2],
+            [-1, -1],
+            [-1, -1],
+            [-1, -1],
+            [-1, -1],
+            [0, -1],
+            [0, 1],
+            [0, 1],
+            [0, 1],
+        ]
+
+        params = ExtParams()
+        params.adjust(
+            {
+                "extend_param": [
+                    {"d0": 3, "value": -1},
+                    {"d0": 5, "d1": "c1", "value": 0},
+                    {"d0": 5, "d1": "c2", "value": 1},
+                    {"d0": 8, "d1": "c1", "value": 22},
+                    {"d0": 8, "d1": "c2", "value": 23},
+                ]
+            }
+        )
+
+        assert params.extend_param.tolist() == [
+            [1, 2],
+            [1, 2],
+            [1, 2],
+            [-1, -1],
+            [-1, -1],
+            [0, 1],
+            [0, 1],
+            [0, 1],
+            [22, 23],
+            [22, 23],
+            [22, 23],
+        ]

--- a/paramtools/tests/test_parameters.py
+++ b/paramtools/tests/test_parameters.py
@@ -886,33 +886,6 @@ class TestExtend:
         ]
         assert params.from_array("int_dense_array_param") == exp
 
-    def test_inconsistent_labels(self, array_first_defaults):
-        array_first_defaults = {
-            "schema": array_first_defaults["schema"],
-            "int_dense_array_param": array_first_defaults[
-                "int_dense_array_param"
-            ],
-        }
-        new_vos = []
-        for vo in array_first_defaults["int_dense_array_param"]["value"]:
-            if vo["label0"] == "one":
-                vo.update({"value": vo["value"] - 18})
-                # make labels inconsistent by removing the label2 values
-                # for some value objects.
-                if vo["label2"] == 1:
-                    vo.pop("label2")
-                new_vos.append(vo)
-
-        array_first_defaults["int_dense_array_param"]["value"] = new_vos
-
-        class AFParams(Parameters):
-            defaults = array_first_defaults
-            label_to_extend = "label0"
-            array_first = True
-
-        with pytest.raises(InconsistentLabelsException):
-            AFParams()
-
     def test_extend_w_array(self, extend_ex_path):
         class ExtParams(Parameters):
             defaults = extend_ex_path
@@ -1012,30 +985,6 @@ class TestExtend:
                 "extend_param": [
                     {"d0": 3, "value": -1},
                     {"d0": 5, "d1": "c1", "value": 0},
-                    {"d0": 6, "d1": "c2", "value": 1},
-                ]
-            }
-        )
-        assert params.extend_param.tolist() == [
-            [1, 2],
-            [1, 2],
-            [1, 2],
-            [-1, -1],
-            [-1, -1],
-            [-1, -1],
-            [-1, -1],
-            [0, -1],
-            [0, 1],
-            [0, 1],
-            [0, 1],
-        ]
-
-        params = ExtParams()
-        params.adjust(
-            {
-                "extend_param": [
-                    {"d0": 3, "value": -1},
-                    {"d0": 5, "d1": "c1", "value": 0},
                     {"d0": 5, "d1": "c2", "value": 1},
                     {"d0": 8, "d1": "c1", "value": 22},
                     {"d0": 8, "d1": "c2", "value": 23},
@@ -1056,3 +1005,32 @@ class TestExtend:
             [22, 23],
             [22, 23],
         ]
+
+        params = ExtParams()
+        params.adjust(
+            {
+                "extend_param": [
+                    {"d0": 3, "value": -1},
+                    {"d0": 5, "d1": "c1", "value": 0},
+                    {"d0": 6, "d1": "c2", "value": 1},
+                ]
+            }
+        )
+        assert params.extend_param.tolist() == [
+            [1, 2],
+            [1, 2],
+            [1, 2],
+            [-1, -1],
+            [-1, -1],
+            [0, -1],
+            [0, 1],
+            [0, 1],
+            [0, 1],
+            [0, 1],
+            [0, 1],
+        ]
+
+        params = ExtParams()
+        params.adjust({"extend_param": [{"d0": 0, "value": 1}]})
+
+        assert params.extend_param.tolist() == [[1, 1]] * 11

--- a/paramtools/tests/test_parameters.py
+++ b/paramtools/tests/test_parameters.py
@@ -1044,5 +1044,10 @@ class TestExtend:
             params.adjust({"extend_param": 102})
 
         params = ExtParams()
-        with pytest.raises(ValidationError):
+        with pytest.raises(ValidationError) as excinfo:
             params.adjust({"extend_param": [{"value": 70, "d0": 5}]})
+
+        emsg = json.loads(excinfo.value.args[0])
+        # do=7 is when the 'releated_value' is set to 50, which is
+        # less than 70 ==> causes range error
+        assert "d0=7" in emsg["extend_param"][0]

--- a/paramtools/tests/test_parameters.py
+++ b/paramtools/tests/test_parameters.py
@@ -1034,3 +1034,13 @@ class TestExtend:
         params.adjust({"extend_param": [{"d0": 0, "value": 1}]})
 
         assert params.extend_param.tolist() == [[1, 1]] * 11
+
+    def test_extend_adj_w_errors(self, extend_ex_path):
+        class ExtParams(Parameters):
+            defaults = extend_ex_path
+            label_to_extend = "d0"
+            array_first = True
+
+        params = ExtParams()
+        with pytest.raises(ValidationError):
+            params.adjust({"extend_param": 102})

--- a/paramtools/tests/test_parameters.py
+++ b/paramtools/tests/test_parameters.py
@@ -464,7 +464,7 @@ class TestErrors:
             ]
         }
         params.adjust(adj, raise_errors=False)
-        exp = ["float_list_param[label1=1, label0=zero] [-1.0, 1.0] < min 0 "]
+        exp = ["float_list_param[label0=zero, label1=1] [-1.0, 1.0] < min 0 "]
 
         assert params.errors["float_list_param"] == exp
 

--- a/paramtools/tests/test_select.py
+++ b/paramtools/tests/test_select.py
@@ -1,0 +1,37 @@
+import pytest
+
+from paramtools.select import select_eq, select_ne
+
+
+@pytest.fixture
+def vos():
+    return [
+        {"d0": 1, "d1": "hello", "value": 1},
+        {"d0": 1, "d1": "world", "value": 1},
+        {"d0": 2, "d1": "hello", "value": 1},
+        {"d0": 3, "d1": "world", "value": 1},
+    ]
+
+
+def test_select_eq(vos):
+    assert select_eq(vos, True, labels={"d0": 1, "d1": "hello"}) == [
+        {"d0": 1, "d1": "hello", "value": 1}
+    ]
+
+    assert select_eq(vos, True, labels={"d0": [1, 2], "d1": "hello"}) == [
+        {"d0": 1, "d1": "hello", "value": 1},
+        {"d0": 2, "d1": "hello", "value": 1},
+    ]
+
+
+def test_select_ne(vos):
+    assert select_ne(vos, True, labels={"d0": 1, "d1": "hello"}) == [
+        {"d0": 1, "d1": "world", "value": 1},
+        {"d0": 2, "d1": "hello", "value": 1},
+        {"d0": 3, "d1": "world", "value": 1},
+    ]
+
+    assert select_ne(vos, True, labels={"d0": [1, 2], "d1": "hello"}) == [
+        {"d0": 1, "d1": "world", "value": 1},
+        {"d0": 3, "d1": "world", "value": 1},
+    ]

--- a/paramtools/tests/test_utils.py
+++ b/paramtools/tests/test_utils.py
@@ -3,6 +3,9 @@ from paramtools import (
     ravel,
     consistent_labels,
     ensure_value_object,
+    hashable_value_object,
+    filter_labels,
+    make_label_str,
 )
 
 
@@ -70,3 +73,25 @@ def test_ensure_value_object():
     assert ensure_value_object({"hello": "world"}) == [
         {"value": {"hello": "world"}}
     ]
+
+
+def test_hashable_value_object():
+    assert hash(hashable_value_object({"value": "hello", "world": "!"}))
+
+
+def test_filter_labels():
+    assert filter_labels({"hello": "world"}, drop=["hello"]) == {}
+    assert filter_labels({"hello": "world"}, keep=["hello"]) == {
+        "hello": "world"
+    }
+    assert filter_labels({"hello": "world"}) == {"hello": "world"}
+    assert filter_labels(
+        {"hello": "world", "world": "hello"}, drop=["world"]
+    ) == {"hello": "world"}
+
+
+def test_make_label_str():
+    assert make_label_str({"hello": "world", "value": 0}) == "[hello=world]"
+    assert make_label_str({"value": 0}) == ""
+    assert make_label_str({}) == ""
+    assert make_label_str({"b": 0, "c": 1, "a": 2}) == "[a=2, b=0, c=1]"

--- a/paramtools/tests/test_validate.py
+++ b/paramtools/tests/test_validate.py
@@ -24,8 +24,53 @@ def test_OneOf():
     with pytest.raises(ValidationError):
         oneof([[choices]])
 
+    assert oneof("allowed1")
+    assert oneof({"value": "allowed1"}, is_value_object=True)
 
-def test_Range():
+    with pytest.raises(ValidationError):
+        oneof("notallowed")
+
+    with pytest.raises(ValidationError):
+        oneof({"value": "notallowed"}, is_value_object=True)
+
+
+def test_Range_errors():
+    range_ = Range(0, 10)
+    with pytest.raises(ValidationError):
+        range_(11)
+
+    with pytest.raises(ValidationError):
+        range_({"value": 11}, is_value_object=True)
+
+    range_ = Range(min_vo=[{"value": 0}], max_vo=[{"value": 10}])
+    with pytest.raises(ValidationError):
+        range_(11)
+
+    with pytest.raises(ValidationError):
+        range_({"value": 11}, is_value_object=True)
+
+    range_ = Range(
+        min_vo=[{"lab0": 1, "value": 0}, {"lab0": 2, "value": 2}],
+        max_vo=[{"lab0": 1, "value": 10}, {"lab0": 2, "value": 9}],
+        error_min="param{labels} {input} < min {min} oth_param{oth_labels}",
+        error_max="param{labels} {input} > max {max} max_oth_param{oth_labels}",
+    )
+    with pytest.raises(ValidationError) as excinfo:
+        range_({"lab0": 1, "value": 11}, is_value_object=True)
+    assert (
+        excinfo.value.args[0][0]
+        == "param[lab0=1] 11 > max 10 max_oth_param[lab0=1]"
+    )
+
+    with pytest.raises(ValidationError) as excinfo:
+        range_({"value": 11}, is_value_object=True)
+    assert excinfo.value.args[0] == [
+        "param 11 > max 10 max_oth_param[lab0=1]",
+        "param 11 > max 9 max_oth_param[lab0=2]",
+    ]
+
+
+def test_Range_grid():
     range_ = Range(0, 10)
     assert range_.grid() == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 
@@ -45,3 +90,23 @@ def test_DateRange():
     drange = DateRange("2019-01-01", "2019-01-10", step={"days": 3})
     exp = [datetime.date(2019, 1, i) for i in range(1, 10 + 1, 3)]
     assert drange.grid() == exp
+
+    dranges = [
+        DateRange("2019-01-01", "2019-01-10", step={"days": 1}),
+        DateRange(
+            min_vo=[{"value": "2019-01-01"}],
+            max_vo=[{"value": "2019-01-10"}],
+            step={"days": 1},
+        ),
+    ]
+    for drange in dranges:
+        assert drange(datetime.date(2019, 1, 2))
+        assert drange(
+            {"value": datetime.date(2019, 1, 2)}, is_value_object=True
+        )
+
+        with pytest.raises(ValidationError):
+            drange(datetime.date(2020, 1, 2))
+
+        with pytest.raises(ValidationError):
+            drange({"value": datetime.date(2020, 1, 2)}, is_value_object=True)

--- a/paramtools/typing.py
+++ b/paramtools/typing.py
@@ -1,0 +1,3 @@
+from typing import NewType, Dict, Any
+
+ValueObject = NewType("ValueObject", Dict[str, Any])

--- a/paramtools/utils.py
+++ b/paramtools/utils.py
@@ -1,6 +1,9 @@
 import json
 import os
 from collections import OrderedDict
+from typing import List
+
+from paramtools.typing import ValueObject
 
 
 def read_json(path):
@@ -71,7 +74,7 @@ def ravel(nlabel_list):
     return raveled
 
 
-def consistent_labels(value_items):
+def consistent_labels(value_items: List[ValueObject]):
     """
     Get labels used consistently across all value objects.
     Returns None if labels are omitted or added for
@@ -84,7 +87,7 @@ def consistent_labels(value_items):
     return used
 
 
-def ensure_value_object(vo):
+def ensure_value_object(vo) -> ValueObject:
     if not isinstance(vo, list) or (
         isinstance(vo, list) and not isinstance(vo[0], dict)
     ):
@@ -92,15 +95,32 @@ def ensure_value_object(vo):
     return vo
 
 
-def hashable_value_object(vo):
+def hashable_value_object(vo: ValueObject) -> tuple:
+    """
+    Helper function convertinga value object into a format
+    that can be stored in a set.
+    """
     return tuple(sorted(vo.items()))
 
 
-def filter_out_labels(vo, labels):
-    return {l: lv for l, lv in vo.items() if l not in labels}
+def filter_labels(vo: ValueObject, drop=None, keep=None) -> ValueObject:
+    """
+    Filter a value objects labels by keeping labels
+    in keep if specified and dropping labels that are in drop.
+    """
+    drop = drop or ()
+    keep = keep or ()
+    return {
+        l: lv
+        for l, lv in vo.items()
+        if (l not in drop) and (not keep or l in keep)
+    }
 
 
-def make_label_str(vo):
+def make_label_str(vo: ValueObject) -> str:
+    """
+    Create string from labels. This is used to create error messages.
+    """
     lab_str = ", ".join(
         [f"{lab}={vo[lab]}" for lab in sorted(vo) if lab != "value"]
     )

--- a/paramtools/utils.py
+++ b/paramtools/utils.py
@@ -98,3 +98,11 @@ def hashable_value_object(vo):
 
 def filter_out_labels(vo, labels):
     return {l: lv for l, lv in vo.items() if l not in labels}
+
+
+def make_label_str(vo):
+    lab_str = ", ".join([f"{lab}={vo[lab]}" for lab in vo if lab != "value"])
+    if lab_str:
+        return f"[{lab_str}]"
+    else:
+        return ""

--- a/paramtools/utils.py
+++ b/paramtools/utils.py
@@ -90,3 +90,11 @@ def ensure_value_object(vo):
     ):
         vo = [{"value": vo}]
     return vo
+
+
+def hashable_value_object(vo):
+    return tuple(sorted(vo.items()))
+
+
+def filter_out_labels(vo, labels):
+    return {l: lv for l, lv in vo.items() if l not in labels}

--- a/paramtools/utils.py
+++ b/paramtools/utils.py
@@ -101,7 +101,9 @@ def filter_out_labels(vo, labels):
 
 
 def make_label_str(vo):
-    lab_str = ", ".join([f"{lab}={vo[lab]}" for lab in vo if lab != "value"])
+    lab_str = ", ".join(
+        [f"{lab}={vo[lab]}" for lab in sorted(vo) if lab != "value"]
+    )
     if lab_str:
         return f"[{lab_str}]"
     else:


### PR DESCRIPTION
Implementing the extend capability for adjustments exposed some limitations with the [initial approach](https://github.com/PSLmodels/ParamTools/blob/0.6.0/paramtools/parameters.py#L305-L363) in ParamTools 0.6.0. The issue with the initial extend approach was that it was not granular enough. Either all of the allowed label values needed to be defined or none of them could be. The example below exposes this problem:

```python
import paramtools


class TaxParams(paramtools.Parameters):
    defaults = {
        "schema": {
            "labels": {
                "year": {
                    "type": "int",
                    "validators": {"range": {"min": 2013, "max": 2027}}
                },
                "marital_status": {
                    "type": "str",
                    "validators": {"choice": {"choices": ["single", "joint"]}}
                },
            }
        },
        "standard_deduction": {
            "title": "Standard deduction amount",
            "description": "Amount filing unit can use as a standard deduction.",
            "type": "float",
            "value": [
                {"year": 2017, "marital_status": "single", "value": 6350},
                {"year": 2017, "marital_status": "joint", "value": 12700},
                {"year": 2018, "marital_status": "single", "value": 12000},
                {"year": 2018, "marital_status": "joint", "value": 24000},
                {"year": 2026, "marital_status": "single", "value": 7685},
                {"year": 2026, "marital_status": "joint", "value": 15369}],
            "validators": {
                "range": {
                    "min": 0,
                    "max": 9e+99
                }
            }
        },
    }

    label_to_extend = "year"
    array_first = True

params = TaxParams()

params.adjust(
    {
        "standard_deduction": [
            {"year": 2017, "value": 10000},
            {"year": 2020, "marital_status": "single", "value": 15000},
            {"year": 2021, "marital_status": "joint", "value": 20000}
        ]
    }
)
```

The initial approach raised an error because it could not fill in the value for "joint" in 2020 and "single" in the years after that.

```python
SparseValueObjectsException: The Value objects for standard_deduction do not span the specified parameter space. Missing combinations:
	(2020, 'joint')
	(2021, 'single')
	(2022, 'single')
	(2023, 'single')
	(2024, 'single')
	(2025, 'single')
	(2026, 'single')
	(2027, 'single')
```

In the new approach, the array values are filled in without any issues:

```python
# output
# array([[ 6350., 12700.],
#        [ 6350., 12700.],
#        [ 6350., 12700.],
#        [ 6350., 12700.],
#        [10000., 10000.],
#        [10000., 10000.],
#        [10000., 10000.],
#        [15000., 10000.],
#        [15000., 20000.],
#        [15000., 20000.],
#        [15000., 20000.],
#        [15000., 20000.],
#        [15000., 20000.],
#        [15000., 20000.],
#        [15000., 20000.]])

```
