### PR TITLE
Fix bugs from CCC #269

### DIFF
--- a/paramtools/parameters.py
+++ b/paramtools/parameters.py
@@ -131,10 +131,13 @@ class Parameters:
                                 vo[self.label_to_extend]
                                 not in self.label_grid[self.label_to_extend]
                             ):
-                                warnings.warn(
-                                    "warning: adjusting a parameter that is not "
-                                    "active in the current state."
+                                msg = (
+                                    f"{param}[{self.label_to_extend}={vo[self.label_to_extend]}] "
+                                    f"is not active in the current state: "
+                                    f"{self.label_to_extend}= "
+                                    f"{self.label_grid[self.label_to_extend]}."
                                 )
+                                warnings.warn(msg)
                             gt = select_gt_ix(
                                 self._data[param]["value"],
                                 True,

--- a/paramtools/tests/extend_ex.json
+++ b/paramtools/tests/extend_ex.json
@@ -43,5 +43,11 @@
             {"d0": 7, "d1": "c1", "value": 50},
             {"d0": 7, "d1": "c2", "value": 51}
         ]
+    },
+    "nonextend_param": {
+        "title": "nonextend param",
+        "description": "Test error on adjustment extension.",
+        "type": "int",
+        "value": 2
     }
 }

--- a/paramtools/tests/test_parameters.py
+++ b/paramtools/tests/test_parameters.py
@@ -1059,3 +1059,78 @@ class TestExtend:
         )
         assert params.errors["extend_param"] == emsg["extend_param"]
         assert np.allclose(params.extend_param, before)
+
+    def test_extend_adj_nonextend_param(self, extend_ex_path):
+        class ExtParams(Parameters):
+            defaults = extend_ex_path
+            label_to_extend = "d0"
+            array_first = True
+
+        params = ExtParams()
+        params.adjust({"nonextend_param": 3})
+        assert params.nonextend_param == 3
+
+    def test_extend_adj_w_set_state(self, extend_ex_path):
+        class ExtParams(Parameters):
+            defaults = extend_ex_path
+            label_to_extend = "d0"
+            array_first = True
+
+        params = ExtParams()
+        params.set_state(d0=list(range(2, 11)))
+        params.adjust({"extend_param": [{"d0": 2, "value": -1}]})
+
+        assert params.extend_param.tolist() == [
+            # [1, 2],
+            # [1, 2],
+            [-1, -1],
+            [-1, -1],
+            [-1, -1],
+            [-1, -1],
+            [-1, -1],
+            [-1, -1],
+            [-1, -1],
+            [-1, -1],
+            [-1, -1],
+        ]
+
+        params = ExtParams()
+        params.set_state(d0=list(range(2, 11)))
+        params.adjust({"extend_param": [{"d0": 3, "value": -1}]})
+
+        assert params.extend_param.tolist() == [
+            # [1, 2],
+            # [1, 2],
+            [1, 2],
+            [-1, -1],
+            [-1, -1],
+            [-1, -1],
+            [-1, -1],
+            [-1, -1],
+            [-1, -1],
+            [-1, -1],
+            [-1, -1],
+        ]
+
+        params = ExtParams()
+        params.set_state(d0=list(range(2, 11)))
+        params.adjust({"extend_param": [{"d0": 1, "value": -1}]})
+        assert params.extend_param.tolist() == []
+        params.array_first = False
+        params.clear_state()
+        params.extend()
+        params.array_first = True
+        params.set_state()
+        assert params.extend_param.tolist() == [
+            [1, 2],
+            [-1, -1],
+            [-1, -1],
+            [-1, -1],
+            [-1, -1],
+            [-1, -1],
+            [-1, -1],
+            [-1, -1],
+            [-1, -1],
+            [-1, -1],
+            [-1, -1],
+        ]

--- a/paramtools/tests/test_parameters.py
+++ b/paramtools/tests/test_parameters.py
@@ -1114,7 +1114,8 @@ class TestExtend:
 
         params = ExtParams()
         params.set_state(d0=list(range(2, 11)))
-        params.adjust({"extend_param": [{"d0": 1, "value": -1}]})
+        with pytest.warns(UserWarning):
+            params.adjust({"extend_param": [{"d0": 1, "value": -1}]})
         assert params.extend_param.tolist() == []
         params.array_first = False
         params.clear_state()

--- a/paramtools/utils.py
+++ b/paramtools/utils.py
@@ -80,6 +80,8 @@ def consistent_labels(value_items: List[ValueObject]):
     Returns None if labels are omitted or added for
     some value object(s).
     """
+    if not value_items:
+        return set([])
     used = set(k for k in value_items[0] if k != "value")
     for vo in value_items:
         if used != set(k for k in vo if k != "value"):
@@ -128,3 +130,13 @@ def make_label_str(vo: ValueObject) -> str:
         return f"[{lab_str}]"
     else:
         return ""
+
+
+def grid_sort(vos, label_to_extend, grid):
+    def key(v):
+        if label_to_extend in v:
+            return grid.index(v[label_to_extend])
+        else:
+            return grid[0]
+
+    return sorted(vos, key=key)


### PR DESCRIPTION
Fixes two bugs that were exposed in PSLmodels/Cost-of-Capital-Calculator#269:
- Situation where parameters that do not use `label_to_extend` are adjusted in extend mode. This caused a `KeyError`. For example: 
    ```python
    params = ExtParams()
    # nonextend_param is not extended.
    params.adjust({"nonextend_param": 3})
    ```

- Situation where a parameter's value is adjusted at a value of `label_to_extend` that is not active in the current state. For example:
```python
In [1]: import paramtools                                                                                                     

In [2]: class ExtParams(paramtools.Parameters): 
   ...:     defaults = "extend_ex.json" 
   ...:     array_first = True 
   ...:     label_to_extend = "d0" 
   ...:                                                                                                                       

In [3]: params = ExtParams()                                                                                                  

In [4]: params.set_state(d0=3)                                                                                                

In [5]: params.adjust({"extend_param": [{"d0": 2, "value": 5}]})                                                              
parameters.py:139: UserWarning: extend_param[d0=2] is not active in the current state: d0=[3].
  warnings.warn(msg)
```
