### PR TITLE
Add parameter indexing

### DIFF
--- a/docs/docs/api/guide.md
+++ b/docs/docs/api/guide.md
@@ -12,6 +12,8 @@ API
 
 [**Extend:**](/api/extend/) Write more concise JSON schemas with the extend capability.
 
+[**Extend with Indexing:**](/api/index/) Index parameter values.
+
 *Documentation on these parts of the API coming soon:*
 
 **Array access:** Access parameter values as NumPy arrays.

--- a/docs/docs/api/indexing.md
+++ b/docs/docs/api/indexing.md
@@ -1,0 +1,156 @@
+# Extend with Indexing
+
+*(coming soon in ParamTools 0.8.0)*
+
+ParamTools provides out-of-the-box parameter indexing. This is helpful for projects that have parameters that change at some rate over time. For example, tax parameters like the standard deduction are often indexed to price inflation. So, the value of the standard deduction actually increases every year by 1 or 2% depending on that year's inflation rate.
+
+The [extend documentation](/api/extend/) may be useful for gaining a better understanding of how ParamTools extends parameter values along `label_to_extend`.
+
+To use the indexing feature:
+
+ - Set the `label_to_extend` class attribute to the label that should be extended
+ - Set the `indexing_rates` class attribute to a dictionary of inflation rates where the keys correspond to the value of `label_to_extend` and the values are the indexing rates.
+ - Set the `uses_extend_func` class attribute to `True`.
+ - In `defaults` or `defaults.json`, set `indexed` to `True` for each parameter that needs to be indexed.
+
+## Example
+
+This is a continuation of the tax parameters example from the [extend documentation](/api/extend/). The differences are `indexed` is set to `True` for the `standard_deducation` parameter, `uses_extend_func` is set to `True`, and `index_rates` is specified with inflation rates obtained from the open-source tax modeling package, [Tax-Calculator](https://github.com/PSLmodels/Tax-Calculator/), using version 2.5.0.
+
+```python
+import paramtools
+
+
+class TaxParams(paramtools.Parameters):
+    defaults = {
+        "schema": {
+            "labels": {
+                "year": {
+                    "type": "int",
+                    "validators": {"range": {"min": 2013, "max": 2027}}
+                },
+                "marital_status": {
+                    "type": "str",
+                    "validators": {"choice": {"choices": ["single", "joint"]}}
+                },
+            }
+        },
+        "standard_deduction": {
+            "title": "Standard deduction amount",
+            "description": "Amount filing unit can use as a standard deduction.",
+            "type": "float",
+
+            # Set indexed to True to extend standard_deduction with the built-in
+            # extension logic.
+            "indexed": True,
+
+            "value": [
+                {"year": 2017, "marital_status": "single", "value": 6350},
+                {"year": 2017, "marital_status": "joint", "value": 12700},
+                {"year": 2018, "marital_status": "single", "value": 12000},
+                {"year": 2018, "marital_status": "joint", "value": 24000},
+                {"year": 2026, "marital_status": "single", "value": 7685},
+                {"year": 2026, "marital_status": "joint", "value": 15369}],
+            "validators": {
+                "range": {
+                    "min": 0,
+                    "max": 9e+99
+                }
+            }
+        },
+    }
+    array_first = True
+    label_to_extend = "year"
+    # Activate use of extend_func method.
+    uses_extend_func = True
+    # inflation rates from Tax-Calculator v2.5.0
+    index_rates = {
+        2013: 0.0148,
+        2014: 0.0159,
+        2015: 0.0012,
+        2016: 0.0127,
+        2017: 0.0187,
+        2018: 0.0224,
+        2019: 0.0186,
+        2020: 0.0233,
+        2021: 0.0229,
+        2022: 0.0228,
+        2023: 0.0221,
+        2024: 0.0211,
+        2025: 0.0209,
+        2026: 0.0211,
+        2027: 0.0208,
+        2028: 0.021,
+        2029: 0.021
+    }
+
+
+params = TaxParams()
+params.standard_deduction
+
+# output:
+# array([[ 6074.92, 12149.84],
+#        [ 6164.83, 12329.66],
+#        [ 6262.85, 12525.7 ],
+#        [ 6270.37, 12540.73],
+#        [ 6350.  , 12700.  ],
+#        [12000.  , 24000.  ],
+#        [12268.8 , 24537.6 ],
+#        [12497.  , 24994.  ],
+#        [12788.18, 25576.36],
+#        [13081.03, 26162.06],
+#        [13379.28, 26758.55],
+#        [13674.96, 27349.91],
+#        [13963.5 , 27926.99],
+#        [ 7685.  , 15369.  ],
+#        [ 7847.15, 15693.29]])
+```
+
+Adjustments are also indexed. In the example below, `standard_deduction` is set to 10,000 in 2017, increased to 15,000 for single tax units in 2020, and increased to 20,000 for joint tax units in 2021:
+
+```python
+params.adjust(
+    {
+        "standard_deduction": [
+            {"year": 2017, "value": 10000},
+            {"year": 2020, "marital_status": "single", "value": 15000},
+            {"year": 2021, "marital_status": "joint", "value": 20000}
+        ]
+    }
+)
+
+params.standard_deduction
+
+# output:
+# array([[ 6074.92, 12149.84],
+#        [ 6164.83, 12329.66],
+#        [ 6262.85, 12525.7 ],
+#        [ 6270.37, 12540.73],
+#        [10000.  , 10000.  ],
+#        [10187.  , 10187.  ],
+#        [10415.19, 10415.19],
+#        [15000.  , 10608.91],
+#        [15349.5 , 20000.  ],
+#        [15701.  , 20458.  ],
+#        [16058.98, 20924.44],
+#        [16413.88, 21386.87],
+#        [16760.21, 21838.13],
+#        [17110.5 , 22294.55],
+#        [17471.53, 22764.97]])
+
+```
+
+
+### Code for getting Tax-Calculator index rates
+
+```python
+import taxcalc
+pol = taxcalc.Policy()
+index_rates = {
+    year: value
+    for year, value in zip(list(range(2013, 2029 + 1)), pol.inflation_rates())
+}
+
+```
+
+Note that there are some subtle details that are implemented in Tax-Calculator's indexing logic that are not implemented in this example. Tax-Calculator has a parameter called `CPI_offset` that adjusts inflation rates up or down by a fixed amount. The `indexed` property can also be turned on and off for each parameter. Implementing these nuanced features is left as the proverbial "trivial exercise to the reader."

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -5,5 +5,6 @@ nav:
     - API:
         - Guide: 'api/guide.md'
         - Extend: 'api/extend.md'
+        - Extend with Indexing: 'api/indexing.md'
 
 theme: mkdocs

--- a/paramtools/examples/taxparams/defaults.json
+++ b/paramtools/examples/taxparams/defaults.json
@@ -3,45 +3,102 @@
         "labels": {
             "year": {
                 "type": "int",
-                "validators": {"range": {"min": 2013, "max": 2027}}
+                "validators": {
+                    "choice": {
+                        "choices": [
+                            2013,
+                            2014,
+                            2015,
+                            2016,
+                            2017,
+                            2018,
+                            2019,
+                            2020,
+                            2021,
+                            2022,
+                            2023,
+                            2024,
+                            2025,
+                            2026,
+                            2027,
+                            2028,
+                            2029
+                        ]
+                    }
+                }
             },
-            "marital_status": {
+            "MARS": {
                 "type": "str",
-                "validators": {"choice": {"choices": ["single", "joint", "separate",
-                                                     "headhousehold", "widow"]}}
+                "validators": {
+                    "choice": {
+                        "choices": [
+                            "single",
+                            "mjoint",
+                            "mseparate",
+                            "headhh",
+                            "widow"
+                        ]
+                    }
+                }
             },
             "idedtype": {
                 "type": "str",
-                "validators": {"choice": {"choices": ["medical", "statelocal",
-                                                     "realestate", "casualty",
-                                                     "misc", "interest", "charity"]}}
+                "validators": {
+                    "choice": {
+                        "choices": [
+                            "med",
+                            "sltx",
+                            "retx",
+                            "cas",
+                            "misc",
+                            "int",
+                            "char"
+                        ]
+                    }
+                }
             },
             "EIC": {
                 "type": "str",
-                "validators": {"choice": {"choices": ["0kids", "1kid",
-                                                     "2kids", "3+kids"]}}
+                "validators": {
+                    "choice": {
+                        "choices": [
+                            "0kids",
+                            "1kid",
+                            "2kids",
+                            "3+kids"
+                        ]
+                    }
+                }
+            },
+            "data_source": {
+                "type": "str",
+                "validators": {
+                    "choice": {
+                        "choices": [
+                            "PUF",
+                            "CPS",
+                            "other"
+                        ]
+                    }
+                }
             }
         },
         "additional_members": {
-            "section_1": {"type": "str"},
-            "section_2": {"type": "str"},
-            "section_3": {"type": "str"},
-            "irs_ref": {"type": "str"},
-            "start_year": {"type": "int"},
-            "cpi_inflatable": {"type": "bool"},
-            "cpi_inflated": {"type": "bool"},
-            "compatible_data": {"type": "compatible_data"}
+            "section_1": {
+                "type": "str"
+            },
+            "section_2": {
+                "type": "str"
+            },
+            "start_year": {
+                "type": "int"
+            },
+            "indexed": {
+                "type": "bool"
+            }
         }
     },
-    "_cpi_offset": {
-        "description": "Current-law values are zero; reforms that introduce indexing with chained CPI would have values around -0.0025 beginning in the year before the first year policy parameters will have values computed with chained CPI.",
-        "section_1": "Parameter Indexing",
-        "section_2": "Offsets",
-        "irs_ref": "",
-        "notes": "See April 2013 CBO report entitled 'What Would Be the Effect on the Deficit of Using the Chained CPI to Index Benefit Programs and the Tax Code?', which includes this: 'The chained CPI grows more slowly than the traditional CPI does: an average of about 0.25 percentage points more slowly per year over the past decade.' <https://www.cbo.gov/publication/44089>",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+    "CPI_offset": {
         "value": [
             {
                 "year": 2013,
@@ -64,10 +121,6 @@
                 "value": -0.0025
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Decimal offset ADDED to unchained CPI to get parameter indexing rate",
         "type": "float",
         "validators": {
@@ -75,27 +128,20 @@
                 "min": -0.005,
                 "max": 0.005
             }
-        }
+        },
+        "section_1": "Parameter Indexing",
+        "section_2": "Offsets",
+        "indexed": false,
+        "description": "Values are zero before 2017; reforms that introduce indexing with chained CPI would have values around -0.0025 beginning in the year before the first year policy parameters will have values computed with chained CPI.",
+        "notes": "See April 2013 CBO report entitled 'What Would Be the Effect on the Deficit of Using the Chained CPI to Index Benefit Programs and the Tax Code?', which includes this: 'The chained CPI grows more slowly than the traditional CPI does: an average of about 0.25 percentage points more slowly per year over the past decade.' <https://www.cbo.gov/publication/44089>"
     },
-    "_FICA_ss_trt": {
-        "description": "Social Security FICA rate, including both employer and employee.",
-        "section_1": "Payroll Taxes",
-        "section_2": "Social Security FICA",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+    "FICA_ss_trt": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.124
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Social Security payroll tax rate",
         "type": "float",
         "validators": {
@@ -103,17 +149,14 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_SS_Earnings_c": {
-        "description": "Only individual earnings below this maximum amount are subjected to Social Security (OASDI) payroll tax.",
+        },
         "section_1": "Payroll Taxes",
         "section_2": "Social Security FICA",
-        "irs_ref": "W-2, Box 4, instructions",
-        "notes": "This parameter is indexed by the rate of growth in average wages, not by the price inflation rate.",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+        "indexed": false,
+        "description": "Social Security FICA rate, including both employer and employee.",
+        "notes": ""
+    },
+    "SS_Earnings_c": {
         "value": [
             {
                 "year": 2013,
@@ -140,10 +183,6 @@
                 "value": 128400.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Maximum taxable earnings (MTE) for Social Security",
         "type": "float",
         "validators": {
@@ -151,27 +190,20 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
-    },
-    "_SS_Earnings_thd": {
-        "description": "Wages and self-employment income above this threshold are subjected to Social Security (OASDI) payroll tax in addition to earnings below the maximum taxable earnings threshold.",
+        },
         "section_1": "Payroll Taxes",
         "section_2": "Social Security FICA",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": false,
+        "indexed": true,
+        "description": "Individual earnings below this amount are subjected to Social Security (OASDI) payroll tax.",
+        "notes": "This parameter is indexed by the rate of growth in average wages, not by the price inflation rate."
+    },
+    "SS_Earnings_thd": {
         "value": [
             {
                 "year": 2013,
                 "value": 9e+99
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Additional Taxable Earnings Threshold for Social Security",
         "type": "float",
         "validators": {
@@ -179,27 +211,20 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
-    },
-    "_FICA_mc_trt": {
-        "description": "Medicare FICA rate, including both employer and employee.",
+        },
         "section_1": "Payroll Taxes",
-        "section_2": "Medicare FICA",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "section_2": "Social Security FICA",
+        "indexed": false,
+        "description": "Individual earnings above this threshold are subjected to Social Security (OASDI) payroll tax, in addition to earnings below the maximum taxable earnings threshold.",
+        "notes": ""
+    },
+    "FICA_mc_trt": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.029
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Medicare payroll tax rate",
         "type": "float",
         "validators": {
@@ -207,48 +232,41 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_AMEDT_ec": {
-        "description": "The Additional Medicare Tax rate, _AMEDT_rt, applies to all earnings in excess of this excluded amount.",
+        },
         "section_1": "Payroll Taxes",
-        "section_2": "Additional Medicare FICA",
-        "irs_ref": "Form 8959, line 5, in-line. ",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": false,
+        "section_2": "Medicare FICA",
+        "indexed": false,
+        "description": "Medicare FICA rate, including both employer and employee.",
+        "notes": ""
+    },
+    "AMEDT_ec": {
         "value": [
             {
                 "year": 2013,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 200000.0
             },
             {
                 "year": 2013,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 250000.0
             },
             {
                 "year": 2013,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 125000.0
             },
             {
                 "year": 2013,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 200000.0
             },
             {
                 "year": 2013,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 200000.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Additional Medicare tax earnings exclusion",
         "type": "float",
         "validators": {
@@ -256,27 +274,20 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
-    },
-    "_AMEDT_rt": {
-        "description": "This is the rate applied to the portion of Medicare wages, RRTA compensation and self-employment income exceeding the Additional Medicare Tax earning exclusion.",
+        },
         "section_1": "Payroll Taxes",
         "section_2": "Additional Medicare FICA",
-        "irs_ref": "Form 8959, line 7, in-line. ",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "The Additional Medicare Tax rate, AMEDT_rt, applies to all earnings in excess of this excluded amount.",
+        "notes": ""
+    },
+    "AMEDT_rt": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.009
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Additional Medicare tax rate",
         "type": "float",
         "validators": {
@@ -284,76 +295,62 @@
                 "min": 0,
                 "max": 1
             }
-        }
+        },
+        "section_1": "Payroll Taxes",
+        "section_2": "Additional Medicare FICA",
+        "indexed": false,
+        "description": "This is the rate applied to the portion of Medicare wages, RRTA compensation and self-employment income exceeding the Additional Medicare Tax earning exclusion.",
+        "notes": ""
     },
-    "_SS_thd50": {
-        "description": "The first threshold for Social Security benefit taxability: if taxpayers have provisional income greater than this threshold, up to 50% of their Social Security benefit will be subject to tax under current law.",
-        "section_1": "Social Security Taxability",
-        "section_2": "Threshold For Social Security Benefit Taxability 1",
-        "irs_ref": "Form 1040, line 5a&b, calculation (Worksheet, line 8)",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": false,
+    "SS_thd50": {
         "value": [
             {
                 "year": 2013,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 25000.0
             },
             {
                 "year": 2013,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 32000.0
             },
             {
                 "year": 2013,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 25000.0
             },
             {
                 "year": 2013,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 25000.0
             },
             {
                 "year": 2013,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 25000.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Threshold for Social Security benefit taxability 1",
         "type": "float",
         "validators": {
             "range": {
                 "min": 0,
-                "max": "_SS_thd85"
+                "max": "SS_thd85"
             }
-        }
+        },
+        "section_1": "Social Security Taxability",
+        "section_2": "Threshold For Social Security Benefit Taxability 1",
+        "indexed": false,
+        "description": "The first threshold for Social Security benefit taxability: if taxpayers have provisional income greater than this threshold, up to 50% of their Social Security benefit will be subject to tax under current law.",
+        "notes": ""
     },
-    "_SS_percentage1": {
-        "description": "Under current law if their provisional income is above the first threshold for Social Security taxability but below the second threshold, taxpayers need to apply this fraction to both the excess of their provisional income over the first threshold and their Social Security benefits, and then include the smaller one in their AGI.",
-        "section_1": "",
-        "section_2": "",
-        "irs_ref": "Form 1040, line 5b, instructions (Social Security Worksheets, line 2 & 13)",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+    "SS_percentage1": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.5
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Social Security taxable income decimal fraction 1",
         "type": "float",
         "validators": {
@@ -361,76 +358,62 @@
                 "min": 0,
                 "max": 1
             }
-        }
+        },
+        "section_1": "",
+        "section_2": "",
+        "indexed": false,
+        "description": "Under current law if their provisional income is above the first threshold for Social Security taxability but below the second threshold, taxpayers need to apply this fraction to both the excess of their provisional income over the first threshold and their Social Security benefits, and then include the smaller one in their AGI.",
+        "notes": ""
     },
-    "_SS_thd85": {
-        "description": "The second threshold for Social Security taxability: if taxpayers have provisional income greater than this threshold, up to 85% of their Social Security benefit will be subject to tax under current law.",
-        "section_1": "Social Security Taxability",
-        "section_2": "Threshold For Social Security Benefit Taxability 2",
-        "irs_ref": "Form 1040, line 5a&b, calculation (Worksheet, add line 10 values to line 8).",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": false,
+    "SS_thd85": {
         "value": [
             {
                 "year": 2013,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 34000.0
             },
             {
                 "year": 2013,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 44000.0
             },
             {
                 "year": 2013,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 34000.0
             },
             {
                 "year": 2013,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 34000.0
             },
             {
                 "year": 2013,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 34000.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Threshold for Social Security benefit taxability 2",
         "type": "float",
         "validators": {
             "range": {
-                "min": "_SS_thd50",
+                "min": "SS_thd50",
                 "max": 9e+99
             }
-        }
+        },
+        "section_1": "Social Security Taxability",
+        "section_2": "Threshold For Social Security Benefit Taxability 2",
+        "indexed": false,
+        "description": "The second threshold for Social Security taxability: if taxpayers have provisional income greater than this threshold, up to 85% of their Social Security benefit will be subject to tax under current law.",
+        "notes": ""
     },
-    "_SS_percentage2": {
-        "description": "Under current law if their provisional income is above the second threshold for Social Security taxability, taxpayers need to apply this fraction to both the excess of their provisional income over the second threshold and their social security benefits, and then include the smaller one in their AGI.",
-        "section_1": "",
-        "section_2": "",
-        "irs_ref": "Form 1040, line 5b, instructions (Social Security Worksheets, line 15)",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+    "SS_percentage2": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.85
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Social Security taxable income decimal fraction 2",
         "type": "float",
         "validators": {
@@ -438,27 +421,20 @@
                 "min": 0,
                 "max": 1
             }
-        }
+        },
+        "section_1": "",
+        "section_2": "",
+        "indexed": false,
+        "description": "Under current law if their provisional income is above the second threshold for Social Security taxability, taxpayers need to apply this fraction to both the excess of their provisional income over the second threshold and their social security benefits, and then include the smaller one in their AGI.",
+        "notes": ""
     },
-    "_ALD_StudentLoan_hc": {
-        "description": "This decimal fraction can be applied to limit the student loan interest adjustment allowed.",
-        "section_1": "Above The Line Deductions",
-        "section_2": "Misc. Adjustment Haircuts",
-        "irs_ref": "Form 1040 (Schedule 1), line 33",
-        "notes": "The final adjustment amount will be (1-Haircut)*StudentLoanInterest.",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+    "ALD_StudentLoan_hc": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Adjustment for student loan interest haircut",
         "type": "float",
         "validators": {
@@ -466,27 +442,20 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_ALD_SelfEmploymentTax_hc": {
-        "description": "This decimal fraction, if greater than zero, reduces the employer equivalent portion of self-employment adjustment.",
+        },
         "section_1": "Above The Line Deductions",
         "section_2": "Misc. Adjustment Haircuts",
-        "irs_ref": "Form 1040 (Schedule 4), line 57",
-        "notes": "The final adjustment amount would be (1-Haircut)*SelfEmploymentTaxAdjustment.",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "This decimal fraction can be applied to limit the student loan interest adjustment allowed.",
+        "notes": "The final adjustment amount will be (1-Haircut)*StudentLoanInterest."
+    },
+    "ALD_SelfEmploymentTax_hc": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Adjustment for self-employment tax haircut",
         "type": "float",
         "validators": {
@@ -494,27 +463,20 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_ALD_SelfEmp_HealthIns_hc": {
-        "description": "This decimal fraction, if greater than zero, reduces the health insurance adjustment for self-employed taxpayers.",
+        },
         "section_1": "Above The Line Deductions",
         "section_2": "Misc. Adjustment Haircuts",
-        "irs_ref": "Form 1040 (Schedule 4), line 61",
-        "notes": "The final adjustment amount would be (1-Haircut)*SelfEmployedHealthInsuranceAdjustment.",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "This decimal fraction, if greater than zero, reduces the employer equivalent portion of self-employment adjustment.",
+        "notes": "The final adjustment amount would be (1-Haircut)*SelfEmploymentTaxAdjustment."
+    },
+    "ALD_SelfEmp_HealthIns_hc": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Adjustment for self employed health insurance haircut",
         "type": "float",
         "validators": {
@@ -522,27 +484,20 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_ALD_KEOGH_SEP_hc": {
-        "description": "Under current law, contributions to Keogh or SEP plans can be fully deducted from gross income.  This haircut can be used to limit the adjustment allowed.",
+        },
         "section_1": "Above The Line Deductions",
         "section_2": "Misc. Adjustment Haircuts",
-        "irs_ref": "Form 1040 (Schedule 1), line 28",
-        "notes": "The final adjustment amount is (1-Haircut)*KEOGH_SEP_Contributinos.",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "This decimal fraction, if greater than zero, reduces the health insurance adjustment for self-employed taxpayers.",
+        "notes": "The final adjustment amount would be (1-Haircut)*SelfEmployedHealthInsuranceAdjustment."
+    },
+    "ALD_KEOGH_SEP_hc": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Adjustment for contributions to either KEOGH or SEP plan haircut",
         "type": "float",
         "validators": {
@@ -550,27 +505,20 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_ALD_EarlyWithdraw_hc": {
-        "description": "Under current law, early withdraw penalty can be fully deducted from gross income. This haircut can be used to limit the adjustment allowed.",
+        },
         "section_1": "Above The Line Deductions",
         "section_2": "Misc. Adjustment Haircuts",
-        "irs_ref": "Form 1040 (Schedule 1), line 30",
-        "notes": "The final adjustment amount is (1-Haircut)*EarlyWithdrawPenalty.",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "Under current law, contributions to Keogh or SEP plans can be fully deducted from gross income.  This haircut can be used to limit the adjustment allowed.",
+        "notes": "The final adjustment amount is (1-Haircut)*KEOGH_SEP_Contributinos."
+    },
+    "ALD_EarlyWithdraw_hc": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": false
-        },
         "title": "Adjustment for early withdrawal penalty haircut",
         "type": "float",
         "validators": {
@@ -578,17 +526,14 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_ALD_AlimonyPaid_hc": {
-        "description": "Under pre-TCJA law, the full amount of alimony paid is taken as an adjustment from gross income in arriving at AGI. This haircut can be used to change the deduction allowed.",
+        },
         "section_1": "Above The Line Deductions",
         "section_2": "Misc. Adjustment Haircuts",
-        "irs_ref": "Form 1040 (Schedule 1), line 31",
-        "notes": "The final adjustment amount would be (1-Haircut)*AlimonyPaid.",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "Under current law, early withdraw penalty can be fully deducted from gross income. This haircut can be used to limit the adjustment allowed.",
+        "notes": "The final adjustment amount is (1-Haircut)*EarlyWithdrawPenalty."
+    },
+    "ALD_AlimonyPaid_hc": {
         "value": [
             {
                 "year": 2013,
@@ -647,10 +592,6 @@
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": false
-        },
         "title": "Adjustment for alimony-paid haircut",
         "type": "float",
         "validators": {
@@ -658,17 +599,14 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_ALD_AlimonyReceived_hc": {
-        "description": "Under pre-TCJA law, none of alimony received is taken as an adjustment from gross income in arriving at AGI. This haircut can be used to change the deduction allowed.",
+        },
         "section_1": "Above The Line Deductions",
         "section_2": "Misc. Adjustment Haircuts",
-        "irs_ref": "Form 1040 (Schedule 1), line 11 (new with TCJA)",
-        "notes": "The final adjustment amount would be (1-Haircut)*AlimonyReceived.",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "Under pre-TCJA law, the full amount of alimony paid is taken as an adjustment from gross income in arriving at AGI. This haircut can be used to change the deduction allowed.",
+        "notes": "The final adjustment amount would be (1-Haircut)*AlimonyPaid."
+    },
+    "ALD_AlimonyReceived_hc": {
         "value": [
             {
                 "year": 2013,
@@ -727,10 +665,6 @@
                 "value": 1.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Adjustment for alimony-received haircut",
         "type": "float",
         "validators": {
@@ -738,27 +672,20 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_ALD_EducatorExpenses_hc": {
-        "description": "If greater than zero, this decimal fraction reduces the portion of educator expenses that can be deducted from AGI.",
+        },
         "section_1": "Above The Line Deductions",
         "section_2": "Misc. Adjustment Haircuts",
-        "irs_ref": "",
-        "notes": "The final adjustment amount would be (1-Haircut)*EducatorExpenses.",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "Under pre-TCJA law, none of alimony received is taken as an adjustment from gross income in arriving at AGI. This haircut can be used to change the deduction allowed.",
+        "notes": "The final adjustment amount would be (1-Haircut)*AlimonyReceived."
+    },
+    "ALD_EducatorExpenses_hc": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": false
-        },
         "title": "Deduction for educator expenses haircut",
         "type": "float",
         "validators": {
@@ -766,27 +693,20 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_ALD_HSADeduction_hc": {
-        "description": "If greater than zero, this decimal fraction reduces the portion of a taxpayer's HSA deduction that can be deducted from AGI.",
+        },
         "section_1": "Above The Line Deductions",
         "section_2": "Misc. Adjustment Haircuts",
-        "irs_ref": "",
-        "notes": "The final adjustment amount would be (1-Haircut)*HSA_Deduction.",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "If greater than zero, this decimal fraction reduces the portion of educator expenses that can be deducted from AGI.",
+        "notes": "The final adjustment amount would be (1-Haircut)*EducatorExpenses."
+    },
+    "ALD_HSADeduction_hc": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": false
-        },
         "title": "Deduction for HSA deduction haircut",
         "type": "float",
         "validators": {
@@ -794,27 +714,20 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_ALD_IRAContributions_hc": {
-        "description": "If greater than zero, this decimal fraction reduces the portion of IRA contributions that can be deducted from AGI.",
+        },
         "section_1": "Above The Line Deductions",
         "section_2": "Misc. Adjustment Haircuts",
-        "irs_ref": "",
-        "notes": "The final adjustment amount would be (1-Haircut)*IRA_Contribution.",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "If greater than zero, this decimal fraction reduces the portion of a taxpayer's HSA deduction that can be deducted from AGI.",
+        "notes": "The final adjustment amount would be (1-Haircut)*HSA_Deduction."
+    },
+    "ALD_IRAContributions_hc": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Deduction for IRA contributions haircut",
         "type": "float",
         "validators": {
@@ -822,17 +735,14 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_ALD_DomesticProduction_hc": {
-        "description": "If greater than zero, this decimal fraction reduces the portion of domestic production activity that can be deducted from AGI.",
+        },
         "section_1": "Above The Line Deductions",
         "section_2": "Misc. Adjustment Haircuts",
-        "irs_ref": "",
-        "notes": "The final adjustment amount would be (1-Haircut)*DomesticProductionActivity.",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "If greater than zero, this decimal fraction reduces the portion of IRA contributions that can be deducted from AGI.",
+        "notes": "The final adjustment amount would be (1-Haircut)*IRA_Contribution."
+    },
+    "ALD_DomesticProduction_hc": {
         "value": [
             {
                 "year": 2013,
@@ -891,10 +801,6 @@
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Deduction for domestic production activity haircut",
         "type": "float",
         "validators": {
@@ -902,27 +808,40 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_ALD_Tuition_hc": {
-        "description": "If greater than zero, this decimal fraction reduces the portion of tuition and fees that can be deducted from AGI.",
+        },
         "section_1": "Above The Line Deductions",
         "section_2": "Misc. Adjustment Haircuts",
-        "irs_ref": "",
-        "notes": "The final adjustment amount would be (1-Haircut)*TuitionFees.",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "If greater than zero, this decimal fraction reduces the portion of domestic production activity that can be deducted from AGI.",
+        "notes": "The final adjustment amount would be (1-Haircut)*DomesticProductionActivity."
+    },
+    "ALD_Tuition_hc": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.0
+            },
+            {
+                "year": 2014,
+                "value": 0.0
+            },
+            {
+                "year": 2015,
+                "value": 0.0
+            },
+            {
+                "year": 2016,
+                "value": 0.0
+            },
+            {
+                "year": 2017,
+                "value": 0.0
+            },
+            {
+                "year": 2018,
+                "value": 1.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": false
-        },
         "title": "Deduction for tuition and fees haircut",
         "type": "float",
         "validators": {
@@ -930,27 +849,20 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_ALD_InvInc_ec_rt": {
-        "description": "Decimal fraction of investment income base that can be excluded from AGI.",
+        },
         "section_1": "Above The Line Deductions",
-        "section_2": "Misc. Exclusions",
-        "irs_ref": "Form 1040, line 2a",
-        "notes": "The final taxable investment income will be (1-_ALD_InvInc_ec_rt)*investment_income_base. Even though the excluded portion of investment income is not included in AGI, it still is included in investment income used to calculate the Net Investment Income Tax and Earned Income Tax Credit.",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "section_2": "Misc. Adjustment Haircuts",
+        "indexed": false,
+        "description": "If greater than zero, this decimal fraction reduces the portion of tuition and fees that can be deducted from AGI.",
+        "notes": "The final adjustment amount would be (1-Haircut)*TuitionFees."
+    },
+    "ALD_InvInc_ec_rt": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Investment income exclusion rate haircut",
         "type": "float",
         "validators": {
@@ -958,27 +870,20 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_ALD_Dependents_hc": {
-        "description": "This decimal fraction, if greater than zero, reduces the portion of childcare costs that can be deducted from AGI.",
+        },
         "section_1": "Above The Line Deductions",
-        "section_2": "Child And Elderly Care",
-        "irs_ref": "",
-        "notes": "The final adjustment would be (1-Haircut)*AverageChildcareCosts.",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "section_2": "Misc. Exclusions",
+        "indexed": false,
+        "description": "Decimal fraction of investment income base that can be excluded from AGI.",
+        "notes": "The final taxable investment income will be (1-_ALD_InvInc_ec_rt)*investment_income_base. Even though the excluded portion of investment income is not included in AGI, it still is included in investment income used to calculate the Net Investment Income Tax and Earned Income Tax Credit."
+    },
+    "ALD_Dependents_hc": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Deduction for childcare costs haircut",
         "type": "float",
         "validators": {
@@ -986,17 +891,14 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_ALD_Dependents_Child_c": {
-        "description": "The weighted average of childcare costs in the US. 7165 is the weighted average from the 'Child Care in America: 2016 State Fact Sheets'.",
+        },
         "section_1": "Above The Line Deductions",
         "section_2": "Child And Elderly Care",
-        "irs_ref": "",
-        "notes": "This is a weighted average of childcare costs in each state",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+        "indexed": false,
+        "description": "This decimal fraction, if greater than zero, reduces the portion of childcare costs that can be deducted from AGI.",
+        "notes": "The final adjustment would be (1-Haircut)*AverageChildcareCosts."
+    },
+    "ALD_Dependents_Child_c": {
         "value": [
             {
                 "year": 2013,
@@ -1023,10 +925,6 @@
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "National average childcare costs: ceiling for available childcare deduction.",
         "type": "float",
         "validators": {
@@ -1034,17 +932,14 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
-    },
-    "_ALD_Dependents_Elder_c": {
-        "description": "A taxpayer can take an above the line deduction up to this amount if they have an elderly dependent. The Trump 2016 campaign proposal was for $5000.",
+        },
         "section_1": "Above The Line Deductions",
         "section_2": "Child And Elderly Care",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+        "indexed": true,
+        "description": "The weighted average of childcare costs in the US. 7165 is the weighted average from the 'Child Care in America: 2016 State Fact Sheets'.",
+        "notes": "This is a weighted average of childcare costs in each state"
+    },
+    "ALD_Dependents_Elder_c": {
         "value": [
             {
                 "year": 2013,
@@ -1071,10 +966,6 @@
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Ceiling for elderly care deduction proposed in Trump's tax plan",
         "type": "float",
         "validators": {
@@ -1082,48 +973,41 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
-    },
-    "_ALD_Dependents_thd": {
-        "description": "A taxpayer can only claim the dependent care deduction if their total income is below this level. The Trump 2016 campaign proposal was for 250000 single, 500000 joint, 250000 separate, 500000 headhousehold].",
+        },
         "section_1": "Above The Line Deductions",
         "section_2": "Child And Elderly Care",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": false,
+        "indexed": true,
+        "description": "A taxpayer can take an above the line deduction up to this amount if they have an elderly dependent. The Trump 2016 campaign proposal was for $5000.",
+        "notes": ""
+    },
+    "ALD_Dependents_thd": {
         "value": [
             {
                 "year": 2013,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 0.0
             },
             {
                 "year": 2013,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 0.0
             },
             {
                 "year": 2013,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 0.0
             },
             {
                 "year": 2013,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 0.0
             },
             {
                 "year": 2013,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Maximum level of income to qualify for the dependent care deduction",
         "type": "float",
         "validators": {
@@ -1131,373 +1015,366 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
-    },
-    "_ALD_BusinessLosses_c": {
-        "description": "Business losses in excess of this amount may not be deducted from AGI.",
+        },
         "section_1": "Above The Line Deductions",
-        "section_2": "Misc. Exclusions",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+        "section_2": "Child And Elderly Care",
+        "indexed": false,
+        "description": "A taxpayer can only claim the dependent care deduction if their total income is below this level. The Trump 2016 campaign proposal was for 250000 single, 500000 joint, 250000 separate, 500000 head of household].",
+        "notes": ""
+    },
+    "ALD_BusinessLosses_c": {
         "value": [
             {
                 "year": 2013,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2013,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2013,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2013,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2013,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 250000.0
             },
             {
                 "year": 2018,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 500000.0
             },
             {
                 "year": 2018,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 250000.0
             },
             {
                 "year": 2018,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 250000.0
             },
             {
                 "year": 2018,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 500000.0
             },
             {
                 "year": 2019,
-                "marital_status": "single",
-                "value": 255725.0
+                "MARS": "single",
+                "value": 255600.0
             },
             {
                 "year": 2019,
-                "marital_status": "joint",
-                "value": 511450.0
+                "MARS": "mjoint",
+                "value": 511200.0
             },
             {
                 "year": 2019,
-                "marital_status": "separate",
-                "value": 255725.0
+                "MARS": "mseparate",
+                "value": 255600.0
             },
             {
                 "year": 2019,
-                "marital_status": "headhousehold",
-                "value": 255725.0
+                "MARS": "headhh",
+                "value": 255600.0
             },
             {
                 "year": 2019,
-                "marital_status": "widow",
-                "value": 511450.0
+                "MARS": "widow",
+                "value": 511200.0
             },
             {
                 "year": 2020,
-                "marital_status": "single",
-                "value": 260813.93
+                "MARS": "single",
+                "value": 260354.16
             },
             {
                 "year": 2020,
-                "marital_status": "joint",
-                "value": 521627.86
+                "MARS": "mjoint",
+                "value": 520708.32
             },
             {
                 "year": 2020,
-                "marital_status": "separate",
-                "value": 260813.93
+                "MARS": "mseparate",
+                "value": 260354.16
             },
             {
                 "year": 2020,
-                "marital_status": "headhousehold",
-                "value": 260813.93
+                "MARS": "headhh",
+                "value": 260354.16
             },
             {
                 "year": 2020,
-                "marital_status": "widow",
-                "value": 521627.86
+                "MARS": "widow",
+                "value": 520708.32
             },
             {
                 "year": 2021,
-                "marital_status": "single",
-                "value": 266656.16
+                "MARS": "single",
+                "value": 266420.41
             },
             {
                 "year": 2021,
-                "marital_status": "joint",
-                "value": 533312.32
+                "MARS": "mjoint",
+                "value": 532840.82
             },
             {
                 "year": 2021,
-                "marital_status": "separate",
-                "value": 266656.16
+                "MARS": "mseparate",
+                "value": 266420.41
             },
             {
                 "year": 2021,
-                "marital_status": "headhousehold",
-                "value": 266656.16
+                "MARS": "headhh",
+                "value": 266420.41
             },
             {
                 "year": 2021,
-                "marital_status": "widow",
-                "value": 533312.32
+                "MARS": "widow",
+                "value": 532840.82
             },
             {
                 "year": 2022,
-                "marital_status": "single",
-                "value": 272709.25
+                "MARS": "single",
+                "value": 272521.44
             },
             {
                 "year": 2022,
-                "marital_status": "joint",
-                "value": 545418.51
+                "MARS": "mjoint",
+                "value": 545042.88
             },
             {
                 "year": 2022,
-                "marital_status": "separate",
-                "value": 272709.25
+                "MARS": "mseparate",
+                "value": 272521.44
             },
             {
                 "year": 2022,
-                "marital_status": "headhousehold",
-                "value": 272709.25
+                "MARS": "headhh",
+                "value": 272521.44
             },
             {
                 "year": 2022,
-                "marital_status": "widow",
-                "value": 545418.51
+                "MARS": "widow",
+                "value": 545042.88
             },
             {
                 "year": 2023,
-                "marital_status": "single",
-                "value": 278790.67
+                "MARS": "single",
+                "value": 278734.93
             },
             {
                 "year": 2023,
-                "marital_status": "joint",
-                "value": 557581.34
+                "MARS": "mjoint",
+                "value": 557469.86
             },
             {
                 "year": 2023,
-                "marital_status": "separate",
-                "value": 278790.67
+                "MARS": "mseparate",
+                "value": 278734.93
             },
             {
                 "year": 2023,
-                "marital_status": "headhousehold",
-                "value": 278790.67
+                "MARS": "headhh",
+                "value": 278734.93
             },
             {
                 "year": 2023,
-                "marital_status": "widow",
-                "value": 557581.34
+                "MARS": "widow",
+                "value": 557469.86
             },
             {
                 "year": 2024,
-                "marital_status": "single",
-                "value": 284868.31
+                "MARS": "single",
+                "value": 284894.97
             },
             {
                 "year": 2024,
-                "marital_status": "joint",
-                "value": 569736.61
+                "MARS": "mjoint",
+                "value": 569789.94
             },
             {
                 "year": 2024,
-                "marital_status": "separate",
-                "value": 284868.31
+                "MARS": "mseparate",
+                "value": 284894.97
             },
             {
                 "year": 2024,
-                "marital_status": "headhousehold",
-                "value": 284868.31
+                "MARS": "headhh",
+                "value": 284894.97
             },
             {
                 "year": 2024,
-                "marital_status": "widow",
-                "value": 569736.61
+                "MARS": "widow",
+                "value": 569789.94
             },
             {
                 "year": 2025,
-                "marital_status": "single",
-                "value": 290992.98
+                "MARS": "single",
+                "value": 290906.25
             },
             {
                 "year": 2025,
-                "marital_status": "joint",
-                "value": 581985.95
+                "MARS": "mjoint",
+                "value": 581812.51
             },
             {
                 "year": 2025,
-                "marital_status": "separate",
-                "value": 290992.98
+                "MARS": "mseparate",
+                "value": 290906.25
             },
             {
                 "year": 2025,
-                "marital_status": "headhousehold",
-                "value": 290992.98
+                "MARS": "headhh",
+                "value": 290906.25
             },
             {
                 "year": 2025,
-                "marital_status": "widow",
-                "value": 581985.95
+                "MARS": "widow",
+                "value": 581812.51
             },
             {
                 "year": 2026,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2026,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2026,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2026,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2026,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Maximum amount of business losses deductible",
         "type": "float",
         "validators": {
@@ -1505,17 +1382,14 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
+        },
+        "section_1": "Above The Line Deductions",
+        "section_2": "Misc. Exclusions",
+        "indexed": true,
+        "description": "Business losses in excess of this amount may not be deducted from AGI.",
+        "notes": ""
     },
-    "_II_em": {
-        "description": "Subtracted from AGI in the calculation of taxable income, per taxpayer and dependent.",
-        "section_1": "Personal Exemptions",
-        "section_2": "Personal And Dependent Exemption Amount",
-        "irs_ref": "Form 1040, line 42. ",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+    "II_em": {
         "value": [
             {
                 "year": 2013,
@@ -1571,13 +1445,9 @@
             },
             {
                 "year": 2026,
-                "value": 4905.0
+                "value": 4901.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Personal and dependent exemption amount",
         "type": "float",
         "validators": {
@@ -1585,173 +1455,166 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
+        },
+        "section_1": "Personal Exemptions",
+        "section_2": "Personal And Dependent Exemption Amount",
+        "indexed": true,
+        "description": "Subtracted from AGI in the calculation of taxable income, per taxpayer and dependent.",
+        "notes": ""
     },
-    "_II_em_ps": {
-        "description": "If taxpayers' AGI is above this level, their personal exemption will start to decrease at the personal exemption phaseout rate (PEP provision).",
-        "section_1": "",
-        "section_2": "",
-        "irs_ref": "Form 1040, line 42, instruction (Worksheet).",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+    "II_em_ps": {
         "value": [
             {
                 "year": 2013,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 250000.0
             },
             {
                 "year": 2013,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 300000.0
             },
             {
                 "year": 2013,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 150000.0
             },
             {
                 "year": 2013,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 275000.0
             },
             {
                 "year": 2013,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 300000.0
             },
             {
                 "year": 2014,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 254200.0
             },
             {
                 "year": 2014,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 305050.0
             },
             {
                 "year": 2014,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 152525.0
             },
             {
                 "year": 2014,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 279650.0
             },
             {
                 "year": 2014,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 305050.0
             },
             {
                 "year": 2015,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 258250.0
             },
             {
                 "year": 2015,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 309900.0
             },
             {
                 "year": 2015,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 154950.0
             },
             {
                 "year": 2015,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 284040.0
             },
             {
                 "year": 2015,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 309900.0
             },
             {
                 "year": 2016,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 259400.0
             },
             {
                 "year": 2016,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 311300.0
             },
             {
                 "year": 2016,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 155650.0
             },
             {
                 "year": 2016,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 285350.0
             },
             {
                 "year": 2016,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 311300.0
             },
             {
                 "year": 2017,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 261500.0
             },
             {
                 "year": 2017,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 313800.0
             },
             {
                 "year": 2017,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 156900.0
             },
             {
                 "year": 2017,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 287650.0
             },
             {
                 "year": 2017,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 313800.0
             },
             {
                 "year": 2018,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Personal exemption phaseout starting income",
         "type": "float",
         "validators": {
@@ -1759,27 +1622,20 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
+        },
+        "section_1": "",
+        "section_2": "",
+        "indexed": true,
+        "description": "If taxpayers' AGI is above this level, their personal exemption will start to decrease at the personal exemption phaseout rate (PEP provision).",
+        "notes": ""
     },
-    "_II_prt": {
-        "description": "Personal exemption amount will decrease by this rate for each dollar of AGI exceeding exemption phaseout start.",
-        "section_1": "Personal Exemptions",
-        "section_2": "Personal Exemption Phaseout Rate",
-        "irs_ref": "Form 1040, line 42, instruction (Worksheet).",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+    "II_prt": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.02
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Personal exemption phaseout rate",
         "type": "float",
         "validators": {
@@ -1787,27 +1643,20 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_II_no_em_nu18": {
-        "description": "Total personal exemptions will be decreased by the number of dependents under the age of 18.",
+        },
         "section_1": "Personal Exemptions",
-        "section_2": "Repeal for Dependents Under Age 18",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "section_2": "Personal Exemption Phaseout Rate",
+        "indexed": false,
+        "description": "Personal exemption amount will decrease by this rate for each dollar of AGI exceeding exemption phaseout start.",
+        "notes": ""
+    },
+    "II_no_em_nu18": {
         "value": [
             {
                 "year": 2013,
                 "value": false
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Repeal personal exemptions for dependents under age 18",
         "type": "bool",
         "validators": {
@@ -1815,373 +1664,366 @@
                 "min": false,
                 "max": true
             }
-        }
+        },
+        "section_1": "Personal Exemptions",
+        "section_2": "Repeal for Dependents Under Age 18",
+        "indexed": false,
+        "description": "Total personal exemptions will be decreased by the number of dependents under the age of 18.",
+        "notes": ""
     },
-    "_standard_deduction": {
-        "description": "Amount filing unit can use as a standard deduction.",
-        "section_1": "Standard Deduction",
-        "section_2": "Standard Deduction Amount",
-        "irs_ref": "Form 1040, line 8, instructions. ",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+    "STD": {
         "value": [
             {
                 "year": 2013,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 6100.0
             },
             {
                 "year": 2013,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 12200.0
             },
             {
                 "year": 2013,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 6100.0
             },
             {
                 "year": 2013,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 8950.0
             },
             {
                 "year": 2013,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 12200.0
             },
             {
                 "year": 2014,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 6200.0
             },
             {
                 "year": 2014,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 12400.0
             },
             {
                 "year": 2014,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 6200.0
             },
             {
                 "year": 2014,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9100.0
             },
             {
                 "year": 2014,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 12400.0
             },
             {
                 "year": 2015,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 6300.0
             },
             {
                 "year": 2015,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 12600.0
             },
             {
                 "year": 2015,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 6300.0
             },
             {
                 "year": 2015,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9250.0
             },
             {
                 "year": 2015,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 12600.0
             },
             {
                 "year": 2016,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 6300.0
             },
             {
                 "year": 2016,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 12600.0
             },
             {
                 "year": 2016,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 6300.0
             },
             {
                 "year": 2016,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9300.0
             },
             {
                 "year": 2016,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 12600.0
             },
             {
                 "year": 2017,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 6350.0
             },
             {
                 "year": 2017,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 12700.0
             },
             {
                 "year": 2017,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 6350.0
             },
             {
                 "year": 2017,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9350.0
             },
             {
                 "year": 2017,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 12700.0
             },
             {
                 "year": 2018,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 12000.0
             },
             {
                 "year": 2018,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 24000.0
             },
             {
                 "year": 2018,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 12000.0
             },
             {
                 "year": 2018,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 18000.0
             },
             {
                 "year": 2018,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 24000.0
             },
             {
                 "year": 2019,
-                "marital_status": "single",
-                "value": 12274.8
+                "MARS": "single",
+                "value": 12268.8
             },
             {
                 "year": 2019,
-                "marital_status": "joint",
-                "value": 24549.6
+                "MARS": "mjoint",
+                "value": 24537.6
             },
             {
                 "year": 2019,
-                "marital_status": "separate",
-                "value": 12274.8
+                "MARS": "mseparate",
+                "value": 12268.8
             },
             {
                 "year": 2019,
-                "marital_status": "headhousehold",
-                "value": 18412.2
+                "MARS": "headhh",
+                "value": 18403.2
             },
             {
                 "year": 2019,
-                "marital_status": "widow",
-                "value": 24549.6
+                "MARS": "widow",
+                "value": 24537.6
             },
             {
                 "year": 2020,
-                "marital_status": "single",
-                "value": 12519.07
+                "MARS": "single",
+                "value": 12497.0
             },
             {
                 "year": 2020,
-                "marital_status": "joint",
-                "value": 25038.14
+                "MARS": "mjoint",
+                "value": 24994.0
             },
             {
                 "year": 2020,
-                "marital_status": "separate",
-                "value": 12519.07
+                "MARS": "mseparate",
+                "value": 12497.0
             },
             {
                 "year": 2020,
-                "marital_status": "headhousehold",
-                "value": 18778.6
+                "MARS": "headhh",
+                "value": 18745.5
             },
             {
                 "year": 2020,
-                "marital_status": "widow",
-                "value": 25038.14
+                "MARS": "widow",
+                "value": 24994.0
             },
             {
                 "year": 2021,
-                "marital_status": "single",
-                "value": 12799.5
+                "MARS": "single",
+                "value": 12788.18
             },
             {
                 "year": 2021,
-                "marital_status": "joint",
-                "value": 25598.99
+                "MARS": "mjoint",
+                "value": 25576.36
             },
             {
                 "year": 2021,
-                "marital_status": "separate",
-                "value": 12799.5
+                "MARS": "mseparate",
+                "value": 12788.18
             },
             {
                 "year": 2021,
-                "marital_status": "headhousehold",
-                "value": 19199.24
+                "MARS": "headhh",
+                "value": 19182.27
             },
             {
                 "year": 2021,
-                "marital_status": "widow",
-                "value": 25598.99
+                "MARS": "widow",
+                "value": 25576.36
             },
             {
                 "year": 2022,
-                "marital_status": "single",
-                "value": 13090.04
+                "MARS": "single",
+                "value": 13081.03
             },
             {
                 "year": 2022,
-                "marital_status": "joint",
-                "value": 26180.09
+                "MARS": "mjoint",
+                "value": 26162.06
             },
             {
                 "year": 2022,
-                "marital_status": "separate",
-                "value": 13090.04
+                "MARS": "mseparate",
+                "value": 13081.03
             },
             {
                 "year": 2022,
-                "marital_status": "headhousehold",
-                "value": 19635.07
+                "MARS": "headhh",
+                "value": 19621.54
             },
             {
                 "year": 2022,
-                "marital_status": "widow",
-                "value": 26180.09
+                "MARS": "widow",
+                "value": 26162.06
             },
             {
                 "year": 2023,
-                "marital_status": "single",
-                "value": 13381.95
+                "MARS": "single",
+                "value": 13379.28
             },
             {
                 "year": 2023,
-                "marital_status": "joint",
-                "value": 26763.9
+                "MARS": "mjoint",
+                "value": 26758.55
             },
             {
                 "year": 2023,
-                "marital_status": "separate",
-                "value": 13381.95
+                "MARS": "mseparate",
+                "value": 13379.28
             },
             {
                 "year": 2023,
-                "marital_status": "headhousehold",
-                "value": 20072.93
+                "MARS": "headhh",
+                "value": 20068.91
             },
             {
                 "year": 2023,
-                "marital_status": "widow",
-                "value": 26763.9
+                "MARS": "widow",
+                "value": 26758.55
             },
             {
                 "year": 2024,
-                "marital_status": "single",
-                "value": 13673.68
+                "MARS": "single",
+                "value": 13674.96
             },
             {
                 "year": 2024,
-                "marital_status": "joint",
-                "value": 27347.36
+                "MARS": "mjoint",
+                "value": 27349.92
             },
             {
                 "year": 2024,
-                "marital_status": "separate",
-                "value": 13673.68
+                "MARS": "mseparate",
+                "value": 13674.96
             },
             {
                 "year": 2024,
-                "marital_status": "headhousehold",
-                "value": 20510.52
+                "MARS": "headhh",
+                "value": 20512.44
             },
             {
                 "year": 2024,
-                "marital_status": "widow",
-                "value": 27347.36
+                "MARS": "widow",
+                "value": 27349.92
             },
             {
                 "year": 2025,
-                "marital_status": "single",
-                "value": 13967.66
+                "MARS": "single",
+                "value": 13963.5
             },
             {
                 "year": 2025,
-                "marital_status": "joint",
-                "value": 27935.33
+                "MARS": "mjoint",
+                "value": 27927.0
             },
             {
                 "year": 2025,
-                "marital_status": "separate",
-                "value": 13967.66
+                "MARS": "mseparate",
+                "value": 13963.5
             },
             {
                 "year": 2025,
-                "marital_status": "headhousehold",
-                "value": 20951.49
+                "MARS": "headhh",
+                "value": 20945.25
             },
             {
                 "year": 2025,
-                "marital_status": "widow",
-                "value": 27935.33
+                "MARS": "widow",
+                "value": 27927.0
             },
             {
                 "year": 2026,
-                "marital_status": "single",
-                "value": 7690.0
+                "MARS": "single",
+                "value": 7685.0
             },
             {
                 "year": 2026,
-                "marital_status": "joint",
-                "value": 15380.0
+                "MARS": "mjoint",
+                "value": 15369.0
             },
             {
                 "year": 2026,
-                "marital_status": "separate",
-                "value": 7690.0
+                "MARS": "mseparate",
+                "value": 7685.0
             },
             {
                 "year": 2026,
-                "marital_status": "headhousehold",
-                "value": 11323.0
+                "MARS": "headhh",
+                "value": 11315.0
             },
             {
                 "year": 2026,
-                "marital_status": "widow",
-                "value": 15380.0
+                "MARS": "widow",
+                "value": 15369.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Standard deduction amount",
         "type": "float",
         "validators": {
@@ -2189,17 +2031,14 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
+        },
+        "section_1": "Standard Deduction",
+        "section_2": "Standard Deduction Amount",
+        "indexed": true,
+        "description": "Amount filing unit can use as a standard deduction.",
+        "notes": ""
     },
-    "_STD_Dep": {
-        "description": "This is the maximum standard deduction for dependents.",
-        "section_1": "",
-        "section_2": "",
-        "irs_ref": "Form 1040, line 8, instructions. ",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+    "STD_Dep": {
         "value": [
             {
                 "year": 2013,
@@ -2226,10 +2065,6 @@
                 "value": 1050.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Standard deduction for dependents",
         "type": "float",
         "validators": {
@@ -2237,173 +2072,166 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
+        },
+        "section_1": "",
+        "section_2": "",
+        "indexed": true,
+        "description": "This is the maximum standard deduction for dependents.",
+        "notes": ""
     },
-    "_STD_Aged": {
-        "description": "To get the standard deduction for aged or blind individuals, taxpayers need to add this value to regular standard deduction.",
-        "section_1": "Standard Deduction",
-        "section_2": "Additional Standard Deduction For Blind And Aged",
-        "irs_ref": "Form 1040, line 8, calculation (the difference of the two tables given in the instruction).",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+    "STD_Aged": {
         "value": [
             {
                 "year": 2013,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 1500.0
             },
             {
                 "year": 2013,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 1200.0
             },
             {
                 "year": 2013,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 1200.0
             },
             {
                 "year": 2013,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 1500.0
             },
             {
                 "year": 2013,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 1500.0
             },
             {
                 "year": 2014,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 1550.0
             },
             {
                 "year": 2014,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 1200.0
             },
             {
                 "year": 2014,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 1200.0
             },
             {
                 "year": 2014,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 1550.0
             },
             {
                 "year": 2014,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 1550.0
             },
             {
                 "year": 2015,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 1550.0
             },
             {
                 "year": 2015,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 1250.0
             },
             {
                 "year": 2015,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 1250.0
             },
             {
                 "year": 2015,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 1550.0
             },
             {
                 "year": 2015,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 1550.0
             },
             {
                 "year": 2016,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 1550.0
             },
             {
                 "year": 2016,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 1250.0
             },
             {
                 "year": 2016,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 1250.0
             },
             {
                 "year": 2016,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 1550.0
             },
             {
                 "year": 2016,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 1550.0
             },
             {
                 "year": 2017,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 1550.0
             },
             {
                 "year": 2017,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 1250.0
             },
             {
                 "year": 2017,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 1250.0
             },
             {
                 "year": 2017,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 1550.0
             },
             {
                 "year": 2017,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 1550.0
             },
             {
                 "year": 2018,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 1600.0
             },
             {
                 "year": 2018,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 1300.0
             },
             {
                 "year": 2018,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 1300.0
             },
             {
                 "year": 2018,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 1600.0
             },
             {
                 "year": 2018,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 1300.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Additional standard deduction for blind and aged",
         "type": "float",
         "validators": {
@@ -2411,27 +2239,20 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
+        },
+        "section_1": "Standard Deduction",
+        "section_2": "Additional Standard Deduction For Blind And Aged",
+        "indexed": true,
+        "description": "To get the standard deduction for aged or blind individuals, taxpayers need to add this value to regular standard deduction.",
+        "notes": ""
     },
-    "_STD_allow_charity_ded_nonitemizers": {
-        "description": "Extends the charitable contributions deduction to taxpayers who take the standard deduction. The same ceilings, floor, and haircuts applied to itemized deduction for charitable contributions also apply here.",
-        "section_1": "",
-        "section_2": "",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+    "STD_allow_charity_ded_nonitemizers": {
         "value": [
             {
                 "year": 2013,
                 "value": false
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Allow standard deduction filers to take the charitable contributions deduction",
         "type": "bool",
         "validators": {
@@ -2439,173 +2260,166 @@
                 "min": false,
                 "max": true
             }
-        }
+        },
+        "section_1": "",
+        "section_2": "",
+        "indexed": false,
+        "description": "Extends the charitable contributions deduction to taxpayers who take the standard deduction. The same ceilings, floor, and haircuts applied to itemized deduction for charitable contributions also apply here.",
+        "notes": ""
     },
-    "_II_credit": {
-        "description": "This credit amount is fully refundable and is phased out based on AGI. It is available to tax units who would otherwise not file.",
-        "section_1": "Refundable Credits",
-        "section_2": "Personal Refundable Credit",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+    "II_credit": {
         "value": [
             {
                 "year": 2013,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 0.0
             },
             {
                 "year": 2013,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 0.0
             },
             {
                 "year": 2013,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 0.0
             },
             {
                 "year": 2013,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 0.0
             },
             {
                 "year": 2013,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 0.0
             },
             {
                 "year": 2014,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 0.0
             },
             {
                 "year": 2014,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 0.0
             },
             {
                 "year": 2014,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 0.0
             },
             {
                 "year": 2014,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 0.0
             },
             {
                 "year": 2014,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 0.0
             },
             {
                 "year": 2015,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 0.0
             },
             {
                 "year": 2015,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 0.0
             },
             {
                 "year": 2015,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 0.0
             },
             {
                 "year": 2015,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 0.0
             },
             {
                 "year": 2015,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 0.0
             },
             {
                 "year": 2016,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 0.0
             },
             {
                 "year": 2016,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 0.0
             },
             {
                 "year": 2016,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 0.0
             },
             {
                 "year": 2016,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 0.0
             },
             {
                 "year": 2016,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 0.0
             },
             {
                 "year": 2017,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 0.0
             },
             {
                 "year": 2017,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 0.0
             },
             {
                 "year": 2017,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 0.0
             },
             {
                 "year": 2017,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 0.0
             },
             {
                 "year": 2017,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 0.0
             },
             {
                 "year": 2018,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 0.0
             },
             {
                 "year": 2018,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 0.0
             },
             {
                 "year": 2018,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 0.0
             },
             {
                 "year": 2018,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 0.0
             },
             {
                 "year": 2018,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Personal refundable credit maximum amount",
         "type": "float",
         "validators": {
@@ -2613,173 +2427,166 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
-    },
-    "_II_credit_ps": {
-        "description": "The personal refundable credit amount will be reduced for taxpayers with AGI higher than this threshold level.",
+        },
         "section_1": "Refundable Credits",
         "section_2": "Personal Refundable Credit",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+        "indexed": true,
+        "description": "This credit amount is fully refundable and is phased out based on AGI. It is available to tax units who would otherwise not file.",
+        "notes": ""
+    },
+    "II_credit_ps": {
         "value": [
             {
                 "year": 2013,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 0.0
             },
             {
                 "year": 2013,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 0.0
             },
             {
                 "year": 2013,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 0.0
             },
             {
                 "year": 2013,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 0.0
             },
             {
                 "year": 2013,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 0.0
             },
             {
                 "year": 2014,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 0.0
             },
             {
                 "year": 2014,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 0.0
             },
             {
                 "year": 2014,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 0.0
             },
             {
                 "year": 2014,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 0.0
             },
             {
                 "year": 2014,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 0.0
             },
             {
                 "year": 2015,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 0.0
             },
             {
                 "year": 2015,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 0.0
             },
             {
                 "year": 2015,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 0.0
             },
             {
                 "year": 2015,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 0.0
             },
             {
                 "year": 2015,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 0.0
             },
             {
                 "year": 2016,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 0.0
             },
             {
                 "year": 2016,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 0.0
             },
             {
                 "year": 2016,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 0.0
             },
             {
                 "year": 2016,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 0.0
             },
             {
                 "year": 2016,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 0.0
             },
             {
                 "year": 2017,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 0.0
             },
             {
                 "year": 2017,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 0.0
             },
             {
                 "year": 2017,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 0.0
             },
             {
                 "year": 2017,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 0.0
             },
             {
                 "year": 2017,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 0.0
             },
             {
                 "year": 2018,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 0.0
             },
             {
                 "year": 2018,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 0.0
             },
             {
                 "year": 2018,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 0.0
             },
             {
                 "year": 2018,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 0.0
             },
             {
                 "year": 2018,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Personal refundable credit phaseout start",
         "type": "float",
         "validators": {
@@ -2787,27 +2594,20 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
-    },
-    "_II_credit_prt": {
-        "description": "The personal refundable credit amount will be reduced at this rate for each dollar of AGI exceeding the _II_credit_ps threshold.",
+        },
         "section_1": "Refundable Credits",
         "section_2": "Personal Refundable Credit",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": true,
+        "description": "The personal refundable credit amount will be reduced for taxpayers with AGI higher than this threshold level.",
+        "notes": ""
+    },
+    "II_credit_prt": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Personal refundable credit phaseout rate",
         "type": "float",
         "validators": {
@@ -2815,173 +2615,166 @@
                 "min": 0,
                 "max": 1
             }
-        }
+        },
+        "section_1": "Refundable Credits",
+        "section_2": "Personal Refundable Credit",
+        "indexed": false,
+        "description": "The personal refundable credit amount will be reduced at this rate for each dollar of AGI exceeding the II_credit_ps threshold.",
+        "notes": ""
     },
-    "_II_credit_nr": {
-        "description": "This credit amount is not refundable and is phased out based on AGI.",
-        "section_1": "Nonrefundable Credits",
-        "section_2": "Personal Nonrefundable Credit",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+    "II_credit_nr": {
         "value": [
             {
                 "year": 2013,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 0.0
             },
             {
                 "year": 2013,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 0.0
             },
             {
                 "year": 2013,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 0.0
             },
             {
                 "year": 2013,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 0.0
             },
             {
                 "year": 2013,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 0.0
             },
             {
                 "year": 2014,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 0.0
             },
             {
                 "year": 2014,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 0.0
             },
             {
                 "year": 2014,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 0.0
             },
             {
                 "year": 2014,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 0.0
             },
             {
                 "year": 2014,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 0.0
             },
             {
                 "year": 2015,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 0.0
             },
             {
                 "year": 2015,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 0.0
             },
             {
                 "year": 2015,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 0.0
             },
             {
                 "year": 2015,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 0.0
             },
             {
                 "year": 2015,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 0.0
             },
             {
                 "year": 2016,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 0.0
             },
             {
                 "year": 2016,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 0.0
             },
             {
                 "year": 2016,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 0.0
             },
             {
                 "year": 2016,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 0.0
             },
             {
                 "year": 2016,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 0.0
             },
             {
                 "year": 2017,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 0.0
             },
             {
                 "year": 2017,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 0.0
             },
             {
                 "year": 2017,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 0.0
             },
             {
                 "year": 2017,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 0.0
             },
             {
                 "year": 2017,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 0.0
             },
             {
                 "year": 2018,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 0.0
             },
             {
                 "year": 2018,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 0.0
             },
             {
                 "year": 2018,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 0.0
             },
             {
                 "year": 2018,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 0.0
             },
             {
                 "year": 2018,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Personal nonrefundable credit maximum amount",
         "type": "float",
         "validators": {
@@ -2989,173 +2782,166 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
-    },
-    "_II_credit_nr_ps": {
-        "description": "The personal nonrefundable credit amount will be reduced for taxpayers with AGI higher than this threshold level.",
+        },
         "section_1": "Nonrefundable Credits",
         "section_2": "Personal Nonrefundable Credit",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+        "indexed": true,
+        "description": "This credit amount is not refundable and is phased out based on AGI.",
+        "notes": ""
+    },
+    "II_credit_nr_ps": {
         "value": [
             {
                 "year": 2013,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 0.0
             },
             {
                 "year": 2013,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 0.0
             },
             {
                 "year": 2013,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 0.0
             },
             {
                 "year": 2013,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 0.0
             },
             {
                 "year": 2013,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 0.0
             },
             {
                 "year": 2014,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 0.0
             },
             {
                 "year": 2014,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 0.0
             },
             {
                 "year": 2014,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 0.0
             },
             {
                 "year": 2014,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 0.0
             },
             {
                 "year": 2014,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 0.0
             },
             {
                 "year": 2015,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 0.0
             },
             {
                 "year": 2015,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 0.0
             },
             {
                 "year": 2015,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 0.0
             },
             {
                 "year": 2015,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 0.0
             },
             {
                 "year": 2015,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 0.0
             },
             {
                 "year": 2016,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 0.0
             },
             {
                 "year": 2016,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 0.0
             },
             {
                 "year": 2016,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 0.0
             },
             {
                 "year": 2016,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 0.0
             },
             {
                 "year": 2016,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 0.0
             },
             {
                 "year": 2017,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 0.0
             },
             {
                 "year": 2017,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 0.0
             },
             {
                 "year": 2017,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 0.0
             },
             {
                 "year": 2017,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 0.0
             },
             {
                 "year": 2017,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 0.0
             },
             {
                 "year": 2018,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 0.0
             },
             {
                 "year": 2018,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 0.0
             },
             {
                 "year": 2018,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 0.0
             },
             {
                 "year": 2018,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 0.0
             },
             {
                 "year": 2018,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Personal nonrefundable credit phaseout start",
         "type": "float",
         "validators": {
@@ -3163,27 +2949,20 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
-    },
-    "_II_credit_nr_prt": {
-        "description": "The personal nonrefundable credit amount will be reduced at this rate for each dollar of AGI exceeding the _II_credit_nr_ps threshold.",
+        },
         "section_1": "Nonrefundable Credits",
         "section_2": "Personal Nonrefundable Credit",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": true,
+        "description": "The personal nonrefundable credit amount will be reduced for taxpayers with AGI higher than this threshold level.",
+        "notes": ""
+    },
+    "II_credit_nr_prt": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Personal nonrefundable credit phaseout rate",
         "type": "float",
         "validators": {
@@ -3191,17 +2970,14 @@
                 "min": 0,
                 "max": 1
             }
-        }
+        },
+        "section_1": "Nonrefundable Credits",
+        "section_2": "Personal Nonrefundable Credit",
+        "indexed": false,
+        "description": "The personal nonrefundable credit amount will be reduced at this rate for each dollar of AGI exceeding the II_credit_nr_ps threshold.",
+        "notes": ""
     },
-    "_ID_Medical_frt": {
-        "description": "Taxpayers are eligible to deduct the portion of their medical expenses exceeding this fraction of AGI.",
-        "section_1": "Itemized Deductions",
-        "section_2": "Medical Expenses",
-        "irs_ref": "Form 1040 Schedule A, line 3, in-line. ",
-        "notes": "When using PUF data, lowering this parameter value may produce unexpected results because PUF e17500 variable is zero below the floor.",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+    "ID_Medical_frt": {
         "value": [
             {
                 "year": 2013,
@@ -3232,10 +3008,6 @@
                 "value": 0.1
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Floor (as a decimal fraction of AGI) for deductible medical expenses.",
         "type": "float",
         "validators": {
@@ -3243,17 +3015,14 @@
                 "min": 0.075,
                 "max": 0.1
             }
-        }
-    },
-    "_ID_Medical_frt_add4aged": {
-        "description": "Elderly taxpayers have this fraction added to the value of the regular floor rate for deductible medical expenses.  This fraction was -0.025 from 2013 to 2016, but that was temporary and it changed to zero beginning in 2017.",
+        },
         "section_1": "Itemized Deductions",
         "section_2": "Medical Expenses",
-        "irs_ref": "Form 1040 Schedule A, line 3, in-line. ",
-        "notes": "When using PUF data, changing this parameter value may produce unexpected results because PUF e17500 variable is zero below the floor.",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "Taxpayers are eligible to deduct the portion of their medical expenses exceeding this fraction of AGI.",
+        "notes": "When using PUF data, lowering this parameter value may produce unexpected results because PUF e17500 variable is zero below the floor."
+    },
+    "ID_Medical_frt_add4aged": {
         "value": [
             {
                 "year": 2013,
@@ -3276,10 +3045,6 @@
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Addon floor (as a decimal fraction of AGI) for deductible medical expenses for elderly filing units.",
         "type": "float",
         "validators": {
@@ -3287,27 +3052,20 @@
                 "min": -0.025,
                 "max": 0.0
             }
-        }
-    },
-    "_ID_Medical_hc": {
-        "description": "This decimal fraction can be applied to limit the amount of medical expense deduction allowed.",
+        },
         "section_1": "Itemized Deductions",
         "section_2": "Medical Expenses",
-        "irs_ref": "",
-        "notes": "This parameter is currently used to eliminate this part of itemized deduction.",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "Elderly taxpayers have this fraction added to the value of the regular floor rate for deductible medical expenses.  This fraction was -0.025 from 2013 to 2016, but that was temporary and it changed to zero beginning in 2017.",
+        "notes": "When using PUF data, changing this parameter value may produce unexpected results because PUF e17500 variable is zero below the floor."
+    },
+    "ID_Medical_hc": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Medical expense deduction haircut",
         "type": "float",
         "validators": {
@@ -3315,173 +3073,166 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_ID_Medical_c": {
-        "description": "The amount of medical expense deduction is limited to this dollar amount.",
+        },
         "section_1": "Itemized Deductions",
         "section_2": "Medical Expenses",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+        "indexed": false,
+        "description": "This decimal fraction can be applied to limit the amount of medical expense deduction allowed.",
+        "notes": ""
+    },
+    "ID_Medical_c": {
         "value": [
             {
                 "year": 2013,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2013,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2013,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2013,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2013,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Ceiling on the amount of medical expense deduction allowed (dollars)",
         "type": "float",
         "validators": {
@@ -3489,27 +3240,20 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
-    },
-    "_ID_StateLocalTax_hc": {
-        "description": "This decimal fraction reduces the state and local income and sales tax deduction.",
+        },
         "section_1": "Itemized Deductions",
-        "section_2": "State And Local Income And Sales Taxes",
-        "irs_ref": "",
-        "notes": "This parameter allows for the implementation of Option 51 from https://www.cbo.gov/sites/default/files/cbofiles/attachments/49638-BudgetOptions.pdf.",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "section_2": "Medical Expenses",
+        "indexed": true,
+        "description": "The amount of medical expense deduction is limited to this dollar amount.",
+        "notes": ""
+    },
+    "ID_StateLocalTax_hc": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "State and local income and sales taxes deduction haircut.",
         "type": "float",
         "validators": {
@@ -3517,27 +3261,20 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_ID_StateLocalTax_crt": {
-        "description": "The total deduction for state and local taxes is capped at this fraction of AGI.",
+        },
         "section_1": "Itemized Deductions",
         "section_2": "State And Local Income And Sales Taxes",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "This decimal fraction reduces the state and local income and sales tax deduction.",
+        "notes": ""
+    },
+    "ID_StateLocalTax_crt": {
         "value": [
             {
                 "year": 2013,
                 "value": 9e+99
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Ceiling (as a decimal fraction of AGI) for the combination of all state and local income and sales tax deductions.",
         "type": "float",
         "validators": {
@@ -3545,173 +3282,166 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
-    },
-    "_ID_StateLocalTax_c": {
-        "description": "The amount of state and local income and sales taxes deduction is limited to this dollar amount.",
+        },
         "section_1": "Itemized Deductions",
         "section_2": "State And Local Income And Sales Taxes",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+        "indexed": false,
+        "description": "The total deduction for state and local taxes is capped at this fraction of AGI.",
+        "notes": ""
+    },
+    "ID_StateLocalTax_c": {
         "value": [
             {
                 "year": 2013,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2013,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2013,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2013,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2013,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Ceiling on the amount of state and local income and sales taxes deduction allowed (dollars)",
         "type": "float",
         "validators": {
@@ -3719,27 +3449,20 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
-    },
-    "_ID_RealEstate_hc": {
-        "description": "This decimal fraction reduces real estate taxes paid eligible to deduct in itemized deduction.",
+        },
         "section_1": "Itemized Deductions",
-        "section_2": "State, Local, And Foreign Real Estate Taxes",
-        "irs_ref": "",
-        "notes": "This parameter is currently used to eliminate real estate taxes paid itemized deduction.",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "section_2": "State And Local Income And Sales Taxes",
+        "indexed": true,
+        "description": "The amount of state and local income and sales taxes deduction is limited to this dollar amount.",
+        "notes": ""
+    },
+    "ID_RealEstate_hc": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "State, local, and foreign real estate taxes deduction haircut.",
         "type": "float",
         "validators": {
@@ -3747,27 +3470,20 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_ID_RealEstate_crt": {
-        "description": "The total deduction for all real estate taxes is capped at this fraction of AGI.",
+        },
         "section_1": "Itemized Deductions",
         "section_2": "State, Local, And Foreign Real Estate Taxes",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "This decimal fraction reduces real estate taxes paid eligible to deduct in itemized deduction.",
+        "notes": ""
+    },
+    "ID_RealEstate_crt": {
         "value": [
             {
                 "year": 2013,
                 "value": 9e+99
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Ceiling (as a decimal fraction of AGI) for the combination of all state, local, and foreign real estate tax deductions.",
         "type": "float",
         "validators": {
@@ -3775,173 +3491,166 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
-    },
-    "_ID_RealEstate_c": {
-        "description": "The amount of real estate taxes deduction is limited to this dollar amount.",
+        },
         "section_1": "Itemized Deductions",
         "section_2": "State, Local, And Foreign Real Estate Taxes",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+        "indexed": false,
+        "description": "The total deduction for all real estate taxes is capped at this fraction of AGI.",
+        "notes": ""
+    },
+    "ID_RealEstate_c": {
         "value": [
             {
                 "year": 2013,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2013,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2013,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2013,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2013,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Ceiling on the amount of state, local, and foreign real estate taxes deduction allowed (dollars)",
         "type": "float",
         "validators": {
@@ -3949,373 +3658,387 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
-    },
-    "_ID_AllTaxes_c": {
-        "description": "The amount of state and local income, sales and real estate tax deductions is limited to this dollar amount.",
+        },
         "section_1": "Itemized Deductions",
-        "section_2": "State And Local Income And Sales Taxes",
-        "irs_ref": "Form 1040 Schedule A, line 5e, in-line.",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+        "section_2": "State, Local, And Foreign Real Estate Taxes",
+        "indexed": true,
+        "description": "The amount of real estate taxes deduction is limited to this dollar amount.",
+        "notes": ""
+    },
+    "ID_AllTaxes_hc": {
         "value": [
             {
                 "year": 2013,
-                "marital_status": "single",
+                "value": 0.0
+            }
+        ],
+        "title": "State and local income, sales, and real estate tax deduction haircut.",
+        "type": "float",
+        "validators": {
+            "range": {
+                "min": 0,
+                "max": 1
+            }
+        },
+        "section_1": "Itemized Deductions",
+        "section_2": "State And Local Taxes And Real Estate Taxes",
+        "indexed": false,
+        "description": "This decimal fraction reduces all state and local taxes paid eligible to deduct in itemized deduction.",
+        "notes": ""
+    },
+    "ID_AllTaxes_c": {
+        "value": [
+            {
+                "year": 2013,
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2013,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2013,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2013,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2013,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 10000.0
             },
             {
                 "year": 2018,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 10000.0
             },
             {
                 "year": 2018,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 5000.0
             },
             {
                 "year": 2018,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 10000.0
             },
             {
                 "year": 2018,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 10000.0
             },
             {
                 "year": 2019,
-                "marital_status": "single",
-                "value": 10229.0
+                "MARS": "single",
+                "value": 10224.0
             },
             {
                 "year": 2019,
-                "marital_status": "joint",
-                "value": 10229.0
+                "MARS": "mjoint",
+                "value": 10224.0
             },
             {
                 "year": 2019,
-                "marital_status": "separate",
-                "value": 5114.5
+                "MARS": "mseparate",
+                "value": 5112.0
             },
             {
                 "year": 2019,
-                "marital_status": "headhousehold",
-                "value": 10229.0
+                "MARS": "headhh",
+                "value": 10224.0
             },
             {
                 "year": 2019,
-                "marital_status": "widow",
-                "value": 10229.0
+                "MARS": "widow",
+                "value": 10224.0
             },
             {
                 "year": 2020,
-                "marital_status": "single",
-                "value": 10432.56
+                "MARS": "single",
+                "value": 10414.17
             },
             {
                 "year": 2020,
-                "marital_status": "joint",
-                "value": 10432.56
+                "MARS": "mjoint",
+                "value": 10414.17
             },
             {
                 "year": 2020,
-                "marital_status": "separate",
-                "value": 5216.28
+                "MARS": "mseparate",
+                "value": 5207.08
             },
             {
                 "year": 2020,
-                "marital_status": "headhousehold",
-                "value": 10432.56
+                "MARS": "headhh",
+                "value": 10414.17
             },
             {
                 "year": 2020,
-                "marital_status": "widow",
-                "value": 10432.56
+                "MARS": "widow",
+                "value": 10414.17
             },
             {
                 "year": 2021,
-                "marital_status": "single",
-                "value": 10666.25
+                "MARS": "single",
+                "value": 10656.82
             },
             {
                 "year": 2021,
-                "marital_status": "joint",
-                "value": 10666.25
+                "MARS": "mjoint",
+                "value": 10656.82
             },
             {
                 "year": 2021,
-                "marital_status": "separate",
-                "value": 5333.12
+                "MARS": "mseparate",
+                "value": 5328.41
             },
             {
                 "year": 2021,
-                "marital_status": "headhousehold",
-                "value": 10666.25
+                "MARS": "headhh",
+                "value": 10656.82
             },
             {
                 "year": 2021,
-                "marital_status": "widow",
-                "value": 10666.25
+                "MARS": "widow",
+                "value": 10656.82
             },
             {
                 "year": 2022,
-                "marital_status": "single",
-                "value": 10908.37
+                "MARS": "single",
+                "value": 10900.86
             },
             {
                 "year": 2022,
-                "marital_status": "joint",
-                "value": 10908.37
+                "MARS": "mjoint",
+                "value": 10900.86
             },
             {
                 "year": 2022,
-                "marital_status": "separate",
-                "value": 5454.19
+                "MARS": "mseparate",
+                "value": 5450.43
             },
             {
                 "year": 2022,
-                "marital_status": "headhousehold",
-                "value": 10908.37
+                "MARS": "headhh",
+                "value": 10900.86
             },
             {
                 "year": 2022,
-                "marital_status": "widow",
-                "value": 10908.37
+                "MARS": "widow",
+                "value": 10900.86
             },
             {
                 "year": 2023,
-                "marital_status": "single",
-                "value": 11151.63
+                "MARS": "single",
+                "value": 11149.4
             },
             {
                 "year": 2023,
-                "marital_status": "joint",
-                "value": 11151.63
+                "MARS": "mjoint",
+                "value": 11149.4
             },
             {
                 "year": 2023,
-                "marital_status": "separate",
-                "value": 5575.81
+                "MARS": "mseparate",
+                "value": 5574.7
             },
             {
                 "year": 2023,
-                "marital_status": "headhousehold",
-                "value": 11151.63
+                "MARS": "headhh",
+                "value": 11149.4
             },
             {
                 "year": 2023,
-                "marital_status": "widow",
-                "value": 11151.63
+                "MARS": "widow",
+                "value": 11149.4
             },
             {
                 "year": 2024,
-                "marital_status": "single",
-                "value": 11394.73
+                "MARS": "single",
+                "value": 11395.8
             },
             {
                 "year": 2024,
-                "marital_status": "joint",
-                "value": 11394.73
+                "MARS": "mjoint",
+                "value": 11395.8
             },
             {
                 "year": 2024,
-                "marital_status": "separate",
-                "value": 5697.37
+                "MARS": "mseparate",
+                "value": 5697.9
             },
             {
                 "year": 2024,
-                "marital_status": "headhousehold",
-                "value": 11394.73
+                "MARS": "headhh",
+                "value": 11395.8
             },
             {
                 "year": 2024,
-                "marital_status": "widow",
-                "value": 11394.73
+                "MARS": "widow",
+                "value": 11395.8
             },
             {
                 "year": 2025,
-                "marital_status": "single",
-                "value": 11639.72
+                "MARS": "single",
+                "value": 11636.25
             },
             {
                 "year": 2025,
-                "marital_status": "joint",
-                "value": 11639.72
+                "MARS": "mjoint",
+                "value": 11636.25
             },
             {
                 "year": 2025,
-                "marital_status": "separate",
-                "value": 5819.86
+                "MARS": "mseparate",
+                "value": 5818.13
             },
             {
                 "year": 2025,
-                "marital_status": "headhousehold",
-                "value": 11639.72
+                "MARS": "headhh",
+                "value": 11636.25
             },
             {
                 "year": 2025,
-                "marital_status": "widow",
-                "value": 11639.72
+                "MARS": "widow",
+                "value": 11636.25
             },
             {
                 "year": 2026,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2026,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2026,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2026,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2026,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Ceiling on the amount of state and local income, sales and real estate tax deductions allowed (dollars)",
         "type": "float",
         "validators": {
@@ -4323,27 +4046,20 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
-    },
-    "_ID_InterestPaid_hc": {
-        "description": "This decimal fraction can be applied to limit the amount of interest paid deduction allowed.",
+        },
         "section_1": "Itemized Deductions",
-        "section_2": "Interest Paid",
-        "irs_ref": "",
-        "notes": "This parameter is currently used to eliminate this part of itemized deduction. ",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "section_2": "State And Local Taxes And Real Estate Taxes",
+        "indexed": true,
+        "description": "The amount of state and local income, sales and real estate tax deductions is limited to this dollar amount.",
+        "notes": ""
+    },
+    "ID_InterestPaid_hc": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Interest paid deduction haircut",
         "type": "float",
         "validators": {
@@ -4351,173 +4067,166 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_ID_InterestPaid_c": {
-        "description": "The amount of interest paid deduction is limited to this dollar amount.",
+        },
         "section_1": "Itemized Deductions",
         "section_2": "Interest Paid",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+        "indexed": false,
+        "description": "This decimal fraction can be applied to limit the amount of interest paid deduction allowed.",
+        "notes": ""
+    },
+    "ID_InterestPaid_c": {
         "value": [
             {
                 "year": 2013,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2013,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2013,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2013,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2013,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Ceiling on the amount of interest paid deduction allowed (dollars)",
         "type": "float",
         "validators": {
@@ -4525,17 +4234,14 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
-    },
-    "_ID_Charity_crt_all": {
-        "description": "The total deduction for charity is capped at this fraction of AGI.",
+        },
         "section_1": "Itemized Deductions",
-        "section_2": "Charity",
-        "irs_ref": "Pub. 526, Limits on Deductions: 50% Limit Organizations. ",
-        "notes": "When using PUF data, raising this parameter value may produce unexpected results because in PUF data the variables e19800 and e20100 are already capped.",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "section_2": "Interest Paid",
+        "indexed": true,
+        "description": "The amount of interest paid deduction is limited to this dollar amount.",
+        "notes": ""
+    },
+    "ID_Charity_crt_all": {
         "value": [
             {
                 "year": 2013,
@@ -4594,10 +4300,6 @@
                 "value": 0.5
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Ceiling (as a decimal fraction of AGI) for all charitable contribution deductions",
         "type": "float",
         "validators": {
@@ -4605,27 +4307,20 @@
                 "min": 0,
                 "max": 0.6
             }
-        }
-    },
-    "_ID_Charity_crt_noncash": {
-        "description": "The deduction for noncash charity contributions is capped at this fraction of AGI.",
+        },
         "section_1": "Itemized Deductions",
         "section_2": "Charity",
-        "irs_ref": "Pub 526, Limits on Deductions: Special 30% Limit for Capital Gain Property. ",
-        "notes": "When using PUF data, raising this parameter value may produce unexpected results because in PUF data the variables e19800 and e20100 are already capped.",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "The total deduction for charity is capped at this fraction of AGI.",
+        "notes": "When using PUF data, raising this parameter value may produce unexpected results because in PUF data the variables e19800 and e20100 are already capped."
+    },
+    "ID_Charity_crt_noncash": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.3
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Ceiling (as a decimal fraction of AGI) for noncash charitable contribution deductions",
         "type": "float",
         "validators": {
@@ -4633,27 +4328,20 @@
                 "min": 0,
                 "max": 0.3
             }
-        }
-    },
-    "_ID_Charity_frt": {
-        "description": "Taxpayers are eligible to deduct the portion of their charitable expense exceeding this fraction of AGI.",
+        },
         "section_1": "Itemized Deductions",
         "section_2": "Charity",
-        "irs_ref": "",
-        "notes": "This parameter allows for implementation of Option 52 from https://www.cbo.gov/sites/default/files/cbofiles/attachments/49638-BudgetOptions.pdf.",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "The deduction for noncash charity contributions is capped at this fraction of AGI.",
+        "notes": "When using PUF data, raising this parameter value may produce unexpected results because in PUF data the variables e19800 and e20100 are already capped."
+    },
+    "ID_Charity_frt": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Floor (as a decimal fraction of AGI) for deductible charitable contributions.",
         "type": "float",
         "validators": {
@@ -4661,27 +4349,20 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_ID_Charity_hc": {
-        "description": "This decimal fraction can be applied to limit the amount of charity expense deduction allowed.",
+        },
         "section_1": "Itemized Deductions",
         "section_2": "Charity",
-        "irs_ref": "",
-        "notes": "This parameter is currently used to eliminate this part of itemized deduction. ",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "Taxpayers are eligible to deduct the portion of their charitable expense exceeding this fraction of AGI.",
+        "notes": "This parameter allows for implementation of Option 52 from https://www.cbo.gov/sites/default/files/cbofiles/attachments/49638-BudgetOptions.pdf."
+    },
+    "ID_Charity_hc": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Charity expense deduction haircut",
         "type": "float",
         "validators": {
@@ -4689,173 +4370,166 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_ID_Charity_c": {
-        "description": "The amount of charity expense deduction is limited to this dollar amount.",
+        },
         "section_1": "Itemized Deductions",
         "section_2": "Charity",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+        "indexed": false,
+        "description": "This decimal fraction can be applied to limit the amount of charity expense deduction allowed.",
+        "notes": ""
+    },
+    "ID_Charity_c": {
         "value": [
             {
                 "year": 2013,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2013,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2013,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2013,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2013,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Ceiling on the amount of charity expense deduction allowed (dollars)",
         "type": "float",
         "validators": {
@@ -4863,48 +4537,41 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
-    },
-    "_ID_Charity_f": {
-        "description": "Only charitable giving in excess of this dollar amount is eligible for a deduction.",
+        },
         "section_1": "Itemized Deductions",
         "section_2": "Charity",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": true,
+        "description": "The amount of charity expense deduction is limited to this dollar amount.",
+        "notes": ""
+    },
+    "ID_Charity_f": {
         "value": [
             {
                 "year": 2013,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 0.0
             },
             {
                 "year": 2013,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 0.0
             },
             {
                 "year": 2013,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 0.0
             },
             {
                 "year": 2013,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 0.0
             },
             {
                 "year": 2013,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Floor on the amount of charity expense deduction allowed (dollars)",
         "type": "float",
         "validators": {
@@ -4912,27 +4579,20 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
-    },
-    "_ID_Casualty_frt": {
-        "description": "Taxpayers are eligible to deduct the portion of their gross casualty losses exceeding this fraction of AGI.",
+        },
         "section_1": "Itemized Deductions",
-        "section_2": "Casualty",
-        "irs_ref": "Form 4684, line 17, in-line.",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "section_2": "Charity",
+        "indexed": false,
+        "description": "Only charitable giving in excess of this dollar amount is eligible for a deduction.",
+        "notes": ""
+    },
+    "ID_Casualty_frt": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.1
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": false
-        },
         "title": "Floor (as a decimal fraction of AGI) for deductible casualty loss.",
         "type": "float",
         "validators": {
@@ -4940,17 +4600,14 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_ID_Casualty_hc": {
-        "description": "This decimal fraction can be applied to limit the amount of casualty expense deduction allowed.",
+        },
         "section_1": "Itemized Deductions",
         "section_2": "Casualty",
-        "irs_ref": "",
-        "notes": "This parameter is currently used to eliminate this part of itemized deduction. ",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "Taxpayers are eligible to deduct the portion of their gross casualty losses exceeding this fraction of AGI.",
+        "notes": ""
+    },
+    "ID_Casualty_hc": {
         "value": [
             {
                 "year": 2013,
@@ -5009,10 +4666,6 @@
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": false
-        },
         "title": "Casualty expense deduction haircut",
         "type": "float",
         "validators": {
@@ -5020,173 +4673,166 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_ID_Casualty_c": {
-        "description": "The amount of casualty expense deduction is limited to this dollar amount.",
+        },
         "section_1": "Itemized Deductions",
         "section_2": "Casualty",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+        "indexed": false,
+        "description": "This decimal fraction can be applied to limit the amount of casualty expense deduction allowed.",
+        "notes": ""
+    },
+    "ID_Casualty_c": {
         "value": [
             {
                 "year": 2013,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2013,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2013,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2013,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2013,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": false
-        },
         "title": "Ceiling on the amount of casualty expense deduction allowed (dollars)",
         "type": "float",
         "validators": {
@@ -5194,27 +4840,20 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
-    },
-    "_ID_Miscellaneous_frt": {
-        "description": "Taxpayers are eligible to deduct the portion of their miscellaneous expense exceeding this fraction of AGI.",
+        },
         "section_1": "Itemized Deductions",
-        "section_2": "Miscellaneous",
-        "irs_ref": "Form 1040 Schedule A, line 16, instructions. ",
-        "notes": "When using PUF data, lowering this parameter value may produce unexpected results because in PUF data the variable e20400 is zero below the floor.",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "section_2": "Casualty",
+        "indexed": true,
+        "description": "The amount of casualty expense deduction is limited to this dollar amount.",
+        "notes": ""
+    },
+    "ID_Miscellaneous_frt": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.02
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Floor (as a decimal fraction of AGI) for deductible miscellaneous expenses.",
         "type": "float",
         "validators": {
@@ -5222,17 +4861,14 @@
                 "min": 0.02,
                 "max": 1
             }
-        }
-    },
-    "_ID_Miscellaneous_hc": {
-        "description": "This decimal fraction can be applied to limit the amount of miscellaneous expense deduction allowed.",
+        },
         "section_1": "Itemized Deductions",
         "section_2": "Miscellaneous",
-        "irs_ref": "",
-        "notes": "This parameter is currently used to eliminate this part of itemized deduction. ",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "Taxpayers are eligible to deduct the portion of their miscellaneous expense exceeding this fraction of AGI.",
+        "notes": "When using PUF data, lowering this parameter value may produce unexpected results because in PUF data the variable e20400 is zero below the floor."
+    },
+    "ID_Miscellaneous_hc": {
         "value": [
             {
                 "year": 2013,
@@ -5291,10 +4927,6 @@
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Miscellaneous expense deduction haircut",
         "type": "float",
         "validators": {
@@ -5302,173 +4934,166 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_ID_Miscellaneous_c": {
-        "description": "The amount of miscellaneous expense deduction is limited to this dollar amount.",
+        },
         "section_1": "Itemized Deductions",
         "section_2": "Miscellaneous",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+        "indexed": false,
+        "description": "This decimal fraction can be applied to limit the amount of miscellaneous expense deduction allowed.",
+        "notes": ""
+    },
+    "ID_Miscellaneous_c": {
         "value": [
             {
                 "year": 2013,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2013,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2013,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2013,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2013,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Ceiling on the amount of miscellaneous expense deduction allowed (dollars)",
         "type": "float",
         "validators": {
@@ -5476,373 +5101,366 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
-    },
-    "_ID_ps": {
-        "description": "The itemized deductions will be reduced for taxpayers with AGI higher than this level.",
+        },
         "section_1": "Itemized Deductions",
-        "section_2": "Itemized Deduction Limitation",
-        "irs_ref": "Form 1040 Schedule A, line 29, instructions.",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+        "section_2": "Miscellaneous",
+        "indexed": true,
+        "description": "The amount of miscellaneous expense deduction is limited to this dollar amount.",
+        "notes": ""
+    },
+    "ID_ps": {
         "value": [
             {
                 "year": 2013,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 250000.0
             },
             {
                 "year": 2013,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 300000.0
             },
             {
                 "year": 2013,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 150000.0
             },
             {
                 "year": 2013,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 275000.0
             },
             {
                 "year": 2013,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 300000.0
             },
             {
                 "year": 2014,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 254200.0
             },
             {
                 "year": 2014,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 305050.0
             },
             {
                 "year": 2014,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 152525.0
             },
             {
                 "year": 2014,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 279650.0
             },
             {
                 "year": 2014,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 305050.0
             },
             {
                 "year": 2015,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 258250.0
             },
             {
                 "year": 2015,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 309900.0
             },
             {
                 "year": 2015,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 154950.0
             },
             {
                 "year": 2015,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 284050.0
             },
             {
                 "year": 2015,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 309900.0
             },
             {
                 "year": 2016,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 259400.0
             },
             {
                 "year": 2016,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 311300.0
             },
             {
                 "year": 2016,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 155650.0
             },
             {
                 "year": 2016,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 285350.0
             },
             {
                 "year": 2016,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 311300.0
             },
             {
                 "year": 2017,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 261500.0
             },
             {
                 "year": 2017,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 313800.0
             },
             {
                 "year": 2017,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 156900.0
             },
             {
                 "year": 2017,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 287650.0
             },
             {
                 "year": 2017,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 313800.0
             },
             {
                 "year": 2018,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2019,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2019,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2019,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2019,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2019,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2020,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2020,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2020,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2020,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2020,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2021,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2021,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2021,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2021,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2021,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2022,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2022,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2022,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2022,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2022,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2023,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2023,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2023,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2023,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2023,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2024,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2024,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2024,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2024,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2024,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2025,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2025,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2025,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2025,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2025,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2026,
-                "marital_status": "single",
-                "value": 316675.0
+                "MARS": "single",
+                "value": 316457.0
             },
             {
                 "year": 2026,
-                "marital_status": "joint",
-                "value": 380010.0
+                "MARS": "mjoint",
+                "value": 379748.0
             },
             {
                 "year": 2026,
-                "marital_status": "separate",
-                "value": 190005.0
+                "MARS": "mseparate",
+                "value": 189874.0
             },
             {
                 "year": 2026,
-                "marital_status": "headhousehold",
-                "value": 348343.0
+                "MARS": "headhh",
+                "value": 348102.0
             },
             {
                 "year": 2026,
-                "marital_status": "widow",
-                "value": 380010.0
+                "MARS": "widow",
+                "value": 379748.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Itemized deduction phaseout AGI start (Pease provision)",
         "type": "float",
         "validators": {
@@ -5850,17 +5468,14 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
-    },
-    "_ID_prt": {
-        "description": "Taxpayers will not be eligible to deduct the full amount of itemized deduction if their AGI is above the phaseout start. The deductible portion would be decreased at this rate for each dollar exceeding the start.",
+        },
         "section_1": "Itemized Deductions",
         "section_2": "Itemized Deduction Limitation",
-        "irs_ref": "Schedule A, line 29, instructions. ",
-        "notes": "This phaseout rate cannot be lower than 0.03 for each dollar, due to limited data on non-itemizers.",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": true,
+        "description": "The itemized deductions will be reduced for taxpayers with AGI higher than this level.",
+        "notes": ""
+    },
+    "ID_prt": {
         "value": [
             {
                 "year": 2013,
@@ -5919,10 +5534,6 @@
                 "value": 0.03
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Itemized deduction phaseout rate (Pease provision)",
         "type": "float",
         "validators": {
@@ -5930,17 +5541,14 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_ID_crt": {
-        "description": "The phaseout amount is capped at this fraction of the original total deduction.",
+        },
         "section_1": "Itemized Deductions",
         "section_2": "Itemized Deduction Limitation",
-        "irs_ref": "Form 1040 Schedule A, line 17, instructions. ",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "Taxpayers will not be eligible to deduct the full amount of itemized deduction if their AGI is above the phaseout start. The deductible portion would be decreased at this rate for each dollar exceeding the start.",
+        "notes": "This phaseout rate cannot be lower than 0.03 for each dollar, due to limited data on non-itemizers."
+    },
+    "ID_crt": {
         "value": [
             {
                 "year": 2013,
@@ -5999,10 +5607,6 @@
                 "value": 0.8
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Itemized deduction maximum phaseout as a decimal fraction of total itemized deductions (Pease provision)",
         "type": "float",
         "validators": {
@@ -6010,27 +5614,20 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_ID_BenefitSurtax_trt": {
-        "description": "The benefit from specified itemized deductions exceeding the credit is taxed at this rate. A surtax rate of 1 strictly limits the benefit from specified itemized deductions to the specified credit. In http://www.nber.org/papers/w16921, Feldstein, Feenberg, and MacGuineas propose a credit of 2% of AGI against a 100% tax rate; in their proposal, however, a broader set of tax benefits, including the employer provided health exclusion, would be taxed.",
+        },
         "section_1": "Itemized Deductions",
-        "section_2": "Surtax On Itemized Deduction Benefits Above An AGI Threshold",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "section_2": "Itemized Deduction Limitation",
+        "indexed": false,
+        "description": "The phaseout amount is capped at this fraction of the original total deduction.",
+        "notes": ""
+    },
+    "ID_BenefitSurtax_trt": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Surtax rate on the benefits from specified itemized deductions",
         "type": "float",
         "validators": {
@@ -6038,27 +5635,20 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_ID_BenefitSurtax_crt": {
-        "description": "The surtax on specified itemized deductions applies to benefits in excess of this fraction of AGI. In http://www.nber.org/papers/w16921, Feldstein, Feenberg, and MacGuineas propose a credit of 2% of AGI against a 100% tax rate; in their proposal, however, a broader set of tax benefits, including the employer provided health exclusion, would be taxed.",
+        },
         "section_1": "Itemized Deductions",
         "section_2": "Surtax On Itemized Deduction Benefits Above An AGI Threshold",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "The benefit from specified itemized deductions exceeding the credit is taxed at this rate. A surtax rate of 1 strictly limits the benefit from specified itemized deductions to the specified credit. In http://www.nber.org/papers/w16921, Feldstein, Feenberg, and MacGuineas propose a credit of 2% of AGI against a 100% tax rate; in their proposal, however, a broader set of tax benefits, including the employer provided health exclusion, would be taxed.",
+        "notes": ""
+    },
+    "ID_BenefitSurtax_crt": {
         "value": [
             {
                 "year": 2013,
                 "value": 1.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Credit on itemized deduction benefit surtax (decimal fraction of AGI)",
         "type": "float",
         "validators": {
@@ -6066,173 +5656,166 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_ID_BenefitSurtax_em": {
-        "description": "This amount is subtracted from itemized deduction benefits in the calculation of the itemized deduction benefit surtax. With _ID_BenefitSurtax_crt set to 0.0 and _ID_BenefitSurtax_trt set to 1.0, this amount serves as a dollar limit on the value of itemized deductions.",
+        },
         "section_1": "Itemized Deductions",
         "section_2": "Surtax On Itemized Deduction Benefits Above An AGI Threshold",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+        "indexed": false,
+        "description": "The surtax on specified itemized deductions applies to benefits in excess of this fraction of AGI. In http://www.nber.org/papers/w16921, Feldstein, Feenberg, and MacGuineas propose a credit of 2% of AGI against a 100% tax rate; in their proposal, however, a broader set of tax benefits, including the employer provided health exclusion, would be taxed.",
+        "notes": ""
+    },
+    "ID_BenefitSurtax_em": {
         "value": [
             {
                 "year": 2013,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 0.0
             },
             {
                 "year": 2013,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 0.0
             },
             {
                 "year": 2013,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 0.0
             },
             {
                 "year": 2013,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 0.0
             },
             {
                 "year": 2013,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 0.0
             },
             {
                 "year": 2014,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 0.0
             },
             {
                 "year": 2014,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 0.0
             },
             {
                 "year": 2014,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 0.0
             },
             {
                 "year": 2014,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 0.0
             },
             {
                 "year": 2014,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 0.0
             },
             {
                 "year": 2015,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 0.0
             },
             {
                 "year": 2015,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 0.0
             },
             {
                 "year": 2015,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 0.0
             },
             {
                 "year": 2015,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 0.0
             },
             {
                 "year": 2015,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 0.0
             },
             {
                 "year": 2016,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 0.0
             },
             {
                 "year": 2016,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 0.0
             },
             {
                 "year": 2016,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 0.0
             },
             {
                 "year": 2016,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 0.0
             },
             {
                 "year": 2016,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 0.0
             },
             {
                 "year": 2017,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 0.0
             },
             {
                 "year": 2017,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 0.0
             },
             {
                 "year": 2017,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 0.0
             },
             {
                 "year": 2017,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 0.0
             },
             {
                 "year": 2017,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 0.0
             },
             {
                 "year": 2018,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 0.0
             },
             {
                 "year": 2018,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 0.0
             },
             {
                 "year": 2018,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 0.0
             },
             {
                 "year": 2018,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 0.0
             },
             {
                 "year": 2018,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Exemption for itemized deduction benefit surtax (dollar AGI threshold)",
         "type": "float",
         "validators": {
@@ -6240,36 +5823,33 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
-    },
-    "_ID_BenefitSurtax_Switch": {
-        "description": "The surtax on itemized deduction benefits applies to the benefits derived from the itemized deductions specified with this parameter.",
+        },
         "section_1": "Itemized Deductions",
         "section_2": "Surtax On Itemized Deduction Benefits Above An AGI Threshold",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": true,
+        "description": "This amount is subtracted from itemized deduction benefits in the calculation of the itemized deduction benefit surtax. With ID_BenefitSurtax_crt set to 0.0 and ID_BenefitSurtax_trt set to 1.0, this amount serves as a dollar limit on the value of itemized deductions.",
+        "notes": ""
+    },
+    "ID_BenefitSurtax_Switch": {
         "value": [
             {
                 "year": 2013,
-                "idedtype": "medical",
+                "idedtype": "med",
                 "value": true
             },
             {
                 "year": 2013,
-                "idedtype": "statelocal",
+                "idedtype": "sltx",
                 "value": true
             },
             {
                 "year": 2013,
-                "idedtype": "realestate",
+                "idedtype": "retx",
                 "value": true
             },
             {
                 "year": 2013,
-                "idedtype": "casualty",
+                "idedtype": "cas",
                 "value": true
             },
             {
@@ -6279,19 +5859,15 @@
             },
             {
                 "year": 2013,
-                "idedtype": "interest",
+                "idedtype": "int",
                 "value": true
             },
             {
                 "year": 2013,
-                "idedtype": "charity",
+                "idedtype": "char",
                 "value": true
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Deductions subject to the surtax on itemized deduction benefits",
         "type": "bool",
         "validators": {
@@ -6299,27 +5875,20 @@
                 "min": false,
                 "max": true
             }
-        }
-    },
-    "_ID_BenefitCap_rt": {
-        "description": "The benefit from specified itemized deductions is capped at this percent of the total deductible expenses.",
+        },
         "section_1": "Itemized Deductions",
-        "section_2": "Ceiling On The Benefit Of Itemized Deductions As A Percent Of Deductible Expenses",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "section_2": "Surtax On Itemized Deduction Benefits Above An AGI Threshold",
+        "indexed": false,
+        "description": "The surtax on itemized deduction benefits applies to the benefits derived from the itemized deductions specified with this parameter.",
+        "notes": ""
+    },
+    "ID_BenefitCap_rt": {
         "value": [
             {
                 "year": 2013,
                 "value": 1.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Ceiling on the benefits from itemized deductions; decimal fraction of total deductible expenses",
         "type": "float",
         "validators": {
@@ -6327,36 +5896,33 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_ID_BenefitCap_Switch": {
-        "description": "The cap on itemized deduction benefits applies to the benefits derived from the itemized deductions specified with this parameter.",
+        },
         "section_1": "Itemized Deductions",
         "section_2": "Ceiling On The Benefit Of Itemized Deductions As A Percent Of Deductible Expenses",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "The benefit from specified itemized deductions is capped at this percent of the total deductible expenses.",
+        "notes": ""
+    },
+    "ID_BenefitCap_Switch": {
         "value": [
             {
                 "year": 2013,
-                "idedtype": "medical",
+                "idedtype": "med",
                 "value": true
             },
             {
                 "year": 2013,
-                "idedtype": "statelocal",
+                "idedtype": "sltx",
                 "value": true
             },
             {
                 "year": 2013,
-                "idedtype": "realestate",
+                "idedtype": "retx",
                 "value": true
             },
             {
                 "year": 2013,
-                "idedtype": "casualty",
+                "idedtype": "cas",
                 "value": true
             },
             {
@@ -6366,19 +5932,15 @@
             },
             {
                 "year": 2013,
-                "idedtype": "interest",
+                "idedtype": "int",
                 "value": true
             },
             {
                 "year": 2013,
-                "idedtype": "charity",
+                "idedtype": "char",
                 "value": true
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Deductions subject to the cap on itemized deduction benefits",
         "type": "bool",
         "validators": {
@@ -6386,173 +5948,166 @@
                 "min": false,
                 "max": true
             }
-        }
-    },
-    "_ID_c": {
-        "description": "The amount of itemized deductions is limited to this dollar amount.",
+        },
         "section_1": "Itemized Deductions",
-        "section_2": "Ceiling On The Amount Of Itemized Deductions Allowed",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+        "section_2": "Ceiling On The Benefit Of Itemized Deductions As A Percent Of Deductible Expenses",
+        "indexed": false,
+        "description": "The cap on itemized deduction benefits applies to the benefits derived from the itemized deductions specified with this parameter.",
+        "notes": ""
+    },
+    "ID_c": {
         "value": [
             {
                 "year": 2013,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2013,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2013,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2013,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2013,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Ceiling on the amount of itemized deductions allowed (dollars)",
         "type": "float",
         "validators": {
@@ -6560,27 +6115,20 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
-    },
-    "_ID_AmountCap_rt": {
-        "description": "The gross allowable amount of specified itemized deductions is capped at this percent of AGI.",
+        },
         "section_1": "Itemized Deductions",
         "section_2": "Ceiling On The Amount Of Itemized Deductions Allowed",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": true,
+        "description": "The amount of itemized deductions is limited to this dollar amount.",
+        "notes": ""
+    },
+    "ID_AmountCap_rt": {
         "value": [
             {
                 "year": 2013,
                 "value": 9e+99
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Ceiling on the gross amount of itemized deductions allowed; decimal fraction of AGI",
         "type": "float",
         "validators": {
@@ -6588,36 +6136,33 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
-    },
-    "_ID_AmountCap_Switch": {
-        "description": "The cap on itemized deduction benefits applies to the benefits derived from the itemized deductions specified with this parameter.",
+        },
         "section_1": "Itemized Deductions",
         "section_2": "Ceiling On The Amount Of Itemized Deductions Allowed",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "The gross allowable amount of specified itemized deductions is capped at this percent of AGI.",
+        "notes": ""
+    },
+    "ID_AmountCap_Switch": {
         "value": [
             {
                 "year": 2013,
-                "idedtype": "medical",
+                "idedtype": "med",
                 "value": true
             },
             {
                 "year": 2013,
-                "idedtype": "statelocal",
+                "idedtype": "sltx",
                 "value": true
             },
             {
                 "year": 2013,
-                "idedtype": "realestate",
+                "idedtype": "retx",
                 "value": true
             },
             {
                 "year": 2013,
-                "idedtype": "casualty",
+                "idedtype": "cas",
                 "value": true
             },
             {
@@ -6627,19 +6172,15 @@
             },
             {
                 "year": 2013,
-                "idedtype": "interest",
+                "idedtype": "int",
                 "value": true
             },
             {
                 "year": 2013,
-                "idedtype": "charity",
+                "idedtype": "char",
                 "value": true
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Deductions subject to the cap on itemized deduction benefits",
         "type": "bool",
         "validators": {
@@ -6647,27 +6188,20 @@
                 "min": false,
                 "max": true
             }
-        }
+        },
+        "section_1": "Itemized Deductions",
+        "section_2": "Ceiling On The Amount Of Itemized Deductions Allowed",
+        "indexed": false,
+        "description": "The cap on itemized deduction benefits applies to the benefits derived from the itemized deductions specified with this parameter.",
+        "notes": ""
     },
-    "_CG_rt1": {
-        "description": "The capital gain and dividends (stacked on top of regular income) that are below threshold 1 are taxed at this rate.",
-        "section_1": "Capital Gains And Dividends",
-        "section_2": "Regular - Long Term Capital Gains And Qualified Dividends",
-        "irs_ref": "Form 1040 Schedule D tax worksheet, line 20, in-line. ",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+    "CG_rt1": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Long term capital gain and qualified dividends (regular/non-AMT) rate 1",
         "type": "float",
         "validators": {
@@ -6675,201 +6209,187 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_CG_brk1": {
-        "description": "The gains and dividends (stacked on top of regular income) below this are taxed at capital gain rate 1.",
+        },
         "section_1": "Capital Gains And Dividends",
         "section_2": "Regular - Long Term Capital Gains And Qualified Dividends",
-        "irs_ref": "Form 1040 Schedule D tax worksheet, line 15, in-line. ",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+        "indexed": false,
+        "description": "The capital gain and dividends (stacked on top of regular income) that are below threshold 1 are taxed at this rate.",
+        "notes": ""
+    },
+    "CG_brk1": {
         "value": [
             {
                 "year": 2013,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 36250.0
             },
             {
                 "year": 2013,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 72500.0
             },
             {
                 "year": 2013,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 36250.0
             },
             {
                 "year": 2013,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 48600.0
             },
             {
                 "year": 2013,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 72500.0
             },
             {
                 "year": 2014,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 36900.0
             },
             {
                 "year": 2014,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 73800.0
             },
             {
                 "year": 2014,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 36900.0
             },
             {
                 "year": 2014,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 49400.0
             },
             {
                 "year": 2014,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 73800.0
             },
             {
                 "year": 2015,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 37450.0
             },
             {
                 "year": 2015,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 74900.0
             },
             {
                 "year": 2015,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 37450.0
             },
             {
                 "year": 2015,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 50200.0
             },
             {
                 "year": 2015,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 74900.0
             },
             {
                 "year": 2016,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 37650.0
             },
             {
                 "year": 2016,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 75300.0
             },
             {
                 "year": 2016,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 37650.0
             },
             {
                 "year": 2016,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 50400.0
             },
             {
                 "year": 2016,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 75300.0
             },
             {
                 "year": 2017,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 37950.0
             },
             {
                 "year": 2017,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 75900.0
             },
             {
                 "year": 2017,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 37950.0
             },
             {
                 "year": 2017,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 50800.0
             },
             {
                 "year": 2017,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 75900.0
             },
             {
                 "year": 2018,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 38600.0
             },
             {
                 "year": 2018,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 77200.0
             },
             {
                 "year": 2018,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 38600.0
             },
             {
                 "year": 2018,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 51700.0
             },
             {
                 "year": 2018,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 77200.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Top of long-term capital gains and qualified dividends (regular/non-AMT) tax bracket 1",
         "type": "float",
         "validators": {
             "range": {
                 "min": 0,
-                "max": "_CG_brk2"
+                "max": "CG_brk2"
             }
-        }
-    },
-    "_CG_rt2": {
-        "description": "The capital gain and dividends (stacked on top of regular income) that are below threshold 2 and above threshold 1 are taxed at this rate.",
+        },
         "section_1": "Capital Gains And Dividends",
         "section_2": "Regular - Long Term Capital Gains And Qualified Dividends",
-        "irs_ref": "Form 1040 Schedule D tax worksheet, line 29, in-line. ",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": true,
+        "description": "The gains and dividends (stacked on top of regular income) below this are taxed at capital gain rate 1.",
+        "notes": ""
+    },
+    "CG_rt2": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.15
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Long term capital gain and qualified dividends (regular/non-AMT) rate 2",
         "type": "float",
         "validators": {
@@ -6877,201 +6397,187 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_CG_brk2": {
-        "description": "The gains and dividends (stacked on top of regular income) below this and above top of bracket 1 are taxed at capital gain rate 2.",
+        },
         "section_1": "Capital Gains And Dividends",
         "section_2": "Regular - Long Term Capital Gains And Qualified Dividends",
-        "irs_ref": "Form 1040 Schedule D tax worksheet, line 24, in-line. ",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+        "indexed": false,
+        "description": "The capital gain and dividends (stacked on top of regular income) that are below threshold 2 and above threshold 1 are taxed at this rate.",
+        "notes": ""
+    },
+    "CG_brk2": {
         "value": [
             {
                 "year": 2013,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 400000.0
             },
             {
                 "year": 2013,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 450000.0
             },
             {
                 "year": 2013,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 225000.0
             },
             {
                 "year": 2013,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 425000.0
             },
             {
                 "year": 2013,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 450000.0
             },
             {
                 "year": 2014,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 406750.0
             },
             {
                 "year": 2014,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 457600.0
             },
             {
                 "year": 2014,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 228800.0
             },
             {
                 "year": 2014,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 432200.0
             },
             {
                 "year": 2014,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 457600.0
             },
             {
                 "year": 2015,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 413200.0
             },
             {
                 "year": 2015,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 464850.0
             },
             {
                 "year": 2015,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 232425.0
             },
             {
                 "year": 2015,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 439000.0
             },
             {
                 "year": 2015,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 464850.0
             },
             {
                 "year": 2016,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 415050.0
             },
             {
                 "year": 2016,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 466950.0
             },
             {
                 "year": 2016,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 233475.0
             },
             {
                 "year": 2016,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 441000.0
             },
             {
                 "year": 2016,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 466950.0
             },
             {
                 "year": 2017,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 418400.0
             },
             {
                 "year": 2017,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 470700.0
             },
             {
                 "year": 2017,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 235350.0
             },
             {
                 "year": 2017,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 444550.0
             },
             {
                 "year": 2017,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 470700.0
             },
             {
                 "year": 2018,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 425800.0
             },
             {
                 "year": 2018,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 479000.0
             },
             {
                 "year": 2018,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 239500.0
             },
             {
                 "year": 2018,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 452400.0
             },
             {
                 "year": 2018,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 479000.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Top of long-term capital gains and qualified dividends (regular/non-AMT) tax bracket 2",
         "type": "float",
         "validators": {
             "range": {
-                "min": "_CG_brk1",
-                "max": "_CG_brk3"
+                "min": "CG_brk1",
+                "max": "CG_brk3"
             }
-        }
-    },
-    "_CG_rt3": {
-        "description": "The capital gain and dividends (stacked on top of regular income) that are above threshold 2 and below threshold 3 are taxed at this rate.",
+        },
         "section_1": "Capital Gains And Dividends",
         "section_2": "Regular - Long Term Capital Gains And Qualified Dividends",
-        "irs_ref": "Form 1040 Schedule D tax worksheet, line 32, in-line. ",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": true,
+        "description": "The gains and dividends (stacked on top of regular income) below this and above top of bracket 1 are taxed at capital gain rate 2.",
+        "notes": ""
+    },
+    "CG_rt3": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.2
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Long term capital gain and qualified dividends (regular/non-AMT) rate 3",
         "type": "float",
         "validators": {
@@ -7079,201 +6585,187 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_CG_brk3": {
-        "description": "The gains and dividends (stacked on top of regular income) below this and above top of bracket 2 are taxed at the capital gain rate 3; above this they are taxed at capital gain rate 4.  Default value is essentially infinity.",
+        },
         "section_1": "Capital Gains And Dividends",
         "section_2": "Regular - Long Term Capital Gains And Qualified Dividends",
-        "irs_ref": "Form 1040 Schedule D tax worksheet, line 24, in-line. ",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+        "indexed": false,
+        "description": "The capital gain and dividends (stacked on top of regular income) that are above threshold 2 and below threshold 3 are taxed at this rate.",
+        "notes": ""
+    },
+    "CG_brk3": {
         "value": [
             {
                 "year": 2013,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2013,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2013,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2013,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2013,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Top of long-term capital gains and qualified dividend tax (regular/non-AMT) bracket 3",
         "type": "float",
         "validators": {
             "range": {
-                "min": "_CG_brk2",
+                "min": "CG_brk2",
                 "max": 9e+99
             }
-        }
-    },
-    "_CG_rt4": {
-        "description": "The capital gain and dividends (stacked on top of regular income) that are above threshold 3 are taxed at this rate.",
+        },
         "section_1": "Capital Gains And Dividends",
         "section_2": "Regular - Long Term Capital Gains And Qualified Dividends",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": true,
+        "description": "The gains and dividends (stacked on top of regular income) below this and above top of bracket 2 are taxed at the capital gain rate 3; above this they are taxed at capital gain rate 4.  Default value is essentially infinity.",
+        "notes": ""
+    },
+    "CG_rt4": {
         "value": [
             {
                 "year": 2013,
                 "value": 1.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Long term capital gain and qualified dividends (regular/non-AMT) rate 4",
         "type": "float",
         "validators": {
@@ -7281,27 +6773,20 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_AMT_CG_rt1": {
-        "description": "Capital gain and qualified dividends (stacked on top of regular income) below threshold 1 are taxed at this rate.",
+        },
         "section_1": "Capital Gains And Dividends",
-        "section_2": "AMT - Long Term Capital Gains And Qualified Dividends",
-        "irs_ref": "Form 6251, line 47, in-line. ",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "section_2": "Regular - Long Term Capital Gains And Qualified Dividends",
+        "indexed": false,
+        "description": "The capital gain and dividends (stacked on top of regular income) that are above threshold 3 are taxed at this rate.",
+        "notes": ""
+    },
+    "AMT_CG_rt1": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Long term capital gain and qualified dividends (AMT) rate 1",
         "type": "float",
         "validators": {
@@ -7309,201 +6794,187 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_AMT_CG_brk1": {
-        "description": "The gains and dividends, stacked last, of AMT taxable income below this are taxed at AMT capital gain rate 1.",
+        },
         "section_1": "Capital Gains And Dividends",
         "section_2": "AMT - Long Term Capital Gains And Qualified Dividends",
-        "irs_ref": "Form 6251, line 19, in-line. ",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+        "indexed": false,
+        "description": "Capital gain and qualified dividends (stacked on top of regular income) below threshold 1 are taxed at this rate.",
+        "notes": ""
+    },
+    "AMT_CG_brk1": {
         "value": [
             {
                 "year": 2013,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 36250.0
             },
             {
                 "year": 2013,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 72500.0
             },
             {
                 "year": 2013,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 36250.0
             },
             {
                 "year": 2013,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 48600.0
             },
             {
                 "year": 2013,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 72500.0
             },
             {
                 "year": 2014,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 36900.0
             },
             {
                 "year": 2014,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 73800.0
             },
             {
                 "year": 2014,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 36900.0
             },
             {
                 "year": 2014,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 49400.0
             },
             {
                 "year": 2014,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 73800.0
             },
             {
                 "year": 2015,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 37450.0
             },
             {
                 "year": 2015,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 74900.0
             },
             {
                 "year": 2015,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 37450.0
             },
             {
                 "year": 2015,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 50200.0
             },
             {
                 "year": 2015,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 74900.0
             },
             {
                 "year": 2016,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 37650.0
             },
             {
                 "year": 2016,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 75300.0
             },
             {
                 "year": 2016,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 37650.0
             },
             {
                 "year": 2016,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 50400.0
             },
             {
                 "year": 2016,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 75300.0
             },
             {
                 "year": 2017,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 37950.0
             },
             {
                 "year": 2017,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 75900.0
             },
             {
                 "year": 2017,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 37950.0
             },
             {
                 "year": 2017,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 50800.0
             },
             {
                 "year": 2017,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 75900.0
             },
             {
                 "year": 2018,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 38600.0
             },
             {
                 "year": 2018,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 77200.0
             },
             {
                 "year": 2018,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 38600.0
             },
             {
                 "year": 2018,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 51700.0
             },
             {
                 "year": 2018,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 77200.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Top of long-term capital gains and qualified dividends (AMT) tax bracket 1",
         "type": "float",
         "validators": {
             "range": {
                 "min": 0,
-                "max": "_AMT_CG_brk2"
+                "max": "AMT_CG_brk2"
             }
-        }
-    },
-    "_AMT_CG_rt2": {
+        },
         "section_1": "Capital Gains And Dividends",
         "section_2": "AMT - Long Term Capital Gains And Qualified Dividends",
-        "description": "Capital gain and qualified dividend (stacked on top of regular income) below threshold 2 and above threshold 1 are taxed at this rate.",
-        "irs_ref": "Form 6251, line 31, in-line. ",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": true,
+        "description": "The gains and dividends, stacked last, of AMT taxable income below this are taxed at AMT capital gain rate 1.",
+        "notes": ""
+    },
+    "AMT_CG_rt2": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.15
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Long term capital gain and qualified dividends (AMT) rate 2",
         "type": "float",
         "validators": {
@@ -7511,201 +6982,187 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_AMT_CG_brk2": {
-        "description": "The gains and dividends, stacked last, of AMT taxable income below this threshold and above bracket 1 are taxed at AMT capital gain rate 2.",
+        },
         "section_1": "Capital Gains And Dividends",
         "section_2": "AMT - Long Term Capital Gains And Qualified Dividends",
-        "notes": "",
-        "irs_ref": "Form 6251, line 25, in-line. ",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+        "indexed": false,
+        "description": "Capital gain and qualified dividend (stacked on top of regular income) below threshold 2 and above threshold 1 are taxed at this rate.",
+        "notes": ""
+    },
+    "AMT_CG_brk2": {
         "value": [
             {
                 "year": 2013,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 400000.0
             },
             {
                 "year": 2013,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 450000.0
             },
             {
                 "year": 2013,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 225000.0
             },
             {
                 "year": 2013,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 425000.0
             },
             {
                 "year": 2013,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 450000.0
             },
             {
                 "year": 2014,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 406750.0
             },
             {
                 "year": 2014,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 457600.0
             },
             {
                 "year": 2014,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 228800.0
             },
             {
                 "year": 2014,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 432200.0
             },
             {
                 "year": 2014,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 457600.0
             },
             {
                 "year": 2015,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 413200.0
             },
             {
                 "year": 2015,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 464850.0
             },
             {
                 "year": 2015,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 232425.0
             },
             {
                 "year": 2015,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 439000.0
             },
             {
                 "year": 2015,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 464850.0
             },
             {
                 "year": 2016,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 415050.0
             },
             {
                 "year": 2016,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 466950.0
             },
             {
                 "year": 2016,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 233475.0
             },
             {
                 "year": 2016,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 441000.0
             },
             {
                 "year": 2016,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 466950.0
             },
             {
                 "year": 2017,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 418400.0
             },
             {
                 "year": 2017,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 470700.0
             },
             {
                 "year": 2017,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 235350.0
             },
             {
                 "year": 2017,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 444550.0
             },
             {
                 "year": 2017,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 470700.0
             },
             {
                 "year": 2018,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 425800.0
             },
             {
                 "year": 2018,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 479000.0
             },
             {
                 "year": 2018,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 239500.0
             },
             {
                 "year": 2018,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 452400.0
             },
             {
                 "year": 2018,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 479000.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Top of long-term capital gains and qualified dividends (AMT) tax bracket 2",
         "type": "float",
         "validators": {
             "range": {
-                "min": "_AMT_CG_brk1",
-                "max": "_AMT_CG_brk3"
+                "min": "AMT_CG_brk1",
+                "max": "AMT_CG_brk3"
             }
-        }
-    },
-    "_AMT_CG_rt3": {
-        "description": "The capital gain and qualified dividend (stacked on top of regular income) above threshold 2 and below threshold 3 are taxed at this rate.",
+        },
         "section_1": "Capital Gains And Dividends",
         "section_2": "AMT - Long Term Capital Gains And Qualified Dividends",
-        "irs_ref": "Form 6251, line 34, in-line. ",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": true,
+        "description": "The gains and dividends, stacked last, of AMT taxable income below this threshold and above bracket 1 are taxed at AMT capital gain rate 2.",
+        "notes": ""
+    },
+    "AMT_CG_rt3": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.2
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Long term capital gain and qualified dividends (AMT) rate 3",
         "type": "float",
         "validators": {
@@ -7713,201 +7170,187 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_AMT_CG_brk3": {
-        "description": "The gains and dividends, stacked last, of AMT taxable income below this and above bracket 2 are taxed at capital gain rate 3; above thisthey are taxed at AMT capital gain rate 4.  Default value is essentially infinity.",
+        },
         "section_1": "Capital Gains And Dividends",
         "section_2": "AMT - Long Term Capital Gains And Qualified Dividends",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+        "indexed": false,
+        "description": "The capital gain and qualified dividend (stacked on top of regular income) above threshold 2 and below threshold 3 are taxed at this rate.",
+        "notes": ""
+    },
+    "AMT_CG_brk3": {
         "value": [
             {
                 "year": 2013,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2013,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2013,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2013,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2013,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Long term capital gain and qualified dividends (AMT) threshold 3",
         "type": "float",
         "validators": {
             "range": {
-                "min": "_AMT_CG_brk2",
+                "min": "AMT_CG_brk2",
                 "max": 9e+99
             }
-        }
-    },
-    "_AMT_CG_rt4": {
-        "description": "The capital gain and dividends (stacked on top of regular income) that are above threshold 3 are taxed at this rate.",
+        },
         "section_1": "Capital Gains And Dividends",
         "section_2": "AMT - Long Term Capital Gains And Qualified Dividends",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": true,
+        "description": "The gains and dividends, stacked last, of AMT taxable income below this and above bracket 2 are taxed at capital gain rate 3; above thisthey are taxed at AMT capital gain rate 4.  Default value is essentially infinity.",
+        "notes": ""
+    },
+    "AMT_CG_rt4": {
         "value": [
             {
                 "year": 2013,
                 "value": 1.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": false
-        },
         "title": "Long term capital gain and qualified dividends (AMT) rate 4",
         "type": "float",
         "validators": {
@@ -7915,27 +7358,20 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_CG_nodiff": {
-        "description": "Specifies whether or not long term capital gains and qualified dividends are taxed like regular taxable income.",
+        },
         "section_1": "Capital Gains And Dividends",
-        "section_2": "Tax All Capital Gains And Dividends The Same As Regular Taxable Income",
-        "irs_ref": "Current-law value is zero implying different tax treatment in Schedule D and AMT; a value of one implies same tax treatment in both regular and alternative minimum tax rules, but the same treatment can differ for regular and AMT.",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "section_2": "AMT - Long Term Capital Gains And Qualified Dividends",
+        "indexed": false,
+        "description": "The capital gain and dividends (stacked on top of regular income) that are above threshold 3 are taxed at this rate.",
+        "notes": ""
+    },
+    "CG_nodiff": {
         "value": [
             {
                 "year": 2013,
                 "value": false
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Long term capital gains and qualified dividends taxed no differently than regular taxable income",
         "type": "bool",
         "validators": {
@@ -7943,17 +7379,14 @@
                 "min": false,
                 "max": true
             }
-        }
-    },
-    "_CG_ec": {
-        "description": "Positive value used only if long term capital gains and qualified dividends taxed no differently than regular taxable income.",
+        },
         "section_1": "Capital Gains And Dividends",
         "section_2": "Tax All Capital Gains And Dividends The Same As Regular Taxable Income",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+        "indexed": false,
+        "description": "Specifies whether or not long term capital gains and qualified dividends are taxed like regular taxable income.",
+        "notes": ""
+    },
+    "CG_ec": {
         "value": [
             {
                 "year": 2013,
@@ -7980,10 +7413,6 @@
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Dollar amount of all capital gains and qualified dividends that are excluded from AGI.",
         "type": "float",
         "validators": {
@@ -7991,27 +7420,20 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
-    },
-    "_CG_reinvest_ec_rt": {
-        "description": "Positive value used only if long term capital gains and qualified dividends taxed no differently than regular taxable income.  To limit the exclusion to capital gains and dividends invested within one year, set to statutory exclusion rate times the fraction of capital gains and qualified dividends in excess of the exclusion that are assumed to be reinvested within the year.",
+        },
         "section_1": "Capital Gains And Dividends",
         "section_2": "Tax All Capital Gains And Dividends The Same As Regular Taxable Income",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": true,
+        "description": "Positive value used only if long term capital gains and qualified dividends taxed no differently than regular taxable income.",
+        "notes": ""
+    },
+    "CG_reinvest_ec_rt": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Fraction of all capital gains and qualified dividends in excess of the dollar exclusion that are excluded from AGI.",
         "type": "float",
         "validators": {
@@ -8019,17 +7441,14 @@
                 "min": 0,
                 "max": 1
             }
-        }
+        },
+        "section_1": "Capital Gains And Dividends",
+        "section_2": "Tax All Capital Gains And Dividends The Same As Regular Taxable Income",
+        "indexed": false,
+        "description": "Positive value used only if long term capital gains and qualified dividends taxed no differently than regular taxable income.  To limit the exclusion to capital gains and dividends invested within one year, set to statutory exclusion rate times the fraction of capital gains and qualified dividends in excess of the exclusion that are assumed to be reinvested within the year.",
+        "notes": ""
     },
-    "_II_rt1": {
-        "description": "The lowest tax rate, applied to the portion of taxable income below tax bracket 1.",
-        "section_1": "Personal Income",
-        "section_2": "Regular: Non-AMT, Non-Pass-Through",
-        "irs_ref": "Form 1040, line 11, instruction (Schedule XYZ)",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+    "II_rt1": {
         "value": [
             {
                 "year": 2013,
@@ -8088,10 +7507,6 @@
                 "value": 0.1
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Personal income (regular/non-AMT/non-pass-through) tax rate 1",
         "type": "float",
         "validators": {
@@ -8099,391 +7514,381 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_II_brk1": {
-        "description": "Taxable income below this threshold is taxed at tax rate 1.",
+        },
         "section_1": "Personal Income",
         "section_2": "Regular: Non-AMT, Non-Pass-Through",
-        "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ).",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+        "indexed": false,
+        "description": "The lowest tax rate, applied to the portion of taxable income below tax bracket 1.",
+        "notes": ""
+    },
+    "II_brk1": {
         "value": [
             {
                 "year": 2013,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 8925.0
             },
             {
                 "year": 2013,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 17850.0
             },
             {
                 "year": 2013,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 8925.0
             },
             {
                 "year": 2013,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 12750.0
             },
             {
                 "year": 2013,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 17850.0
             },
             {
                 "year": 2014,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9075.0
             },
             {
                 "year": 2014,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 18150.0
             },
             {
                 "year": 2014,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9075.0
             },
             {
                 "year": 2014,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 12950.0
             },
             {
                 "year": 2014,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 18150.0
             },
             {
                 "year": 2015,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9225.0
             },
             {
                 "year": 2015,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 18450.0
             },
             {
                 "year": 2015,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9225.0
             },
             {
                 "year": 2015,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 13150.0
             },
             {
                 "year": 2015,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 18450.0
             },
             {
                 "year": 2016,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9275.0
             },
             {
                 "year": 2016,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 18550.0
             },
             {
                 "year": 2016,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9275.0
             },
             {
                 "year": 2016,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 13250.0
             },
             {
                 "year": 2016,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 18550.0
             },
             {
                 "year": 2017,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9325.0
             },
             {
                 "year": 2017,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 18650.0
             },
             {
                 "year": 2017,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9325.0
             },
             {
                 "year": 2017,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 13350.0
             },
             {
                 "year": 2017,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 18650.0
             },
             {
                 "year": 2018,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9525.0
             },
             {
                 "year": 2018,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 19050.0
             },
             {
                 "year": 2018,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9525.0
             },
             {
                 "year": 2018,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 13600.0
             },
             {
                 "year": 2018,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 19050.0
             },
             {
                 "year": 2019,
-                "marital_status": "single",
-                "value": 9743.12
+                "MARS": "single",
+                "value": 9738.36
             },
             {
                 "year": 2019,
-                "marital_status": "joint",
-                "value": 19486.24
+                "MARS": "mjoint",
+                "value": 19476.72
             },
             {
                 "year": 2019,
-                "marital_status": "separate",
-                "value": 9743.12
+                "MARS": "mseparate",
+                "value": 9738.36
             },
             {
                 "year": 2019,
-                "marital_status": "headhousehold",
-                "value": 13911.44
+                "MARS": "headhh",
+                "value": 13904.64
             },
             {
                 "year": 2019,
-                "marital_status": "widow",
-                "value": 19486.24
+                "MARS": "widow",
+                "value": 19476.72
             },
             {
                 "year": 2020,
-                "marital_status": "single",
-                "value": 9937.01
+                "MARS": "single",
+                "value": 9919.49
             },
             {
                 "year": 2020,
-                "marital_status": "joint",
-                "value": 19874.02
+                "MARS": "mjoint",
+                "value": 19838.99
             },
             {
                 "year": 2020,
-                "marital_status": "separate",
-                "value": 9937.01
+                "MARS": "mseparate",
+                "value": 9919.49
             },
             {
                 "year": 2020,
-                "marital_status": "headhousehold",
-                "value": 14188.28
+                "MARS": "headhh",
+                "value": 14163.27
             },
             {
                 "year": 2020,
-                "marital_status": "widow",
-                "value": 19874.02
+                "MARS": "widow",
+                "value": 19838.99
             },
             {
                 "year": 2021,
-                "marital_status": "single",
-                "value": 10159.6
+                "MARS": "single",
+                "value": 10150.62
             },
             {
                 "year": 2021,
-                "marital_status": "joint",
-                "value": 20319.2
+                "MARS": "mjoint",
+                "value": 20301.24
             },
             {
                 "year": 2021,
-                "marital_status": "separate",
-                "value": 10159.6
+                "MARS": "mseparate",
+                "value": 10150.62
             },
             {
                 "year": 2021,
-                "marital_status": "headhousehold",
-                "value": 14506.1
+                "MARS": "headhh",
+                "value": 14493.27
             },
             {
                 "year": 2021,
-                "marital_status": "widow",
-                "value": 20319.2
+                "MARS": "widow",
+                "value": 20301.24
             },
             {
                 "year": 2022,
-                "marital_status": "single",
-                "value": 10390.22
+                "MARS": "single",
+                "value": 10383.07
             },
             {
                 "year": 2022,
-                "marital_status": "joint",
-                "value": 20780.45
+                "MARS": "mjoint",
+                "value": 20766.13
             },
             {
                 "year": 2022,
-                "marital_status": "separate",
-                "value": 10390.22
+                "MARS": "mseparate",
+                "value": 10383.07
             },
             {
                 "year": 2022,
-                "marital_status": "headhousehold",
-                "value": 14835.38
+                "MARS": "headhh",
+                "value": 14825.17
             },
             {
                 "year": 2022,
-                "marital_status": "widow",
-                "value": 20780.45
+                "MARS": "widow",
+                "value": 20766.13
             },
             {
                 "year": 2023,
-                "marital_status": "single",
-                "value": 10621.92
+                "MARS": "single",
+                "value": 10619.8
             },
             {
                 "year": 2023,
-                "marital_status": "joint",
-                "value": 21243.85
+                "MARS": "mjoint",
+                "value": 21239.6
             },
             {
                 "year": 2023,
-                "marital_status": "separate",
-                "value": 10621.92
+                "MARS": "mseparate",
+                "value": 10619.8
             },
             {
                 "year": 2023,
-                "marital_status": "headhousehold",
-                "value": 15166.21
+                "MARS": "headhh",
+                "value": 15163.18
             },
             {
                 "year": 2023,
-                "marital_status": "widow",
-                "value": 21243.85
+                "MARS": "widow",
+                "value": 21239.6
             },
             {
                 "year": 2024,
-                "marital_status": "single",
-                "value": 10853.48
+                "MARS": "single",
+                "value": 10854.5
             },
             {
                 "year": 2024,
-                "marital_status": "joint",
-                "value": 21706.97
+                "MARS": "mjoint",
+                "value": 21709.0
             },
             {
                 "year": 2024,
-                "marital_status": "separate",
-                "value": 10853.48
+                "MARS": "mseparate",
+                "value": 10854.5
             },
             {
                 "year": 2024,
-                "marital_status": "headhousehold",
-                "value": 15496.84
+                "MARS": "headhh",
+                "value": 15498.29
             },
             {
                 "year": 2024,
-                "marital_status": "widow",
-                "value": 21706.97
+                "MARS": "widow",
+                "value": 21709.0
             },
             {
                 "year": 2025,
-                "marital_status": "single",
-                "value": 11086.83
+                "MARS": "single",
+                "value": 11083.53
             },
             {
                 "year": 2025,
-                "marital_status": "joint",
-                "value": 22173.66
+                "MARS": "mjoint",
+                "value": 22167.06
             },
             {
                 "year": 2025,
-                "marital_status": "separate",
-                "value": 11086.83
+                "MARS": "mseparate",
+                "value": 11083.53
             },
             {
                 "year": 2025,
-                "marital_status": "headhousehold",
-                "value": 15830.02
+                "MARS": "headhh",
+                "value": 15825.3
             },
             {
                 "year": 2025,
-                "marital_status": "widow",
-                "value": 22173.66
+                "MARS": "widow",
+                "value": 22167.06
             },
             {
                 "year": 2026,
-                "marital_status": "single",
-                "value": 11293.0
+                "MARS": "single",
+                "value": 11285.0
             },
             {
                 "year": 2026,
-                "marital_status": "joint",
-                "value": 22585.0
+                "MARS": "mjoint",
+                "value": 22569.0
             },
             {
                 "year": 2026,
-                "marital_status": "separate",
-                "value": 11293.0
+                "MARS": "mseparate",
+                "value": 11285.0
             },
             {
                 "year": 2026,
-                "marital_status": "headhousehold",
-                "value": 16167.0
+                "MARS": "headhh",
+                "value": 16156.0
             },
             {
                 "year": 2026,
-                "marital_status": "widow",
-                "value": 22585.0
+                "MARS": "widow",
+                "value": 22569.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Personal income (regular/non-AMT/non-pass-through) tax bracket (upper threshold) 1",
         "type": "float",
         "validators": {
             "range": {
                 "min": 0,
-                "max": "_II_brk2"
+                "max": "II_brk2"
             }
-        }
-    },
-    "_II_rt2": {
-        "description": "The second lowest tax rate, applied to the portion of taxable income below tax bracket 2 and above tax bracket 1.",
+        },
         "section_1": "Personal Income",
         "section_2": "Regular: Non-AMT, Non-Pass-Through",
-        "irs_ref": "Form 1040, line 11, instruction (Schedule XYZ)",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": true,
+        "description": "Taxable income below this threshold is taxed at tax rate 1.",
+        "notes": ""
+    },
+    "II_rt2": {
         "value": [
             {
                 "year": 2013,
@@ -8542,10 +7947,6 @@
                 "value": 0.15
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Personal income (regular/non-AMT/non-pass-through) tax rate 2",
         "type": "float",
         "validators": {
@@ -8553,391 +7954,381 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_II_brk2": {
-        "description": "Income below this threshold and above tax bracket 1 is taxed at tax rate 2.",
+        },
         "section_1": "Personal Income",
         "section_2": "Regular: Non-AMT, Non-Pass-Through",
-        "irs_ref": "Form 1040, line 11, instruction (Schedule XYZ).",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+        "indexed": false,
+        "description": "The second lowest tax rate, applied to the portion of taxable income below tax bracket 2 and above tax bracket 1.",
+        "notes": ""
+    },
+    "II_brk2": {
         "value": [
             {
                 "year": 2013,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 36250.0
             },
             {
                 "year": 2013,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 72500.0
             },
             {
                 "year": 2013,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 36250.0
             },
             {
                 "year": 2013,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 48600.0
             },
             {
                 "year": 2013,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 72500.0
             },
             {
                 "year": 2014,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 36900.0
             },
             {
                 "year": 2014,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 73800.0
             },
             {
                 "year": 2014,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 36900.0
             },
             {
                 "year": 2014,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 49400.0
             },
             {
                 "year": 2014,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 73800.0
             },
             {
                 "year": 2015,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 37450.0
             },
             {
                 "year": 2015,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 74900.0
             },
             {
                 "year": 2015,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 37450.0
             },
             {
                 "year": 2015,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 50200.0
             },
             {
                 "year": 2015,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 74900.0
             },
             {
                 "year": 2016,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 37650.0
             },
             {
                 "year": 2016,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 75300.0
             },
             {
                 "year": 2016,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 37650.0
             },
             {
                 "year": 2016,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 50400.0
             },
             {
                 "year": 2016,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 75300.0
             },
             {
                 "year": 2017,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 37950.0
             },
             {
                 "year": 2017,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 75900.0
             },
             {
                 "year": 2017,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 37950.0
             },
             {
                 "year": 2017,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 50800.0
             },
             {
                 "year": 2017,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 75900.0
             },
             {
                 "year": 2018,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 38700.0
             },
             {
                 "year": 2018,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 77400.0
             },
             {
                 "year": 2018,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 38700.0
             },
             {
                 "year": 2018,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 51800.0
             },
             {
                 "year": 2018,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 77400.0
             },
             {
                 "year": 2019,
-                "marital_status": "single",
-                "value": 39586.23
+                "MARS": "single",
+                "value": 39566.88
             },
             {
                 "year": 2019,
-                "marital_status": "joint",
-                "value": 79172.46
+                "MARS": "mjoint",
+                "value": 79133.76
             },
             {
                 "year": 2019,
-                "marital_status": "separate",
-                "value": 39586.23
+                "MARS": "mseparate",
+                "value": 39566.88
             },
             {
                 "year": 2019,
-                "marital_status": "headhousehold",
-                "value": 52986.22
+                "MARS": "headhh",
+                "value": 52960.32
             },
             {
                 "year": 2019,
-                "marital_status": "widow",
-                "value": 79172.46
+                "MARS": "widow",
+                "value": 79133.76
             },
             {
                 "year": 2020,
-                "marital_status": "single",
-                "value": 40374.0
+                "MARS": "single",
+                "value": 40302.82
             },
             {
                 "year": 2020,
-                "marital_status": "joint",
-                "value": 80747.99
+                "MARS": "mjoint",
+                "value": 80605.65
             },
             {
                 "year": 2020,
-                "marital_status": "separate",
-                "value": 40374.0
+                "MARS": "mseparate",
+                "value": 40302.82
             },
             {
                 "year": 2020,
-                "marital_status": "headhousehold",
-                "value": 54040.65
+                "MARS": "headhh",
+                "value": 53945.38
             },
             {
                 "year": 2020,
-                "marital_status": "widow",
-                "value": 80747.99
+                "MARS": "widow",
+                "value": 80605.65
             },
             {
                 "year": 2021,
-                "marital_status": "single",
-                "value": 41278.37
+                "MARS": "single",
+                "value": 41241.88
             },
             {
                 "year": 2021,
-                "marital_status": "joint",
-                "value": 82556.75
+                "MARS": "mjoint",
+                "value": 82483.76
             },
             {
                 "year": 2021,
-                "marital_status": "separate",
-                "value": 41278.37
+                "MARS": "mseparate",
+                "value": 41241.88
             },
             {
                 "year": 2021,
-                "marital_status": "headhousehold",
-                "value": 55251.16
+                "MARS": "headhh",
+                "value": 55202.31
             },
             {
                 "year": 2021,
-                "marital_status": "widow",
-                "value": 82556.75
+                "MARS": "widow",
+                "value": 82483.76
             },
             {
                 "year": 2022,
-                "marital_status": "single",
-                "value": 42215.39
+                "MARS": "single",
+                "value": 42186.32
             },
             {
                 "year": 2022,
-                "marital_status": "joint",
-                "value": 84430.79
+                "MARS": "mjoint",
+                "value": 84372.64
             },
             {
                 "year": 2022,
-                "marital_status": "separate",
-                "value": 42215.39
+                "MARS": "mseparate",
+                "value": 42186.32
             },
             {
                 "year": 2022,
-                "marital_status": "headhousehold",
-                "value": 56505.36
+                "MARS": "headhh",
+                "value": 56466.44
             },
             {
                 "year": 2022,
-                "marital_status": "widow",
-                "value": 84430.79
+                "MARS": "widow",
+                "value": 84372.64
             },
             {
                 "year": 2023,
-                "marital_status": "single",
-                "value": 43156.8
+                "MARS": "single",
+                "value": 43148.17
             },
             {
                 "year": 2023,
-                "marital_status": "joint",
-                "value": 86313.59
+                "MARS": "mjoint",
+                "value": 86296.33
             },
             {
                 "year": 2023,
-                "marital_status": "separate",
-                "value": 43156.8
+                "MARS": "mseparate",
+                "value": 43148.17
             },
             {
                 "year": 2023,
-                "marital_status": "headhousehold",
-                "value": 57765.43
+                "MARS": "headhh",
+                "value": 57753.88
             },
             {
                 "year": 2023,
-                "marital_status": "widow",
-                "value": 86313.59
+                "MARS": "widow",
+                "value": 86296.33
             },
             {
                 "year": 2024,
-                "marital_status": "single",
-                "value": 44097.61
+                "MARS": "single",
+                "value": 44101.74
             },
             {
                 "year": 2024,
-                "marital_status": "joint",
-                "value": 88195.23
+                "MARS": "mjoint",
+                "value": 88203.48
             },
             {
                 "year": 2024,
-                "marital_status": "separate",
-                "value": 44097.61
+                "MARS": "mseparate",
+                "value": 44101.74
             },
             {
                 "year": 2024,
-                "marital_status": "headhousehold",
-                "value": 59024.71
+                "MARS": "headhh",
+                "value": 59030.24
             },
             {
                 "year": 2024,
-                "marital_status": "widow",
-                "value": 88195.23
+                "MARS": "widow",
+                "value": 88203.48
             },
             {
                 "year": 2025,
-                "marital_status": "single",
-                "value": 45045.71
+                "MARS": "single",
+                "value": 45032.29
             },
             {
                 "year": 2025,
-                "marital_status": "joint",
-                "value": 90091.43
+                "MARS": "mjoint",
+                "value": 90064.58
             },
             {
                 "year": 2025,
-                "marital_status": "separate",
-                "value": 45045.71
+                "MARS": "mseparate",
+                "value": 45032.29
             },
             {
                 "year": 2025,
-                "marital_status": "headhousehold",
-                "value": 60293.74
+                "MARS": "headhh",
+                "value": 60275.78
             },
             {
                 "year": 2025,
-                "marital_status": "widow",
-                "value": 90091.43
+                "MARS": "widow",
+                "value": 90064.58
             },
             {
                 "year": 2026,
-                "marital_status": "single",
-                "value": 45957.0
+                "MARS": "single",
+                "value": 45926.0
             },
             {
                 "year": 2026,
-                "marital_status": "joint",
-                "value": 91915.0
+                "MARS": "mjoint",
+                "value": 91851.0
             },
             {
                 "year": 2026,
-                "marital_status": "separate",
-                "value": 45957.0
+                "MARS": "mseparate",
+                "value": 45926.0
             },
             {
                 "year": 2026,
-                "marital_status": "headhousehold",
-                "value": 61519.0
+                "MARS": "headhh",
+                "value": 61476.0
             },
             {
                 "year": 2026,
-                "marital_status": "widow",
-                "value": 91915.0
+                "MARS": "widow",
+                "value": 91851.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Personal income (regular/non-AMT/non-pass-through) tax bracket (upper threshold) 2",
         "type": "float",
         "validators": {
             "range": {
-                "min": "_II_brk1",
-                "max": "_II_brk3"
+                "min": "II_brk1",
+                "max": "II_brk3"
             }
-        }
-    },
-    "_II_rt3": {
-        "description": "The third lowest tax rate, applied to the portion of taxable income below tax bracket 3 and above tax bracket 2.",
+        },
         "section_1": "Personal Income",
         "section_2": "Regular: Non-AMT, Non-Pass-Through",
-        "irs_ref": "Form 1040, line 11, instruction (Schedule XYZ)",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": true,
+        "description": "Income below this threshold and above tax bracket 1 is taxed at tax rate 2.",
+        "notes": ""
+    },
+    "II_rt3": {
         "value": [
             {
                 "year": 2013,
@@ -8996,10 +8387,6 @@
                 "value": 0.25
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Personal income (regular/non-AMT/non-pass-through) tax rate 3",
         "type": "float",
         "validators": {
@@ -9007,391 +8394,381 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_II_brk3": {
-        "description": "Income below this threshold and above tax bracket 2 is taxed at tax rate 3.",
+        },
         "section_1": "Personal Income",
         "section_2": "Regular: Non-AMT, Non-Pass-Through",
-        "irs_ref": "Form 1040, line 11, instruction (Schedule XYZ).",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+        "indexed": false,
+        "description": "The third lowest tax rate, applied to the portion of taxable income below tax bracket 3 and above tax bracket 2.",
+        "notes": ""
+    },
+    "II_brk3": {
         "value": [
             {
                 "year": 2013,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 87850.0
             },
             {
                 "year": 2013,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 146400.0
             },
             {
                 "year": 2013,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 73200.0
             },
             {
                 "year": 2013,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 125450.0
             },
             {
                 "year": 2013,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 146400.0
             },
             {
                 "year": 2014,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 89350.0
             },
             {
                 "year": 2014,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 148850.0
             },
             {
                 "year": 2014,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 74425.0
             },
             {
                 "year": 2014,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 127550.0
             },
             {
                 "year": 2014,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 148850.0
             },
             {
                 "year": 2015,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 90750.0
             },
             {
                 "year": 2015,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 151200.0
             },
             {
                 "year": 2015,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 75600.0
             },
             {
                 "year": 2015,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 129600.0
             },
             {
                 "year": 2015,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 151200.0
             },
             {
                 "year": 2016,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 91150.0
             },
             {
                 "year": 2016,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 151900.0
             },
             {
                 "year": 2016,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 75950.0
             },
             {
                 "year": 2016,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 130150.0
             },
             {
                 "year": 2016,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 151900.0
             },
             {
                 "year": 2017,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 91900.0
             },
             {
                 "year": 2017,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 153100.0
             },
             {
                 "year": 2017,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 76550.0
             },
             {
                 "year": 2017,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 131200.0
             },
             {
                 "year": 2017,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 153100.0
             },
             {
                 "year": 2018,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 82500.0
             },
             {
                 "year": 2018,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 165000.0
             },
             {
                 "year": 2018,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 82500.0
             },
             {
                 "year": 2018,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 82500.0
             },
             {
                 "year": 2018,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 165000.0
             },
             {
                 "year": 2019,
-                "marital_status": "single",
-                "value": 84389.25
+                "MARS": "single",
+                "value": 84348.0
             },
             {
                 "year": 2019,
-                "marital_status": "joint",
-                "value": 168778.5
+                "MARS": "mjoint",
+                "value": 168696.0
             },
             {
                 "year": 2019,
-                "marital_status": "separate",
-                "value": 84389.25
+                "MARS": "mseparate",
+                "value": 84348.0
             },
             {
                 "year": 2019,
-                "marital_status": "headhousehold",
-                "value": 84389.25
+                "MARS": "headhh",
+                "value": 84348.0
             },
             {
                 "year": 2019,
-                "marital_status": "widow",
-                "value": 168778.5
+                "MARS": "widow",
+                "value": 168696.0
             },
             {
                 "year": 2020,
-                "marital_status": "single",
-                "value": 86068.6
+                "MARS": "single",
+                "value": 85916.87
             },
             {
                 "year": 2020,
-                "marital_status": "joint",
-                "value": 172137.19
+                "MARS": "mjoint",
+                "value": 171833.75
             },
             {
                 "year": 2020,
-                "marital_status": "separate",
-                "value": 86068.6
+                "MARS": "mseparate",
+                "value": 85916.87
             },
             {
                 "year": 2020,
-                "marital_status": "headhousehold",
-                "value": 86068.6
+                "MARS": "headhh",
+                "value": 85916.87
             },
             {
                 "year": 2020,
-                "marital_status": "widow",
-                "value": 172137.19
+                "MARS": "widow",
+                "value": 171833.75
             },
             {
                 "year": 2021,
-                "marital_status": "single",
-                "value": 87996.53
+                "MARS": "single",
+                "value": 87918.74
             },
             {
                 "year": 2021,
-                "marital_status": "joint",
-                "value": 175993.07
+                "MARS": "mjoint",
+                "value": 175837.47
             },
             {
                 "year": 2021,
-                "marital_status": "separate",
-                "value": 87996.53
+                "MARS": "mseparate",
+                "value": 87918.74
             },
             {
                 "year": 2021,
-                "marital_status": "headhousehold",
-                "value": 87996.53
+                "MARS": "headhh",
+                "value": 87918.74
             },
             {
                 "year": 2021,
-                "marital_status": "widow",
-                "value": 175993.07
+                "MARS": "widow",
+                "value": 175837.47
             },
             {
                 "year": 2022,
-                "marital_status": "single",
-                "value": 89994.05
+                "MARS": "single",
+                "value": 89932.07
             },
             {
                 "year": 2022,
-                "marital_status": "joint",
-                "value": 179988.11
+                "MARS": "mjoint",
+                "value": 179864.15
             },
             {
                 "year": 2022,
-                "marital_status": "separate",
-                "value": 89994.05
+                "MARS": "mseparate",
+                "value": 89932.07
             },
             {
                 "year": 2022,
-                "marital_status": "headhousehold",
-                "value": 89994.05
+                "MARS": "headhh",
+                "value": 89932.07
             },
             {
                 "year": 2022,
-                "marital_status": "widow",
-                "value": 179988.11
+                "MARS": "widow",
+                "value": 179864.15
             },
             {
                 "year": 2023,
-                "marital_status": "single",
-                "value": 92000.92
+                "MARS": "single",
+                "value": 91982.53
             },
             {
                 "year": 2023,
-                "marital_status": "joint",
-                "value": 184001.84
+                "MARS": "mjoint",
+                "value": 183965.05
             },
             {
                 "year": 2023,
-                "marital_status": "separate",
-                "value": 92000.92
+                "MARS": "mseparate",
+                "value": 91982.53
             },
             {
                 "year": 2023,
-                "marital_status": "headhousehold",
-                "value": 92000.92
+                "MARS": "headhh",
+                "value": 91982.53
             },
             {
                 "year": 2023,
-                "marital_status": "widow",
-                "value": 184001.84
+                "MARS": "widow",
+                "value": 183965.05
             },
             {
                 "year": 2024,
-                "marital_status": "single",
-                "value": 94006.54
+                "MARS": "single",
+                "value": 94015.34
             },
             {
                 "year": 2024,
-                "marital_status": "joint",
-                "value": 188013.08
+                "MARS": "mjoint",
+                "value": 188030.68
             },
             {
                 "year": 2024,
-                "marital_status": "separate",
-                "value": 94006.54
+                "MARS": "mseparate",
+                "value": 94015.34
             },
             {
                 "year": 2024,
-                "marital_status": "headhousehold",
-                "value": 94006.54
+                "MARS": "headhh",
+                "value": 94015.34
             },
             {
                 "year": 2024,
-                "marital_status": "widow",
-                "value": 188013.08
+                "MARS": "widow",
+                "value": 188030.68
             },
             {
                 "year": 2025,
-                "marital_status": "single",
-                "value": 96027.68
+                "MARS": "single",
+                "value": 95999.06
             },
             {
                 "year": 2025,
-                "marital_status": "joint",
-                "value": 192055.36
+                "MARS": "mjoint",
+                "value": 191998.13
             },
             {
                 "year": 2025,
-                "marital_status": "separate",
-                "value": 96027.68
+                "MARS": "mseparate",
+                "value": 95999.06
             },
             {
                 "year": 2025,
-                "marital_status": "headhousehold",
-                "value": 96027.68
+                "MARS": "headhh",
+                "value": 95999.06
             },
             {
                 "year": 2025,
-                "marital_status": "widow",
-                "value": 192055.36
+                "MARS": "widow",
+                "value": 191998.13
             },
             {
                 "year": 2026,
-                "marital_status": "single",
-                "value": 111290.0
+                "MARS": "single",
+                "value": 111214.0
             },
             {
                 "year": 2026,
-                "marital_status": "joint",
-                "value": 185403.0
+                "MARS": "mjoint",
+                "value": 185275.0
             },
             {
                 "year": 2026,
-                "marital_status": "separate",
-                "value": 92702.0
+                "MARS": "mseparate",
+                "value": 92638.0
             },
             {
                 "year": 2026,
-                "marital_status": "headhousehold",
-                "value": 158883.0
+                "MARS": "headhh",
+                "value": 158773.0
             },
             {
                 "year": 2026,
-                "marital_status": "widow",
-                "value": 185403.0
+                "MARS": "widow",
+                "value": 185275.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Personal income (regular/non-AMT/non-pass-through) tax bracket (upper threshold) 3",
         "type": "float",
         "validators": {
             "range": {
-                "min": "_II_brk2",
-                "max": "_II_brk4"
+                "min": "II_brk2",
+                "max": "II_brk4"
             }
-        }
-    },
-    "_II_rt4": {
-        "description": "The tax rate applied to the portion of taxable income below tax bracket 4 and above tax bracket 3.",
+        },
         "section_1": "Personal Income",
         "section_2": "Regular: Non-AMT, Non-Pass-Through",
-        "irs_ref": "Form 1040, line 11, instruction (Schedule XYZ)",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": true,
+        "description": "Income below this threshold and above tax bracket 2 is taxed at tax rate 3.",
+        "notes": ""
+    },
+    "II_rt4": {
         "value": [
             {
                 "year": 2013,
@@ -9450,10 +8827,6 @@
                 "value": 0.28
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Personal income (regular/non-AMT/non-pass-through) tax rate 4",
         "type": "float",
         "validators": {
@@ -9461,391 +8834,381 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_II_brk4": {
-        "description": "Income below this threshold and above tax bracket 3 is taxed at tax rate 4.",
+        },
         "section_1": "Personal Income",
         "section_2": "Regular: Non-AMT, Non-Pass-Through",
-        "irs_ref": "Form 1040, line 11, instruction (Tax Rate Schedules).",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+        "indexed": false,
+        "description": "The tax rate applied to the portion of taxable income below tax bracket 4 and above tax bracket 3.",
+        "notes": ""
+    },
+    "II_brk4": {
         "value": [
             {
                 "year": 2013,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 183250.0
             },
             {
                 "year": 2013,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 223050.0
             },
             {
                 "year": 2013,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 111525.0
             },
             {
                 "year": 2013,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 203150.0
             },
             {
                 "year": 2013,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 223050.0
             },
             {
                 "year": 2014,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 186350.0
             },
             {
                 "year": 2014,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 226850.0
             },
             {
                 "year": 2014,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 113425.0
             },
             {
                 "year": 2014,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 206600.0
             },
             {
                 "year": 2014,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 226850.0
             },
             {
                 "year": 2015,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 189300.0
             },
             {
                 "year": 2015,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 230450.0
             },
             {
                 "year": 2015,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 115225.0
             },
             {
                 "year": 2015,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 209850.0
             },
             {
                 "year": 2015,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 230450.0
             },
             {
                 "year": 2016,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 190150.0
             },
             {
                 "year": 2016,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 231450.0
             },
             {
                 "year": 2016,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 115725.0
             },
             {
                 "year": 2016,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 210800.0
             },
             {
                 "year": 2016,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 231450.0
             },
             {
                 "year": 2017,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 191650.0
             },
             {
                 "year": 2017,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 233350.0
             },
             {
                 "year": 2017,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 116675.0
             },
             {
                 "year": 2017,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 212500.0
             },
             {
                 "year": 2017,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 233350.0
             },
             {
                 "year": 2018,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 157500.0
             },
             {
                 "year": 2018,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 315000.0
             },
             {
                 "year": 2018,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 157500.0
             },
             {
                 "year": 2018,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 157500.0
             },
             {
                 "year": 2018,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 315000.0
             },
             {
                 "year": 2019,
-                "marital_status": "single",
-                "value": 161106.75
+                "MARS": "single",
+                "value": 161028.0
             },
             {
                 "year": 2019,
-                "marital_status": "joint",
-                "value": 322213.5
+                "MARS": "mjoint",
+                "value": 322056.0
             },
             {
                 "year": 2019,
-                "marital_status": "separate",
-                "value": 161106.75
+                "MARS": "mseparate",
+                "value": 161028.0
             },
             {
                 "year": 2019,
-                "marital_status": "headhousehold",
-                "value": 161106.75
+                "MARS": "headhh",
+                "value": 161028.0
             },
             {
                 "year": 2019,
-                "marital_status": "widow",
-                "value": 322213.5
+                "MARS": "widow",
+                "value": 322056.0
             },
             {
                 "year": 2020,
-                "marital_status": "single",
-                "value": 164312.77
+                "MARS": "single",
+                "value": 164023.12
             },
             {
                 "year": 2020,
-                "marital_status": "joint",
-                "value": 328625.55
+                "MARS": "mjoint",
+                "value": 328046.24
             },
             {
                 "year": 2020,
-                "marital_status": "separate",
-                "value": 164312.77
+                "MARS": "mseparate",
+                "value": 164023.12
             },
             {
                 "year": 2020,
-                "marital_status": "headhousehold",
-                "value": 164312.77
+                "MARS": "headhh",
+                "value": 164023.12
             },
             {
                 "year": 2020,
-                "marital_status": "widow",
-                "value": 328625.55
+                "MARS": "widow",
+                "value": 328046.24
             },
             {
                 "year": 2021,
-                "marital_status": "single",
-                "value": 167993.38
+                "MARS": "single",
+                "value": 167844.86
             },
             {
                 "year": 2021,
-                "marital_status": "joint",
-                "value": 335986.76
+                "MARS": "mjoint",
+                "value": 335689.72
             },
             {
                 "year": 2021,
-                "marital_status": "separate",
-                "value": 167993.38
+                "MARS": "mseparate",
+                "value": 167844.86
             },
             {
                 "year": 2021,
-                "marital_status": "headhousehold",
-                "value": 167993.38
+                "MARS": "headhh",
+                "value": 167844.86
             },
             {
                 "year": 2021,
-                "marital_status": "widow",
-                "value": 335986.76
+                "MARS": "widow",
+                "value": 335689.72
             },
             {
                 "year": 2022,
-                "marital_status": "single",
-                "value": 171806.83
+                "MARS": "single",
+                "value": 171688.51
             },
             {
                 "year": 2022,
-                "marital_status": "joint",
-                "value": 343613.66
+                "MARS": "mjoint",
+                "value": 343377.01
             },
             {
                 "year": 2022,
-                "marital_status": "separate",
-                "value": 171806.83
+                "MARS": "mseparate",
+                "value": 171688.51
             },
             {
                 "year": 2022,
-                "marital_status": "headhousehold",
-                "value": 171806.83
+                "MARS": "headhh",
+                "value": 171688.51
             },
             {
                 "year": 2022,
-                "marital_status": "widow",
-                "value": 343613.66
+                "MARS": "widow",
+                "value": 343377.01
             },
             {
                 "year": 2023,
-                "marital_status": "single",
-                "value": 175638.12
+                "MARS": "single",
+                "value": 175603.0
             },
             {
                 "year": 2023,
-                "marital_status": "joint",
-                "value": 351276.25
+                "MARS": "mjoint",
+                "value": 351206.01
             },
             {
                 "year": 2023,
-                "marital_status": "separate",
-                "value": 175638.12
+                "MARS": "mseparate",
+                "value": 175603.0
             },
             {
                 "year": 2023,
-                "marital_status": "headhousehold",
-                "value": 175638.12
+                "MARS": "headhh",
+                "value": 175603.0
             },
             {
                 "year": 2023,
-                "marital_status": "widow",
-                "value": 351276.25
+                "MARS": "widow",
+                "value": 351206.01
             },
             {
                 "year": 2024,
-                "marital_status": "single",
-                "value": 179467.03
+                "MARS": "single",
+                "value": 179483.83
             },
             {
                 "year": 2024,
-                "marital_status": "joint",
-                "value": 358934.07
+                "MARS": "mjoint",
+                "value": 358967.66
             },
             {
                 "year": 2024,
-                "marital_status": "separate",
-                "value": 179467.03
+                "MARS": "mseparate",
+                "value": 179483.83
             },
             {
                 "year": 2024,
-                "marital_status": "headhousehold",
-                "value": 179467.03
+                "MARS": "headhh",
+                "value": 179483.83
             },
             {
                 "year": 2024,
-                "marital_status": "widow",
-                "value": 358934.07
+                "MARS": "widow",
+                "value": 358967.66
             },
             {
                 "year": 2025,
-                "marital_status": "single",
-                "value": 183325.57
+                "MARS": "single",
+                "value": 183270.94
             },
             {
                 "year": 2025,
-                "marital_status": "joint",
-                "value": 366651.15
+                "MARS": "mjoint",
+                "value": 366541.88
             },
             {
                 "year": 2025,
-                "marital_status": "separate",
-                "value": 183325.57
+                "MARS": "mseparate",
+                "value": 183270.94
             },
             {
                 "year": 2025,
-                "marital_status": "headhousehold",
-                "value": 183325.57
+                "MARS": "headhh",
+                "value": 183270.94
             },
             {
                 "year": 2025,
-                "marital_status": "widow",
-                "value": 366651.15
+                "MARS": "widow",
+                "value": 366541.88
             },
             {
                 "year": 2026,
-                "marital_status": "single",
-                "value": 232087.0
+                "MARS": "single",
+                "value": 231927.0
             },
             {
                 "year": 2026,
-                "marital_status": "joint",
-                "value": 282586.0
+                "MARS": "mjoint",
+                "value": 282391.0
             },
             {
                 "year": 2026,
-                "marital_status": "separate",
-                "value": 141293.0
+                "MARS": "mseparate",
+                "value": 141195.0
             },
             {
                 "year": 2026,
-                "marital_status": "headhousehold",
-                "value": 257336.0
+                "MARS": "headhh",
+                "value": 257159.0
             },
             {
                 "year": 2026,
-                "marital_status": "widow",
-                "value": 282586.0
+                "MARS": "widow",
+                "value": 282391.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Personal income (regular/non-AMT/non-pass-through) tax bracket (upper threshold) 4",
         "type": "float",
         "validators": {
             "range": {
-                "min": "_II_brk3",
-                "max": "_II_brk5"
+                "min": "II_brk3",
+                "max": "II_brk5"
             }
-        }
-    },
-    "_II_rt5": {
-        "description": "The third highest tax rate, applied to the portion of taxable income below tax bracket 5 and above tax bracket 4.",
+        },
         "section_1": "Personal Income",
         "section_2": "Regular: Non-AMT, Non-Pass-Through",
-        "irs_ref": "Form 1040, line 11, instruction (Schedule XYZ)",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": true,
+        "description": "Income below this threshold and above tax bracket 3 is taxed at tax rate 4.",
+        "notes": ""
+    },
+    "II_rt5": {
         "value": [
             {
                 "year": 2013,
@@ -9904,10 +9267,6 @@
                 "value": 0.33
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Personal income (regular/non-AMT/non-pass-through) tax rate 5",
         "type": "float",
         "validators": {
@@ -9915,391 +9274,381 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_II_brk5": {
-        "description": "Income below this threshold and above tax bracket 4 is taxed at tax rate 5.",
+        },
         "section_1": "Personal Income",
         "section_2": "Regular: Non-AMT, Non-Pass-Through",
-        "irs_ref": "Form 1040, line 11, instruction (Schedule XYZ).",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+        "indexed": false,
+        "description": "The third highest tax rate, applied to the portion of taxable income below tax bracket 5 and above tax bracket 4.",
+        "notes": ""
+    },
+    "II_brk5": {
         "value": [
             {
                 "year": 2013,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 398350.0
             },
             {
                 "year": 2013,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 398350.0
             },
             {
                 "year": 2013,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 199175.0
             },
             {
                 "year": 2013,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 398350.0
             },
             {
                 "year": 2013,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 398350.0
             },
             {
                 "year": 2014,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 405100.0
             },
             {
                 "year": 2014,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 405100.0
             },
             {
                 "year": 2014,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 202550.0
             },
             {
                 "year": 2014,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 405100.0
             },
             {
                 "year": 2014,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 405100.0
             },
             {
                 "year": 2015,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 411500.0
             },
             {
                 "year": 2015,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 411500.0
             },
             {
                 "year": 2015,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 205750.0
             },
             {
                 "year": 2015,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 411500.0
             },
             {
                 "year": 2015,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 411500.0
             },
             {
                 "year": 2016,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 413350.0
             },
             {
                 "year": 2016,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 413350.0
             },
             {
                 "year": 2016,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 206675.0
             },
             {
                 "year": 2016,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 413350.0
             },
             {
                 "year": 2016,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 413350.0
             },
             {
                 "year": 2017,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 416700.0
             },
             {
                 "year": 2017,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 416700.0
             },
             {
                 "year": 2017,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 208350.0
             },
             {
                 "year": 2017,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 416700.0
             },
             {
                 "year": 2017,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 416700.0
             },
             {
                 "year": 2018,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 200000.0
             },
             {
                 "year": 2018,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 400000.0
             },
             {
                 "year": 2018,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 200000.0
             },
             {
                 "year": 2018,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 200000.0
             },
             {
                 "year": 2018,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 400000.0
             },
             {
                 "year": 2019,
-                "marital_status": "single",
-                "value": 204580.0
+                "MARS": "single",
+                "value": 204480.0
             },
             {
                 "year": 2019,
-                "marital_status": "joint",
-                "value": 409160.0
+                "MARS": "mjoint",
+                "value": 408960.0
             },
             {
                 "year": 2019,
-                "marital_status": "separate",
-                "value": 204580.0
+                "MARS": "mseparate",
+                "value": 204480.0
             },
             {
                 "year": 2019,
-                "marital_status": "headhousehold",
-                "value": 204580.0
+                "MARS": "headhh",
+                "value": 204480.0
             },
             {
                 "year": 2019,
-                "marital_status": "widow",
-                "value": 409160.0
+                "MARS": "widow",
+                "value": 408960.0
             },
             {
                 "year": 2020,
-                "marital_status": "single",
-                "value": 208651.14
+                "MARS": "single",
+                "value": 208283.33
             },
             {
                 "year": 2020,
-                "marital_status": "joint",
-                "value": 417302.28
+                "MARS": "mjoint",
+                "value": 416566.66
             },
             {
                 "year": 2020,
-                "marital_status": "separate",
-                "value": 208651.14
+                "MARS": "mseparate",
+                "value": 208283.33
             },
             {
                 "year": 2020,
-                "marital_status": "headhousehold",
-                "value": 208651.14
+                "MARS": "headhh",
+                "value": 208283.33
             },
             {
                 "year": 2020,
-                "marital_status": "widow",
-                "value": 417302.28
+                "MARS": "widow",
+                "value": 416566.66
             },
             {
                 "year": 2021,
-                "marital_status": "single",
-                "value": 213324.93
+                "MARS": "single",
+                "value": 213136.33
             },
             {
                 "year": 2021,
-                "marital_status": "joint",
-                "value": 426649.86
+                "MARS": "mjoint",
+                "value": 426272.66
             },
             {
                 "year": 2021,
-                "marital_status": "separate",
-                "value": 213324.93
+                "MARS": "mseparate",
+                "value": 213136.33
             },
             {
                 "year": 2021,
-                "marital_status": "headhousehold",
-                "value": 213324.93
+                "MARS": "headhh",
+                "value": 213136.33
             },
             {
                 "year": 2021,
-                "marital_status": "widow",
-                "value": 426649.86
+                "MARS": "widow",
+                "value": 426272.66
             },
             {
                 "year": 2022,
-                "marital_status": "single",
-                "value": 218167.4
+                "MARS": "single",
+                "value": 218017.15
             },
             {
                 "year": 2022,
-                "marital_status": "joint",
-                "value": 436334.81
+                "MARS": "mjoint",
+                "value": 436034.3
             },
             {
                 "year": 2022,
-                "marital_status": "separate",
-                "value": 218167.4
+                "MARS": "mseparate",
+                "value": 218017.15
             },
             {
                 "year": 2022,
-                "marital_status": "headhousehold",
-                "value": 218167.4
+                "MARS": "headhh",
+                "value": 218017.15
             },
             {
                 "year": 2022,
-                "marital_status": "widow",
-                "value": 436334.81
+                "MARS": "widow",
+                "value": 436034.3
             },
             {
                 "year": 2023,
-                "marital_status": "single",
-                "value": 223032.54
+                "MARS": "single",
+                "value": 222987.94
             },
             {
                 "year": 2023,
-                "marital_status": "joint",
-                "value": 446065.07
+                "MARS": "mjoint",
+                "value": 445975.89
             },
             {
                 "year": 2023,
-                "marital_status": "separate",
-                "value": 223032.54
+                "MARS": "mseparate",
+                "value": 222987.94
             },
             {
                 "year": 2023,
-                "marital_status": "headhousehold",
-                "value": 223032.54
+                "MARS": "headhh",
+                "value": 222987.94
             },
             {
                 "year": 2023,
-                "marital_status": "widow",
-                "value": 446065.07
+                "MARS": "widow",
+                "value": 445975.89
             },
             {
                 "year": 2024,
-                "marital_status": "single",
-                "value": 227894.65
+                "MARS": "single",
+                "value": 227915.98
             },
             {
                 "year": 2024,
-                "marital_status": "joint",
-                "value": 455789.29
+                "MARS": "mjoint",
+                "value": 455831.95
             },
             {
                 "year": 2024,
-                "marital_status": "separate",
-                "value": 227894.65
+                "MARS": "mseparate",
+                "value": 227915.98
             },
             {
                 "year": 2024,
-                "marital_status": "headhousehold",
-                "value": 227894.65
+                "MARS": "headhh",
+                "value": 227915.98
             },
             {
                 "year": 2024,
-                "marital_status": "widow",
-                "value": 455789.29
+                "MARS": "widow",
+                "value": 455831.95
             },
             {
                 "year": 2025,
-                "marital_status": "single",
-                "value": 232794.38
+                "MARS": "single",
+                "value": 232725.0
             },
             {
                 "year": 2025,
-                "marital_status": "joint",
-                "value": 465588.76
+                "MARS": "mjoint",
+                "value": 465450.01
             },
             {
                 "year": 2025,
-                "marital_status": "separate",
-                "value": 232794.38
+                "MARS": "mseparate",
+                "value": 232725.0
             },
             {
                 "year": 2025,
-                "marital_status": "headhousehold",
-                "value": 232794.38
+                "MARS": "headhh",
+                "value": 232725.0
             },
             {
                 "year": 2025,
-                "marital_status": "widow",
-                "value": 465588.76
+                "MARS": "widow",
+                "value": 465450.01
             },
             {
                 "year": 2026,
-                "marital_status": "single",
-                "value": 504622.0
+                "MARS": "single",
+                "value": 504273.0
             },
             {
                 "year": 2026,
-                "marital_status": "joint",
-                "value": 504622.0
+                "MARS": "mjoint",
+                "value": 504273.0
             },
             {
                 "year": 2026,
-                "marital_status": "separate",
-                "value": 252311.0
+                "MARS": "mseparate",
+                "value": 252137.0
             },
             {
                 "year": 2026,
-                "marital_status": "headhousehold",
-                "value": 504622.0
+                "MARS": "headhh",
+                "value": 504273.0
             },
             {
                 "year": 2026,
-                "marital_status": "widow",
-                "value": 504622.0
+                "MARS": "widow",
+                "value": 504273.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Personal income (regular/non-AMT/non-pass-through) tax bracket (upper threshold) 5",
         "type": "float",
         "validators": {
             "range": {
-                "min": "_II_brk4",
-                "max": "_II_brk6"
+                "min": "II_brk4",
+                "max": "II_brk6"
             }
-        }
-    },
-    "_II_rt6": {
-        "description": "The second higher tax rate, applied to the portion of taxable income below tax bracket 6 and above tax bracket 5.",
+        },
         "section_1": "Personal Income",
         "section_2": "Regular: Non-AMT, Non-Pass-Through",
-        "irs_ref": "Form 1040, line 11, instruction (Schedule XYZ)",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": true,
+        "description": "Income below this threshold and above tax bracket 4 is taxed at tax rate 5.",
+        "notes": ""
+    },
+    "II_rt6": {
         "value": [
             {
                 "year": 2013,
@@ -10358,10 +9707,6 @@
                 "value": 0.35
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Personal income (regular/non-AMT/non-pass-through) tax rate 6",
         "type": "float",
         "validators": {
@@ -10369,391 +9714,381 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_II_brk6": {
-        "description": "Income below this threshold and above tax bracket 5 is taxed at tax rate 6.",
+        },
         "section_1": "Personal Income",
         "section_2": "Regular: Non-AMT, Non-Pass-Through",
-        "irs_ref": "Form 1040, line 11, instruction (Schedule XYZ).",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+        "indexed": false,
+        "description": "The second higher tax rate, applied to the portion of taxable income below tax bracket 6 and above tax bracket 5.",
+        "notes": ""
+    },
+    "II_brk6": {
         "value": [
             {
                 "year": 2013,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 400000.0
             },
             {
                 "year": 2013,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 450000.0
             },
             {
                 "year": 2013,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 225000.0
             },
             {
                 "year": 2013,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 425000.0
             },
             {
                 "year": 2013,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 450000.0
             },
             {
                 "year": 2014,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 406750.0
             },
             {
                 "year": 2014,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 457600.0
             },
             {
                 "year": 2014,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 228800.0
             },
             {
                 "year": 2014,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 432200.0
             },
             {
                 "year": 2014,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 457600.0
             },
             {
                 "year": 2015,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 413200.0
             },
             {
                 "year": 2015,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 464850.0
             },
             {
                 "year": 2015,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 232425.0
             },
             {
                 "year": 2015,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 439000.0
             },
             {
                 "year": 2015,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 464850.0
             },
             {
                 "year": 2016,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 415050.0
             },
             {
                 "year": 2016,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 466950.0
             },
             {
                 "year": 2016,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 233475.0
             },
             {
                 "year": 2016,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 441000.0
             },
             {
                 "year": 2016,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 466950.0
             },
             {
                 "year": 2017,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 418400.0
             },
             {
                 "year": 2017,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 470700.0
             },
             {
                 "year": 2017,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 235350.0
             },
             {
                 "year": 2017,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 444550.0
             },
             {
                 "year": 2017,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 470700.0
             },
             {
                 "year": 2018,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 500000.0
             },
             {
                 "year": 2018,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 600000.0
             },
             {
                 "year": 2018,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 300000.0
             },
             {
                 "year": 2018,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 500000.0
             },
             {
                 "year": 2018,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 600000.0
             },
             {
                 "year": 2019,
-                "marital_status": "single",
-                "value": 511450.0
+                "MARS": "single",
+                "value": 511200.0
             },
             {
                 "year": 2019,
-                "marital_status": "joint",
-                "value": 613740.0
+                "MARS": "mjoint",
+                "value": 613440.0
             },
             {
                 "year": 2019,
-                "marital_status": "separate",
-                "value": 306870.0
+                "MARS": "mseparate",
+                "value": 306720.0
             },
             {
                 "year": 2019,
-                "marital_status": "headhousehold",
-                "value": 511450.0
+                "MARS": "headhh",
+                "value": 511200.0
             },
             {
                 "year": 2019,
-                "marital_status": "widow",
-                "value": 613740.0
+                "MARS": "widow",
+                "value": 613440.0
             },
             {
                 "year": 2020,
-                "marital_status": "single",
-                "value": 521627.86
+                "MARS": "single",
+                "value": 520708.32
             },
             {
                 "year": 2020,
-                "marital_status": "joint",
-                "value": 625953.43
+                "MARS": "mjoint",
+                "value": 624849.98
             },
             {
                 "year": 2020,
-                "marital_status": "separate",
-                "value": 312976.71
+                "MARS": "mseparate",
+                "value": 312424.99
             },
             {
                 "year": 2020,
-                "marital_status": "headhousehold",
-                "value": 521627.86
+                "MARS": "headhh",
+                "value": 520708.32
             },
             {
                 "year": 2020,
-                "marital_status": "widow",
-                "value": 625953.43
+                "MARS": "widow",
+                "value": 624849.98
             },
             {
                 "year": 2021,
-                "marital_status": "single",
-                "value": 533312.32
+                "MARS": "single",
+                "value": 532840.82
             },
             {
                 "year": 2021,
-                "marital_status": "joint",
-                "value": 639974.78
+                "MARS": "mjoint",
+                "value": 639408.99
             },
             {
                 "year": 2021,
-                "marital_status": "separate",
-                "value": 319987.39
+                "MARS": "mseparate",
+                "value": 319704.49
             },
             {
                 "year": 2021,
-                "marital_status": "headhousehold",
-                "value": 533312.32
+                "MARS": "headhh",
+                "value": 532840.82
             },
             {
                 "year": 2021,
-                "marital_status": "widow",
-                "value": 639974.78
+                "MARS": "widow",
+                "value": 639408.99
             },
             {
                 "year": 2022,
-                "marital_status": "single",
-                "value": 545418.51
+                "MARS": "single",
+                "value": 545042.88
             },
             {
                 "year": 2022,
-                "marital_status": "joint",
-                "value": 654502.21
+                "MARS": "mjoint",
+                "value": 654051.45
             },
             {
                 "year": 2022,
-                "marital_status": "separate",
-                "value": 327251.11
+                "MARS": "mseparate",
+                "value": 327025.73
             },
             {
                 "year": 2022,
-                "marital_status": "headhousehold",
-                "value": 545418.51
+                "MARS": "headhh",
+                "value": 545042.88
             },
             {
                 "year": 2022,
-                "marital_status": "widow",
-                "value": 654502.21
+                "MARS": "widow",
+                "value": 654051.45
             },
             {
                 "year": 2023,
-                "marital_status": "single",
-                "value": 557581.34
+                "MARS": "single",
+                "value": 557469.86
             },
             {
                 "year": 2023,
-                "marital_status": "joint",
-                "value": 669097.61
+                "MARS": "mjoint",
+                "value": 668963.83
             },
             {
                 "year": 2023,
-                "marital_status": "separate",
-                "value": 334548.8
+                "MARS": "mseparate",
+                "value": 334481.91
             },
             {
                 "year": 2023,
-                "marital_status": "headhousehold",
-                "value": 557581.34
+                "MARS": "headhh",
+                "value": 557469.86
             },
             {
                 "year": 2023,
-                "marital_status": "widow",
-                "value": 669097.61
+                "MARS": "widow",
+                "value": 668963.83
             },
             {
                 "year": 2024,
-                "marital_status": "single",
-                "value": 569736.61
+                "MARS": "single",
+                "value": 569789.94
             },
             {
                 "year": 2024,
-                "marital_status": "joint",
-                "value": 683683.94
+                "MARS": "mjoint",
+                "value": 683747.93
             },
             {
                 "year": 2024,
-                "marital_status": "separate",
-                "value": 341841.97
+                "MARS": "mseparate",
+                "value": 341873.96
             },
             {
                 "year": 2024,
-                "marital_status": "headhousehold",
-                "value": 569736.61
+                "MARS": "headhh",
+                "value": 569789.94
             },
             {
                 "year": 2024,
-                "marital_status": "widow",
-                "value": 683683.94
+                "MARS": "widow",
+                "value": 683747.93
             },
             {
                 "year": 2025,
-                "marital_status": "single",
-                "value": 581985.95
+                "MARS": "single",
+                "value": 581812.51
             },
             {
                 "year": 2025,
-                "marital_status": "joint",
-                "value": 698383.14
+                "MARS": "mjoint",
+                "value": 698175.01
             },
             {
                 "year": 2025,
-                "marital_status": "separate",
-                "value": 349191.57
+                "MARS": "mseparate",
+                "value": 349087.5
             },
             {
                 "year": 2025,
-                "marital_status": "headhousehold",
-                "value": 581985.95
+                "MARS": "headhh",
+                "value": 581812.51
             },
             {
                 "year": 2025,
-                "marital_status": "widow",
-                "value": 698383.14
+                "MARS": "widow",
+                "value": 698175.01
             },
             {
                 "year": 2026,
-                "marital_status": "single",
-                "value": 506680.0
+                "MARS": "single",
+                "value": 506331.0
             },
             {
                 "year": 2026,
-                "marital_status": "joint",
-                "value": 570015.0
+                "MARS": "mjoint",
+                "value": 569622.0
             },
             {
                 "year": 2026,
-                "marital_status": "separate",
-                "value": 285008.0
+                "MARS": "mseparate",
+                "value": 284811.0
             },
             {
                 "year": 2026,
-                "marital_status": "headhousehold",
-                "value": 538348.0
+                "MARS": "headhh",
+                "value": 537976.0
             },
             {
                 "year": 2026,
-                "marital_status": "widow",
-                "value": 570015.0
+                "MARS": "widow",
+                "value": 569622.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Personal income (regular/non-AMT/non-pass-through) tax bracket 6",
         "type": "float",
         "validators": {
             "range": {
-                "min": "_II_brk5",
-                "max": "_II_brk7"
+                "min": "II_brk5",
+                "max": "II_brk7"
             }
-        }
-    },
-    "_II_rt7": {
-        "description": "The tax rate applied to the portion of taxable income below tax bracket 7 and above tax bracket 6.",
+        },
         "section_1": "Personal Income",
         "section_2": "Regular: Non-AMT, Non-Pass-Through",
-        "irs_ref": "Form 1040, line 11, instruction (Schedule XYZ)",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": true,
+        "description": "Income below this threshold and above tax bracket 5 is taxed at tax rate 6.",
+        "notes": ""
+    },
+    "II_rt7": {
         "value": [
             {
                 "year": 2013,
@@ -10812,10 +10147,6 @@
                 "value": 0.396
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Personal income (regular/non-AMT/non-pass-through) tax rate 7",
         "type": "float",
         "validators": {
@@ -10823,401 +10154,387 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_II_brk7": {
-        "description": "Income below this threshold and above tax bracket 6 is taxed at tax rate 7; income above this threshold is taxed at tax rate 8.  Default value is essentially infinity.",
+        },
         "section_1": "Personal Income",
         "section_2": "Regular: Non-AMT, Non-Pass-Through",
-        "irs_ref": "Form 1040, line 11, instruction (Schedule XYZ).",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+        "indexed": false,
+        "description": "The tax rate applied to the portion of taxable income below tax bracket 7 and above tax bracket 6.",
+        "notes": ""
+    },
+    "II_brk7": {
         "value": [
             {
                 "year": 2013,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2013,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2013,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2013,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2013,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2019,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2019,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2019,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2019,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2019,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2020,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2020,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2020,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2020,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2020,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2021,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2021,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2021,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2021,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2021,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2022,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2022,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2022,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2022,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2022,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2023,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2023,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2023,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2023,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2023,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2024,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2024,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2024,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2024,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2024,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2025,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2025,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2025,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2025,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2025,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2026,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2026,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2026,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2026,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2026,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Personal income (regular/non-AMT/non-pass-through) tax bracket 7",
         "type": "float",
         "validators": {
             "range": {
-                "min": "_II_brk6",
+                "min": "II_brk6",
                 "max": 9e+99
             }
-        }
-    },
-    "_II_rt8": {
-        "description": "The tax rate applied to the portion of taxable income above tax bracket 7.",
+        },
         "section_1": "Personal Income",
         "section_2": "Regular: Non-AMT, Non-Pass-Through",
-        "irs_ref": "Form 1040, line 11, instruction (Schedule XYZ)",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": true,
+        "description": "Income below this threshold and above tax bracket 6 is taxed at tax rate 7; income above this threshold is taxed at tax rate 8.  Default value is essentially infinity.",
+        "notes": ""
+    },
+    "II_rt8": {
         "value": [
             {
                 "year": 2013,
                 "value": 1.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Personal income (regular/non-AMT/non-pass-through) tax rate 8",
         "type": "float",
         "validators": {
@@ -11225,17 +10542,14 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_PT_rt1": {
-        "description": "The lowest tax rate, applied to the portion of income from sole proprietorships, partnerships and S-corporations below tax bracket 1.",
+        },
         "section_1": "Personal Income",
-        "section_2": "Pass-Through",
-        "irs_ref": "Form 1040, line 11, instruction (Schedule XYZ)",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "section_2": "Regular: Non-AMT, Non-Pass-Through",
+        "indexed": false,
+        "description": "The tax rate applied to the portion of taxable income above tax bracket 7.",
+        "notes": ""
+    },
+    "PT_rt1": {
         "value": [
             {
                 "year": 2013,
@@ -11294,10 +10608,6 @@
                 "value": 0.1
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Pass-through income tax rate 1",
         "type": "float",
         "validators": {
@@ -11305,391 +10615,381 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_PT_brk1": {
-        "description": "Income from sole proprietorships, partnerships and S-corporations below this threshold is taxed at tax rate 1.",
+        },
         "section_1": "Personal Income",
         "section_2": "Pass-Through",
-        "irs_ref": "Form 1040, line 11, instruction (Schedule XYZ).",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+        "indexed": false,
+        "description": "The lowest tax rate, applied to the portion of income from sole proprietorships, partnerships and S-corporations below tax bracket 1.",
+        "notes": ""
+    },
+    "PT_brk1": {
         "value": [
             {
                 "year": 2013,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 8925.0
             },
             {
                 "year": 2013,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 17850.0
             },
             {
                 "year": 2013,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 8925.0
             },
             {
                 "year": 2013,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 12750.0
             },
             {
                 "year": 2013,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 17850.0
             },
             {
                 "year": 2014,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9075.0
             },
             {
                 "year": 2014,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 18150.0
             },
             {
                 "year": 2014,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9075.0
             },
             {
                 "year": 2014,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 12950.0
             },
             {
                 "year": 2014,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 18150.0
             },
             {
                 "year": 2015,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9225.0
             },
             {
                 "year": 2015,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 18450.0
             },
             {
                 "year": 2015,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9225.0
             },
             {
                 "year": 2015,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 13150.0
             },
             {
                 "year": 2015,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 18450.0
             },
             {
                 "year": 2016,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9275.0
             },
             {
                 "year": 2016,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 18550.0
             },
             {
                 "year": 2016,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9275.0
             },
             {
                 "year": 2016,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 13250.0
             },
             {
                 "year": 2016,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 18550.0
             },
             {
                 "year": 2017,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9325.0
             },
             {
                 "year": 2017,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 18650.0
             },
             {
                 "year": 2017,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9325.0
             },
             {
                 "year": 2017,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 13350.0
             },
             {
                 "year": 2017,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 18650.0
             },
             {
                 "year": 2018,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9525.0
             },
             {
                 "year": 2018,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 19050.0
             },
             {
                 "year": 2018,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9525.0
             },
             {
                 "year": 2018,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 13600.0
             },
             {
                 "year": 2018,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 19050.0
             },
             {
                 "year": 2019,
-                "marital_status": "single",
-                "value": 9743.12
+                "MARS": "single",
+                "value": 9738.36
             },
             {
                 "year": 2019,
-                "marital_status": "joint",
-                "value": 19486.24
+                "MARS": "mjoint",
+                "value": 19476.72
             },
             {
                 "year": 2019,
-                "marital_status": "separate",
-                "value": 9743.12
+                "MARS": "mseparate",
+                "value": 9738.36
             },
             {
                 "year": 2019,
-                "marital_status": "headhousehold",
-                "value": 13911.44
+                "MARS": "headhh",
+                "value": 13904.64
             },
             {
                 "year": 2019,
-                "marital_status": "widow",
-                "value": 19486.24
+                "MARS": "widow",
+                "value": 19476.72
             },
             {
                 "year": 2020,
-                "marital_status": "single",
-                "value": 9937.01
+                "MARS": "single",
+                "value": 9919.49
             },
             {
                 "year": 2020,
-                "marital_status": "joint",
-                "value": 19874.02
+                "MARS": "mjoint",
+                "value": 19838.99
             },
             {
                 "year": 2020,
-                "marital_status": "separate",
-                "value": 9937.01
+                "MARS": "mseparate",
+                "value": 9919.49
             },
             {
                 "year": 2020,
-                "marital_status": "headhousehold",
-                "value": 14188.28
+                "MARS": "headhh",
+                "value": 14163.27
             },
             {
                 "year": 2020,
-                "marital_status": "widow",
-                "value": 19874.02
+                "MARS": "widow",
+                "value": 19838.99
             },
             {
                 "year": 2021,
-                "marital_status": "single",
-                "value": 10159.6
+                "MARS": "single",
+                "value": 10150.62
             },
             {
                 "year": 2021,
-                "marital_status": "joint",
-                "value": 20319.2
+                "MARS": "mjoint",
+                "value": 20301.24
             },
             {
                 "year": 2021,
-                "marital_status": "separate",
-                "value": 10159.6
+                "MARS": "mseparate",
+                "value": 10150.62
             },
             {
                 "year": 2021,
-                "marital_status": "headhousehold",
-                "value": 14506.1
+                "MARS": "headhh",
+                "value": 14493.27
             },
             {
                 "year": 2021,
-                "marital_status": "widow",
-                "value": 20319.2
+                "MARS": "widow",
+                "value": 20301.24
             },
             {
                 "year": 2022,
-                "marital_status": "single",
-                "value": 10390.22
+                "MARS": "single",
+                "value": 10383.07
             },
             {
                 "year": 2022,
-                "marital_status": "joint",
-                "value": 20780.45
+                "MARS": "mjoint",
+                "value": 20766.13
             },
             {
                 "year": 2022,
-                "marital_status": "separate",
-                "value": 10390.22
+                "MARS": "mseparate",
+                "value": 10383.07
             },
             {
                 "year": 2022,
-                "marital_status": "headhousehold",
-                "value": 14835.38
+                "MARS": "headhh",
+                "value": 14825.17
             },
             {
                 "year": 2022,
-                "marital_status": "widow",
-                "value": 20780.45
+                "MARS": "widow",
+                "value": 20766.13
             },
             {
                 "year": 2023,
-                "marital_status": "single",
-                "value": 10621.92
+                "MARS": "single",
+                "value": 10619.8
             },
             {
                 "year": 2023,
-                "marital_status": "joint",
-                "value": 21243.85
+                "MARS": "mjoint",
+                "value": 21239.6
             },
             {
                 "year": 2023,
-                "marital_status": "separate",
-                "value": 10621.92
+                "MARS": "mseparate",
+                "value": 10619.8
             },
             {
                 "year": 2023,
-                "marital_status": "headhousehold",
-                "value": 15166.21
+                "MARS": "headhh",
+                "value": 15163.18
             },
             {
                 "year": 2023,
-                "marital_status": "widow",
-                "value": 21243.85
+                "MARS": "widow",
+                "value": 21239.6
             },
             {
                 "year": 2024,
-                "marital_status": "single",
-                "value": 10853.48
+                "MARS": "single",
+                "value": 10854.5
             },
             {
                 "year": 2024,
-                "marital_status": "joint",
-                "value": 21706.97
+                "MARS": "mjoint",
+                "value": 21709.0
             },
             {
                 "year": 2024,
-                "marital_status": "separate",
-                "value": 10853.48
+                "MARS": "mseparate",
+                "value": 10854.5
             },
             {
                 "year": 2024,
-                "marital_status": "headhousehold",
-                "value": 15496.84
+                "MARS": "headhh",
+                "value": 15498.29
             },
             {
                 "year": 2024,
-                "marital_status": "widow",
-                "value": 21706.97
+                "MARS": "widow",
+                "value": 21709.0
             },
             {
                 "year": 2025,
-                "marital_status": "single",
-                "value": 11086.83
+                "MARS": "single",
+                "value": 11083.53
             },
             {
                 "year": 2025,
-                "marital_status": "joint",
-                "value": 22173.66
+                "MARS": "mjoint",
+                "value": 22167.06
             },
             {
                 "year": 2025,
-                "marital_status": "separate",
-                "value": 11086.83
+                "MARS": "mseparate",
+                "value": 11083.53
             },
             {
                 "year": 2025,
-                "marital_status": "headhousehold",
-                "value": 15830.02
+                "MARS": "headhh",
+                "value": 15825.3
             },
             {
                 "year": 2025,
-                "marital_status": "widow",
-                "value": 22173.66
+                "MARS": "widow",
+                "value": 22167.06
             },
             {
                 "year": 2026,
-                "marital_status": "single",
-                "value": 11293.0
+                "MARS": "single",
+                "value": 11285.0
             },
             {
                 "year": 2026,
-                "marital_status": "joint",
-                "value": 22585.0
+                "MARS": "mjoint",
+                "value": 22569.0
             },
             {
                 "year": 2026,
-                "marital_status": "separate",
-                "value": 11293.0
+                "MARS": "mseparate",
+                "value": 11285.0
             },
             {
                 "year": 2026,
-                "marital_status": "headhousehold",
-                "value": 16167.0
+                "MARS": "headhh",
+                "value": 16156.0
             },
             {
                 "year": 2026,
-                "marital_status": "widow",
-                "value": 22585.0
+                "MARS": "widow",
+                "value": 22569.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Pass-through income tax bracket (upper threshold) 1",
         "type": "float",
         "validators": {
             "range": {
                 "min": 0,
-                "max": "_PT_brk2"
+                "max": "PT_brk2"
             }
-        }
-    },
-    "_PT_rt2": {
-        "description": "The second lowest tax rate, applied to the portion of income from sole proprietorships, partnerships and S-corporations below tax bracket 2 and above tax bracket 1.",
+        },
         "section_1": "Personal Income",
         "section_2": "Pass-Through",
-        "irs_ref": "Form 1040, line 11, instruction (Schedule XYZ)",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": true,
+        "description": "Income from sole proprietorships, partnerships and S-corporations below this threshold is taxed at tax rate 1.",
+        "notes": ""
+    },
+    "PT_rt2": {
         "value": [
             {
                 "year": 2013,
@@ -11748,10 +11048,6 @@
                 "value": 0.15
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Pass-through income tax rate 2",
         "type": "float",
         "validators": {
@@ -11759,391 +11055,381 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_PT_brk2": {
-        "description": "Income from sole proprietorships, partnerships and S-corporations below this threshold and above tax bracket 1 is taxed at tax rate 2.",
+        },
         "section_1": "Personal Income",
         "section_2": "Pass-Through",
-        "irs_ref": "Form 1040, line 11, instruction (Schedule XYZ).",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+        "indexed": false,
+        "description": "The second lowest tax rate, applied to the portion of income from sole proprietorships, partnerships and S-corporations below tax bracket 2 and above tax bracket 1.",
+        "notes": ""
+    },
+    "PT_brk2": {
         "value": [
             {
                 "year": 2013,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 36250.0
             },
             {
                 "year": 2013,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 72500.0
             },
             {
                 "year": 2013,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 36250.0
             },
             {
                 "year": 2013,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 48600.0
             },
             {
                 "year": 2013,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 72500.0
             },
             {
                 "year": 2014,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 36900.0
             },
             {
                 "year": 2014,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 73800.0
             },
             {
                 "year": 2014,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 36900.0
             },
             {
                 "year": 2014,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 49400.0
             },
             {
                 "year": 2014,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 73800.0
             },
             {
                 "year": 2015,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 37450.0
             },
             {
                 "year": 2015,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 74900.0
             },
             {
                 "year": 2015,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 37450.0
             },
             {
                 "year": 2015,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 50200.0
             },
             {
                 "year": 2015,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 74900.0
             },
             {
                 "year": 2016,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 37650.0
             },
             {
                 "year": 2016,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 75300.0
             },
             {
                 "year": 2016,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 37650.0
             },
             {
                 "year": 2016,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 50400.0
             },
             {
                 "year": 2016,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 75300.0
             },
             {
                 "year": 2017,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 37950.0
             },
             {
                 "year": 2017,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 75900.0
             },
             {
                 "year": 2017,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 37950.0
             },
             {
                 "year": 2017,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 50800.0
             },
             {
                 "year": 2017,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 75900.0
             },
             {
                 "year": 2018,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 38700.0
             },
             {
                 "year": 2018,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 77400.0
             },
             {
                 "year": 2018,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 38700.0
             },
             {
                 "year": 2018,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 51800.0
             },
             {
                 "year": 2018,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 77400.0
             },
             {
                 "year": 2019,
-                "marital_status": "single",
-                "value": 39586.23
+                "MARS": "single",
+                "value": 39566.88
             },
             {
                 "year": 2019,
-                "marital_status": "joint",
-                "value": 79172.46
+                "MARS": "mjoint",
+                "value": 79133.76
             },
             {
                 "year": 2019,
-                "marital_status": "separate",
-                "value": 39586.23
+                "MARS": "mseparate",
+                "value": 39566.88
             },
             {
                 "year": 2019,
-                "marital_status": "headhousehold",
-                "value": 52986.22
+                "MARS": "headhh",
+                "value": 52960.32
             },
             {
                 "year": 2019,
-                "marital_status": "widow",
-                "value": 79172.46
+                "MARS": "widow",
+                "value": 79133.76
             },
             {
                 "year": 2020,
-                "marital_status": "single",
-                "value": 40374.0
+                "MARS": "single",
+                "value": 40302.82
             },
             {
                 "year": 2020,
-                "marital_status": "joint",
-                "value": 80747.99
+                "MARS": "mjoint",
+                "value": 80605.65
             },
             {
                 "year": 2020,
-                "marital_status": "separate",
-                "value": 40374.0
+                "MARS": "mseparate",
+                "value": 40302.82
             },
             {
                 "year": 2020,
-                "marital_status": "headhousehold",
-                "value": 54040.65
+                "MARS": "headhh",
+                "value": 53945.38
             },
             {
                 "year": 2020,
-                "marital_status": "widow",
-                "value": 80747.99
+                "MARS": "widow",
+                "value": 80605.65
             },
             {
                 "year": 2021,
-                "marital_status": "single",
-                "value": 41278.37
+                "MARS": "single",
+                "value": 41241.88
             },
             {
                 "year": 2021,
-                "marital_status": "joint",
-                "value": 82556.75
+                "MARS": "mjoint",
+                "value": 82483.76
             },
             {
                 "year": 2021,
-                "marital_status": "separate",
-                "value": 41278.37
+                "MARS": "mseparate",
+                "value": 41241.88
             },
             {
                 "year": 2021,
-                "marital_status": "headhousehold",
-                "value": 55251.16
+                "MARS": "headhh",
+                "value": 55202.31
             },
             {
                 "year": 2021,
-                "marital_status": "widow",
-                "value": 82556.75
+                "MARS": "widow",
+                "value": 82483.76
             },
             {
                 "year": 2022,
-                "marital_status": "single",
-                "value": 42215.39
+                "MARS": "single",
+                "value": 42186.32
             },
             {
                 "year": 2022,
-                "marital_status": "joint",
-                "value": 84430.79
+                "MARS": "mjoint",
+                "value": 84372.64
             },
             {
                 "year": 2022,
-                "marital_status": "separate",
-                "value": 42215.39
+                "MARS": "mseparate",
+                "value": 42186.32
             },
             {
                 "year": 2022,
-                "marital_status": "headhousehold",
-                "value": 56505.36
+                "MARS": "headhh",
+                "value": 56466.44
             },
             {
                 "year": 2022,
-                "marital_status": "widow",
-                "value": 84430.79
+                "MARS": "widow",
+                "value": 84372.64
             },
             {
                 "year": 2023,
-                "marital_status": "single",
-                "value": 43156.8
+                "MARS": "single",
+                "value": 43148.17
             },
             {
                 "year": 2023,
-                "marital_status": "joint",
-                "value": 86313.59
+                "MARS": "mjoint",
+                "value": 86296.33
             },
             {
                 "year": 2023,
-                "marital_status": "separate",
-                "value": 43156.8
+                "MARS": "mseparate",
+                "value": 43148.17
             },
             {
                 "year": 2023,
-                "marital_status": "headhousehold",
-                "value": 57765.43
+                "MARS": "headhh",
+                "value": 57753.88
             },
             {
                 "year": 2023,
-                "marital_status": "widow",
-                "value": 86313.59
+                "MARS": "widow",
+                "value": 86296.33
             },
             {
                 "year": 2024,
-                "marital_status": "single",
-                "value": 44097.61
+                "MARS": "single",
+                "value": 44101.74
             },
             {
                 "year": 2024,
-                "marital_status": "joint",
-                "value": 88195.23
+                "MARS": "mjoint",
+                "value": 88203.48
             },
             {
                 "year": 2024,
-                "marital_status": "separate",
-                "value": 44097.61
+                "MARS": "mseparate",
+                "value": 44101.74
             },
             {
                 "year": 2024,
-                "marital_status": "headhousehold",
-                "value": 59024.71
+                "MARS": "headhh",
+                "value": 59030.24
             },
             {
                 "year": 2024,
-                "marital_status": "widow",
-                "value": 88195.23
+                "MARS": "widow",
+                "value": 88203.48
             },
             {
                 "year": 2025,
-                "marital_status": "single",
-                "value": 45045.71
+                "MARS": "single",
+                "value": 45032.29
             },
             {
                 "year": 2025,
-                "marital_status": "joint",
-                "value": 90091.43
+                "MARS": "mjoint",
+                "value": 90064.58
             },
             {
                 "year": 2025,
-                "marital_status": "separate",
-                "value": 45045.71
+                "MARS": "mseparate",
+                "value": 45032.29
             },
             {
                 "year": 2025,
-                "marital_status": "headhousehold",
-                "value": 60293.74
+                "MARS": "headhh",
+                "value": 60275.78
             },
             {
                 "year": 2025,
-                "marital_status": "widow",
-                "value": 90091.43
+                "MARS": "widow",
+                "value": 90064.58
             },
             {
                 "year": 2026,
-                "marital_status": "single",
-                "value": 45957.0
+                "MARS": "single",
+                "value": 45926.0
             },
             {
                 "year": 2026,
-                "marital_status": "joint",
-                "value": 91915.0
+                "MARS": "mjoint",
+                "value": 91851.0
             },
             {
                 "year": 2026,
-                "marital_status": "separate",
-                "value": 45957.0
+                "MARS": "mseparate",
+                "value": 45926.0
             },
             {
                 "year": 2026,
-                "marital_status": "headhousehold",
-                "value": 61519.0
+                "MARS": "headhh",
+                "value": 61476.0
             },
             {
                 "year": 2026,
-                "marital_status": "widow",
-                "value": 91915.0
+                "MARS": "widow",
+                "value": 91851.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Pass-through income tax bracket (upper threshold) 2",
         "type": "float",
         "validators": {
             "range": {
-                "min": "_PT_brk1",
-                "max": "_PT_brk3"
+                "min": "PT_brk1",
+                "max": "PT_brk3"
             }
-        }
-    },
-    "_PT_rt3": {
-        "description": "The third lowest tax rate, applied to the portion of income from sole proprietorships, partnerships and S-corporations below tax bracket 3 and above tax bracket 2.",
+        },
         "section_1": "Personal Income",
         "section_2": "Pass-Through",
-        "irs_ref": "Form 1040, line 11, instruction (Schedule XYZ)",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": true,
+        "description": "Income from sole proprietorships, partnerships and S-corporations below this threshold and above tax bracket 1 is taxed at tax rate 2.",
+        "notes": ""
+    },
+    "PT_rt3": {
         "value": [
             {
                 "year": 2013,
@@ -12202,10 +11488,6 @@
                 "value": 0.25
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Pass-through income tax rate 3",
         "type": "float",
         "validators": {
@@ -12213,391 +11495,381 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_PT_brk3": {
-        "description": "Income from sole proprietorships, partnerships and S-corporations below this threshold and above tax bracket 2 is taxed at tax rate 3.",
+        },
         "section_1": "Personal Income",
         "section_2": "Pass-Through",
-        "irs_ref": "Form 1040, line 11, instruction (Schedule XYZ).",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+        "indexed": false,
+        "description": "The third lowest tax rate, applied to the portion of income from sole proprietorships, partnerships and S-corporations below tax bracket 3 and above tax bracket 2.",
+        "notes": ""
+    },
+    "PT_brk3": {
         "value": [
             {
                 "year": 2013,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 87850.0
             },
             {
                 "year": 2013,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 146400.0
             },
             {
                 "year": 2013,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 73200.0
             },
             {
                 "year": 2013,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 125450.0
             },
             {
                 "year": 2013,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 146400.0
             },
             {
                 "year": 2014,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 89350.0
             },
             {
                 "year": 2014,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 148850.0
             },
             {
                 "year": 2014,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 74425.0
             },
             {
                 "year": 2014,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 127550.0
             },
             {
                 "year": 2014,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 148850.0
             },
             {
                 "year": 2015,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 90750.0
             },
             {
                 "year": 2015,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 151200.0
             },
             {
                 "year": 2015,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 75600.0
             },
             {
                 "year": 2015,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 129600.0
             },
             {
                 "year": 2015,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 151200.0
             },
             {
                 "year": 2016,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 91150.0
             },
             {
                 "year": 2016,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 151900.0
             },
             {
                 "year": 2016,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 75950.0
             },
             {
                 "year": 2016,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 130150.0
             },
             {
                 "year": 2016,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 151900.0
             },
             {
                 "year": 2017,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 91900.0
             },
             {
                 "year": 2017,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 153100.0
             },
             {
                 "year": 2017,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 76550.0
             },
             {
                 "year": 2017,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 131200.0
             },
             {
                 "year": 2017,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 153100.0
             },
             {
                 "year": 2018,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 82500.0
             },
             {
                 "year": 2018,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 165000.0
             },
             {
                 "year": 2018,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 82500.0
             },
             {
                 "year": 2018,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 82500.0
             },
             {
                 "year": 2018,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 165000.0
             },
             {
                 "year": 2019,
-                "marital_status": "single",
-                "value": 84389.25
+                "MARS": "single",
+                "value": 84348.0
             },
             {
                 "year": 2019,
-                "marital_status": "joint",
-                "value": 168778.5
+                "MARS": "mjoint",
+                "value": 168696.0
             },
             {
                 "year": 2019,
-                "marital_status": "separate",
-                "value": 84389.25
+                "MARS": "mseparate",
+                "value": 84348.0
             },
             {
                 "year": 2019,
-                "marital_status": "headhousehold",
-                "value": 84389.25
+                "MARS": "headhh",
+                "value": 84348.0
             },
             {
                 "year": 2019,
-                "marital_status": "widow",
-                "value": 168778.5
+                "MARS": "widow",
+                "value": 168696.0
             },
             {
                 "year": 2020,
-                "marital_status": "single",
-                "value": 86068.6
+                "MARS": "single",
+                "value": 85916.87
             },
             {
                 "year": 2020,
-                "marital_status": "joint",
-                "value": 172137.19
+                "MARS": "mjoint",
+                "value": 171833.75
             },
             {
                 "year": 2020,
-                "marital_status": "separate",
-                "value": 86068.6
+                "MARS": "mseparate",
+                "value": 85916.87
             },
             {
                 "year": 2020,
-                "marital_status": "headhousehold",
-                "value": 86068.6
+                "MARS": "headhh",
+                "value": 85916.87
             },
             {
                 "year": 2020,
-                "marital_status": "widow",
-                "value": 172137.19
+                "MARS": "widow",
+                "value": 171833.75
             },
             {
                 "year": 2021,
-                "marital_status": "single",
-                "value": 87996.53
+                "MARS": "single",
+                "value": 87918.74
             },
             {
                 "year": 2021,
-                "marital_status": "joint",
-                "value": 175993.07
+                "MARS": "mjoint",
+                "value": 175837.47
             },
             {
                 "year": 2021,
-                "marital_status": "separate",
-                "value": 87996.53
+                "MARS": "mseparate",
+                "value": 87918.74
             },
             {
                 "year": 2021,
-                "marital_status": "headhousehold",
-                "value": 87996.53
+                "MARS": "headhh",
+                "value": 87918.74
             },
             {
                 "year": 2021,
-                "marital_status": "widow",
-                "value": 175993.07
+                "MARS": "widow",
+                "value": 175837.47
             },
             {
                 "year": 2022,
-                "marital_status": "single",
-                "value": 89994.05
+                "MARS": "single",
+                "value": 89932.07
             },
             {
                 "year": 2022,
-                "marital_status": "joint",
-                "value": 179988.11
+                "MARS": "mjoint",
+                "value": 179864.15
             },
             {
                 "year": 2022,
-                "marital_status": "separate",
-                "value": 89994.05
+                "MARS": "mseparate",
+                "value": 89932.07
             },
             {
                 "year": 2022,
-                "marital_status": "headhousehold",
-                "value": 89994.05
+                "MARS": "headhh",
+                "value": 89932.07
             },
             {
                 "year": 2022,
-                "marital_status": "widow",
-                "value": 179988.11
+                "MARS": "widow",
+                "value": 179864.15
             },
             {
                 "year": 2023,
-                "marital_status": "single",
-                "value": 92000.92
+                "MARS": "single",
+                "value": 91982.53
             },
             {
                 "year": 2023,
-                "marital_status": "joint",
-                "value": 184001.84
+                "MARS": "mjoint",
+                "value": 183965.05
             },
             {
                 "year": 2023,
-                "marital_status": "separate",
-                "value": 92000.92
+                "MARS": "mseparate",
+                "value": 91982.53
             },
             {
                 "year": 2023,
-                "marital_status": "headhousehold",
-                "value": 92000.92
+                "MARS": "headhh",
+                "value": 91982.53
             },
             {
                 "year": 2023,
-                "marital_status": "widow",
-                "value": 184001.84
+                "MARS": "widow",
+                "value": 183965.05
             },
             {
                 "year": 2024,
-                "marital_status": "single",
-                "value": 94006.54
+                "MARS": "single",
+                "value": 94015.34
             },
             {
                 "year": 2024,
-                "marital_status": "joint",
-                "value": 188013.08
+                "MARS": "mjoint",
+                "value": 188030.68
             },
             {
                 "year": 2024,
-                "marital_status": "separate",
-                "value": 94006.54
+                "MARS": "mseparate",
+                "value": 94015.34
             },
             {
                 "year": 2024,
-                "marital_status": "headhousehold",
-                "value": 94006.54
+                "MARS": "headhh",
+                "value": 94015.34
             },
             {
                 "year": 2024,
-                "marital_status": "widow",
-                "value": 188013.08
+                "MARS": "widow",
+                "value": 188030.68
             },
             {
                 "year": 2025,
-                "marital_status": "single",
-                "value": 96027.68
+                "MARS": "single",
+                "value": 95999.06
             },
             {
                 "year": 2025,
-                "marital_status": "joint",
-                "value": 192055.36
+                "MARS": "mjoint",
+                "value": 191998.13
             },
             {
                 "year": 2025,
-                "marital_status": "separate",
-                "value": 96027.68
+                "MARS": "mseparate",
+                "value": 95999.06
             },
             {
                 "year": 2025,
-                "marital_status": "headhousehold",
-                "value": 96027.68
+                "MARS": "headhh",
+                "value": 95999.06
             },
             {
                 "year": 2025,
-                "marital_status": "widow",
-                "value": 192055.36
+                "MARS": "widow",
+                "value": 191998.13
             },
             {
                 "year": 2026,
-                "marital_status": "single",
-                "value": 111290.0
+                "MARS": "single",
+                "value": 111214.0
             },
             {
                 "year": 2026,
-                "marital_status": "joint",
-                "value": 185403.0
+                "MARS": "mjoint",
+                "value": 185275.0
             },
             {
                 "year": 2026,
-                "marital_status": "separate",
-                "value": 92702.0
+                "MARS": "mseparate",
+                "value": 92638.0
             },
             {
                 "year": 2026,
-                "marital_status": "headhousehold",
-                "value": 158883.0
+                "MARS": "headhh",
+                "value": 158773.0
             },
             {
                 "year": 2026,
-                "marital_status": "widow",
-                "value": 185403.0
+                "MARS": "widow",
+                "value": 185275.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Pass-through income tax bracket (upper threshold) 3",
         "type": "float",
         "validators": {
             "range": {
-                "min": "_PT_brk2",
-                "max": "_PT_brk4"
+                "min": "PT_brk2",
+                "max": "PT_brk4"
             }
-        }
-    },
-    "_PT_rt4": {
-        "description": "The tax rate applied to the portion of income from sole proprietorships, partnerships and S-corporations below tax bracket 4 and above tax bracket 3.",
+        },
         "section_1": "Personal Income",
         "section_2": "Pass-Through",
-        "irs_ref": "Form 1040, line 11, instruction (Schedule XYZ)",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": true,
+        "description": "Income from sole proprietorships, partnerships and S-corporations below this threshold and above tax bracket 2 is taxed at tax rate 3.",
+        "notes": ""
+    },
+    "PT_rt4": {
         "value": [
             {
                 "year": 2013,
@@ -12656,10 +11928,6 @@
                 "value": 0.28
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Pass-through income tax rate 4",
         "type": "float",
         "validators": {
@@ -12667,391 +11935,381 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_PT_brk4": {
-        "description": "Income from sole proprietorships, partnerships and S-corporations below this threshold and above tax bracket 3 is taxed at tax rate 4.",
+        },
         "section_1": "Personal Income",
         "section_2": "Pass-Through",
-        "irs_ref": "Form 1040, line 11, instruction (Schedule XYZ).",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+        "indexed": false,
+        "description": "The tax rate applied to the portion of income from sole proprietorships, partnerships and S-corporations below tax bracket 4 and above tax bracket 3.",
+        "notes": ""
+    },
+    "PT_brk4": {
         "value": [
             {
                 "year": 2013,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 183250.0
             },
             {
                 "year": 2013,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 223050.0
             },
             {
                 "year": 2013,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 111525.0
             },
             {
                 "year": 2013,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 203150.0
             },
             {
                 "year": 2013,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 223050.0
             },
             {
                 "year": 2014,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 186350.0
             },
             {
                 "year": 2014,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 226850.0
             },
             {
                 "year": 2014,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 113425.0
             },
             {
                 "year": 2014,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 206600.0
             },
             {
                 "year": 2014,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 226850.0
             },
             {
                 "year": 2015,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 189300.0
             },
             {
                 "year": 2015,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 230450.0
             },
             {
                 "year": 2015,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 115225.0
             },
             {
                 "year": 2015,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 209850.0
             },
             {
                 "year": 2015,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 230450.0
             },
             {
                 "year": 2016,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 190150.0
             },
             {
                 "year": 2016,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 231450.0
             },
             {
                 "year": 2016,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 115725.0
             },
             {
                 "year": 2016,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 210800.0
             },
             {
                 "year": 2016,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 231450.0
             },
             {
                 "year": 2017,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 191650.0
             },
             {
                 "year": 2017,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 233350.0
             },
             {
                 "year": 2017,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 116675.0
             },
             {
                 "year": 2017,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 212500.0
             },
             {
                 "year": 2017,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 233350.0
             },
             {
                 "year": 2018,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 157500.0
             },
             {
                 "year": 2018,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 315000.0
             },
             {
                 "year": 2018,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 157500.0
             },
             {
                 "year": 2018,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 157500.0
             },
             {
                 "year": 2018,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 315000.0
             },
             {
                 "year": 2019,
-                "marital_status": "single",
-                "value": 161106.75
+                "MARS": "single",
+                "value": 161028.0
             },
             {
                 "year": 2019,
-                "marital_status": "joint",
-                "value": 322213.5
+                "MARS": "mjoint",
+                "value": 322056.0
             },
             {
                 "year": 2019,
-                "marital_status": "separate",
-                "value": 161106.75
+                "MARS": "mseparate",
+                "value": 161028.0
             },
             {
                 "year": 2019,
-                "marital_status": "headhousehold",
-                "value": 161106.75
+                "MARS": "headhh",
+                "value": 161028.0
             },
             {
                 "year": 2019,
-                "marital_status": "widow",
-                "value": 322213.5
+                "MARS": "widow",
+                "value": 322056.0
             },
             {
                 "year": 2020,
-                "marital_status": "single",
-                "value": 164312.77
+                "MARS": "single",
+                "value": 164023.12
             },
             {
                 "year": 2020,
-                "marital_status": "joint",
-                "value": 328625.55
+                "MARS": "mjoint",
+                "value": 328046.24
             },
             {
                 "year": 2020,
-                "marital_status": "separate",
-                "value": 164312.77
+                "MARS": "mseparate",
+                "value": 164023.12
             },
             {
                 "year": 2020,
-                "marital_status": "headhousehold",
-                "value": 164312.77
+                "MARS": "headhh",
+                "value": 164023.12
             },
             {
                 "year": 2020,
-                "marital_status": "widow",
-                "value": 328625.55
+                "MARS": "widow",
+                "value": 328046.24
             },
             {
                 "year": 2021,
-                "marital_status": "single",
-                "value": 167993.38
+                "MARS": "single",
+                "value": 167844.86
             },
             {
                 "year": 2021,
-                "marital_status": "joint",
-                "value": 335986.76
+                "MARS": "mjoint",
+                "value": 335689.72
             },
             {
                 "year": 2021,
-                "marital_status": "separate",
-                "value": 167993.38
+                "MARS": "mseparate",
+                "value": 167844.86
             },
             {
                 "year": 2021,
-                "marital_status": "headhousehold",
-                "value": 167993.38
+                "MARS": "headhh",
+                "value": 167844.86
             },
             {
                 "year": 2021,
-                "marital_status": "widow",
-                "value": 335986.76
+                "MARS": "widow",
+                "value": 335689.72
             },
             {
                 "year": 2022,
-                "marital_status": "single",
-                "value": 171806.83
+                "MARS": "single",
+                "value": 171688.51
             },
             {
                 "year": 2022,
-                "marital_status": "joint",
-                "value": 343613.66
+                "MARS": "mjoint",
+                "value": 343377.01
             },
             {
                 "year": 2022,
-                "marital_status": "separate",
-                "value": 171806.83
+                "MARS": "mseparate",
+                "value": 171688.51
             },
             {
                 "year": 2022,
-                "marital_status": "headhousehold",
-                "value": 171806.83
+                "MARS": "headhh",
+                "value": 171688.51
             },
             {
                 "year": 2022,
-                "marital_status": "widow",
-                "value": 343613.66
+                "MARS": "widow",
+                "value": 343377.01
             },
             {
                 "year": 2023,
-                "marital_status": "single",
-                "value": 175638.12
+                "MARS": "single",
+                "value": 175603.0
             },
             {
                 "year": 2023,
-                "marital_status": "joint",
-                "value": 351276.25
+                "MARS": "mjoint",
+                "value": 351206.01
             },
             {
                 "year": 2023,
-                "marital_status": "separate",
-                "value": 175638.12
+                "MARS": "mseparate",
+                "value": 175603.0
             },
             {
                 "year": 2023,
-                "marital_status": "headhousehold",
-                "value": 175638.12
+                "MARS": "headhh",
+                "value": 175603.0
             },
             {
                 "year": 2023,
-                "marital_status": "widow",
-                "value": 351276.25
+                "MARS": "widow",
+                "value": 351206.01
             },
             {
                 "year": 2024,
-                "marital_status": "single",
-                "value": 179467.03
+                "MARS": "single",
+                "value": 179483.83
             },
             {
                 "year": 2024,
-                "marital_status": "joint",
-                "value": 358934.07
+                "MARS": "mjoint",
+                "value": 358967.66
             },
             {
                 "year": 2024,
-                "marital_status": "separate",
-                "value": 179467.03
+                "MARS": "mseparate",
+                "value": 179483.83
             },
             {
                 "year": 2024,
-                "marital_status": "headhousehold",
-                "value": 179467.03
+                "MARS": "headhh",
+                "value": 179483.83
             },
             {
                 "year": 2024,
-                "marital_status": "widow",
-                "value": 358934.07
+                "MARS": "widow",
+                "value": 358967.66
             },
             {
                 "year": 2025,
-                "marital_status": "single",
-                "value": 183325.57
+                "MARS": "single",
+                "value": 183270.94
             },
             {
                 "year": 2025,
-                "marital_status": "joint",
-                "value": 366651.15
+                "MARS": "mjoint",
+                "value": 366541.88
             },
             {
                 "year": 2025,
-                "marital_status": "separate",
-                "value": 183325.57
+                "MARS": "mseparate",
+                "value": 183270.94
             },
             {
                 "year": 2025,
-                "marital_status": "headhousehold",
-                "value": 183325.57
+                "MARS": "headhh",
+                "value": 183270.94
             },
             {
                 "year": 2025,
-                "marital_status": "widow",
-                "value": 366651.15
+                "MARS": "widow",
+                "value": 366541.88
             },
             {
                 "year": 2026,
-                "marital_status": "single",
-                "value": 232087.0
+                "MARS": "single",
+                "value": 231927.0
             },
             {
                 "year": 2026,
-                "marital_status": "joint",
-                "value": 282586.0
+                "MARS": "mjoint",
+                "value": 282391.0
             },
             {
                 "year": 2026,
-                "marital_status": "separate",
-                "value": 141293.0
+                "MARS": "mseparate",
+                "value": 141195.0
             },
             {
                 "year": 2026,
-                "marital_status": "headhousehold",
-                "value": 257336.0
+                "MARS": "headhh",
+                "value": 257159.0
             },
             {
                 "year": 2026,
-                "marital_status": "widow",
-                "value": 282586.0
+                "MARS": "widow",
+                "value": 282391.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Pass-through income tax bracket (upper threshold) 4",
         "type": "float",
         "validators": {
             "range": {
-                "min": "_PT_brk3",
-                "max": "_PT_brk5"
+                "min": "PT_brk3",
+                "max": "PT_brk5"
             }
-        }
-    },
-    "_PT_rt5": {
-        "description": "The third highest tax rate, applied to the portion of income from sole proprietorships, partnerships and S-corporations below tax bracket 5 and above tax bracket 4.",
+        },
         "section_1": "Personal Income",
         "section_2": "Pass-Through",
-        "irs_ref": "Form 1040, line 11, instruction (Schedule XYZ)",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": true,
+        "description": "Income from sole proprietorships, partnerships and S-corporations below this threshold and above tax bracket 3 is taxed at tax rate 4.",
+        "notes": ""
+    },
+    "PT_rt5": {
         "value": [
             {
                 "year": 2013,
@@ -13110,10 +12368,6 @@
                 "value": 0.33
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Pass-through income tax rate 5",
         "type": "float",
         "validators": {
@@ -13121,391 +12375,381 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_PT_brk5": {
-        "description": "Income from sole proprietorships, partnerships and S-corporations below this threshold and above tax bracket 4 is taxed at tax rate 5.",
+        },
         "section_1": "Personal Income",
         "section_2": "Pass-Through",
-        "irs_ref": "Form 1040, line 11, instruction (Schedule XYZ).",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+        "indexed": false,
+        "description": "The third highest tax rate, applied to the portion of income from sole proprietorships, partnerships and S-corporations below tax bracket 5 and above tax bracket 4.",
+        "notes": ""
+    },
+    "PT_brk5": {
         "value": [
             {
                 "year": 2013,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 398350.0
             },
             {
                 "year": 2013,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 398350.0
             },
             {
                 "year": 2013,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 199175.0
             },
             {
                 "year": 2013,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 398350.0
             },
             {
                 "year": 2013,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 398350.0
             },
             {
                 "year": 2014,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 405100.0
             },
             {
                 "year": 2014,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 405100.0
             },
             {
                 "year": 2014,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 202550.0
             },
             {
                 "year": 2014,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 405100.0
             },
             {
                 "year": 2014,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 405100.0
             },
             {
                 "year": 2015,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 411500.0
             },
             {
                 "year": 2015,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 411500.0
             },
             {
                 "year": 2015,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 205750.0
             },
             {
                 "year": 2015,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 411500.0
             },
             {
                 "year": 2015,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 411500.0
             },
             {
                 "year": 2016,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 413350.0
             },
             {
                 "year": 2016,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 413350.0
             },
             {
                 "year": 2016,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 206675.0
             },
             {
                 "year": 2016,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 413350.0
             },
             {
                 "year": 2016,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 413350.0
             },
             {
                 "year": 2017,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 416700.0
             },
             {
                 "year": 2017,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 416700.0
             },
             {
                 "year": 2017,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 208350.0
             },
             {
                 "year": 2017,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 416700.0
             },
             {
                 "year": 2017,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 416700.0
             },
             {
                 "year": 2018,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 200000.0
             },
             {
                 "year": 2018,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 400000.0
             },
             {
                 "year": 2018,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 200000.0
             },
             {
                 "year": 2018,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 200000.0
             },
             {
                 "year": 2018,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 400000.0
             },
             {
                 "year": 2019,
-                "marital_status": "single",
-                "value": 204580.0
+                "MARS": "single",
+                "value": 204480.0
             },
             {
                 "year": 2019,
-                "marital_status": "joint",
-                "value": 409160.0
+                "MARS": "mjoint",
+                "value": 408960.0
             },
             {
                 "year": 2019,
-                "marital_status": "separate",
-                "value": 204580.0
+                "MARS": "mseparate",
+                "value": 204480.0
             },
             {
                 "year": 2019,
-                "marital_status": "headhousehold",
-                "value": 204580.0
+                "MARS": "headhh",
+                "value": 204480.0
             },
             {
                 "year": 2019,
-                "marital_status": "widow",
-                "value": 409160.0
+                "MARS": "widow",
+                "value": 408960.0
             },
             {
                 "year": 2020,
-                "marital_status": "single",
-                "value": 208651.14
+                "MARS": "single",
+                "value": 208283.33
             },
             {
                 "year": 2020,
-                "marital_status": "joint",
-                "value": 417302.28
+                "MARS": "mjoint",
+                "value": 416566.66
             },
             {
                 "year": 2020,
-                "marital_status": "separate",
-                "value": 208651.14
+                "MARS": "mseparate",
+                "value": 208283.33
             },
             {
                 "year": 2020,
-                "marital_status": "headhousehold",
-                "value": 208651.14
+                "MARS": "headhh",
+                "value": 208283.33
             },
             {
                 "year": 2020,
-                "marital_status": "widow",
-                "value": 417302.28
+                "MARS": "widow",
+                "value": 416566.66
             },
             {
                 "year": 2021,
-                "marital_status": "single",
-                "value": 213324.93
+                "MARS": "single",
+                "value": 213136.33
             },
             {
                 "year": 2021,
-                "marital_status": "joint",
-                "value": 426649.86
+                "MARS": "mjoint",
+                "value": 426272.66
             },
             {
                 "year": 2021,
-                "marital_status": "separate",
-                "value": 213324.93
+                "MARS": "mseparate",
+                "value": 213136.33
             },
             {
                 "year": 2021,
-                "marital_status": "headhousehold",
-                "value": 213324.93
+                "MARS": "headhh",
+                "value": 213136.33
             },
             {
                 "year": 2021,
-                "marital_status": "widow",
-                "value": 426649.86
+                "MARS": "widow",
+                "value": 426272.66
             },
             {
                 "year": 2022,
-                "marital_status": "single",
-                "value": 218167.4
+                "MARS": "single",
+                "value": 218017.15
             },
             {
                 "year": 2022,
-                "marital_status": "joint",
-                "value": 436334.81
+                "MARS": "mjoint",
+                "value": 436034.3
             },
             {
                 "year": 2022,
-                "marital_status": "separate",
-                "value": 218167.4
+                "MARS": "mseparate",
+                "value": 218017.15
             },
             {
                 "year": 2022,
-                "marital_status": "headhousehold",
-                "value": 218167.4
+                "MARS": "headhh",
+                "value": 218017.15
             },
             {
                 "year": 2022,
-                "marital_status": "widow",
-                "value": 436334.81
+                "MARS": "widow",
+                "value": 436034.3
             },
             {
                 "year": 2023,
-                "marital_status": "single",
-                "value": 223032.54
+                "MARS": "single",
+                "value": 222987.94
             },
             {
                 "year": 2023,
-                "marital_status": "joint",
-                "value": 446065.07
+                "MARS": "mjoint",
+                "value": 445975.89
             },
             {
                 "year": 2023,
-                "marital_status": "separate",
-                "value": 223032.54
+                "MARS": "mseparate",
+                "value": 222987.94
             },
             {
                 "year": 2023,
-                "marital_status": "headhousehold",
-                "value": 223032.54
+                "MARS": "headhh",
+                "value": 222987.94
             },
             {
                 "year": 2023,
-                "marital_status": "widow",
-                "value": 446065.07
+                "MARS": "widow",
+                "value": 445975.89
             },
             {
                 "year": 2024,
-                "marital_status": "single",
-                "value": 227894.65
+                "MARS": "single",
+                "value": 227915.98
             },
             {
                 "year": 2024,
-                "marital_status": "joint",
-                "value": 455789.29
+                "MARS": "mjoint",
+                "value": 455831.95
             },
             {
                 "year": 2024,
-                "marital_status": "separate",
-                "value": 227894.65
+                "MARS": "mseparate",
+                "value": 227915.98
             },
             {
                 "year": 2024,
-                "marital_status": "headhousehold",
-                "value": 227894.65
+                "MARS": "headhh",
+                "value": 227915.98
             },
             {
                 "year": 2024,
-                "marital_status": "widow",
-                "value": 455789.29
+                "MARS": "widow",
+                "value": 455831.95
             },
             {
                 "year": 2025,
-                "marital_status": "single",
-                "value": 232794.38
+                "MARS": "single",
+                "value": 232725.0
             },
             {
                 "year": 2025,
-                "marital_status": "joint",
-                "value": 465588.76
+                "MARS": "mjoint",
+                "value": 465450.01
             },
             {
                 "year": 2025,
-                "marital_status": "separate",
-                "value": 232794.38
+                "MARS": "mseparate",
+                "value": 232725.0
             },
             {
                 "year": 2025,
-                "marital_status": "headhousehold",
-                "value": 232794.38
+                "MARS": "headhh",
+                "value": 232725.0
             },
             {
                 "year": 2025,
-                "marital_status": "widow",
-                "value": 465588.76
+                "MARS": "widow",
+                "value": 465450.01
             },
             {
                 "year": 2026,
-                "marital_status": "single",
-                "value": 504622.0
+                "MARS": "single",
+                "value": 504273.0
             },
             {
                 "year": 2026,
-                "marital_status": "joint",
-                "value": 504622.0
+                "MARS": "mjoint",
+                "value": 504273.0
             },
             {
                 "year": 2026,
-                "marital_status": "separate",
-                "value": 252311.0
+                "MARS": "mseparate",
+                "value": 252137.0
             },
             {
                 "year": 2026,
-                "marital_status": "headhousehold",
-                "value": 504622.0
+                "MARS": "headhh",
+                "value": 504273.0
             },
             {
                 "year": 2026,
-                "marital_status": "widow",
-                "value": 504622.0
+                "MARS": "widow",
+                "value": 504273.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Pass-through income tax bracket (upper threshold) 5",
         "type": "float",
         "validators": {
             "range": {
-                "min": "_PT_brk4",
-                "max": "_PT_brk6"
+                "min": "PT_brk4",
+                "max": "PT_brk6"
             }
-        }
-    },
-    "_PT_rt6": {
-        "description": "The second higher tax rate, applied to the portion of income from sole proprietorships, partnerships and S-corporations below tax bracket 6 and above tax bracket 5.",
+        },
         "section_1": "Personal Income",
         "section_2": "Pass-Through",
-        "irs_ref": "Form 1040, line 11, instruction (Schedule XYZ)",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": true,
+        "description": "Income from sole proprietorships, partnerships and S-corporations below this threshold and above tax bracket 4 is taxed at tax rate 5.",
+        "notes": ""
+    },
+    "PT_rt6": {
         "value": [
             {
                 "year": 2013,
@@ -13564,10 +12808,6 @@
                 "value": 0.35
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Pass-through income tax rate 6",
         "type": "float",
         "validators": {
@@ -13575,391 +12815,381 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_PT_brk6": {
-        "description": "Income from sole proprietorships, partnerships and S-corporations below this threshold and above tax bracket 5 is taxed at tax rate 6.",
+        },
         "section_1": "Personal Income",
         "section_2": "Pass-Through",
-        "irs_ref": "Form 1040, line 11, instruction (Schedule XYZ).",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+        "indexed": false,
+        "description": "The second higher tax rate, applied to the portion of income from sole proprietorships, partnerships and S-corporations below tax bracket 6 and above tax bracket 5.",
+        "notes": ""
+    },
+    "PT_brk6": {
         "value": [
             {
                 "year": 2013,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 400000.0
             },
             {
                 "year": 2013,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 450000.0
             },
             {
                 "year": 2013,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 225000.0
             },
             {
                 "year": 2013,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 425000.0
             },
             {
                 "year": 2013,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 450000.0
             },
             {
                 "year": 2014,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 406750.0
             },
             {
                 "year": 2014,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 457600.0
             },
             {
                 "year": 2014,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 228800.0
             },
             {
                 "year": 2014,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 432200.0
             },
             {
                 "year": 2014,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 457600.0
             },
             {
                 "year": 2015,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 413200.0
             },
             {
                 "year": 2015,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 464850.0
             },
             {
                 "year": 2015,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 232425.0
             },
             {
                 "year": 2015,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 439000.0
             },
             {
                 "year": 2015,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 464850.0
             },
             {
                 "year": 2016,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 415050.0
             },
             {
                 "year": 2016,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 466950.0
             },
             {
                 "year": 2016,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 233475.0
             },
             {
                 "year": 2016,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 441000.0
             },
             {
                 "year": 2016,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 466950.0
             },
             {
                 "year": 2017,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 418400.0
             },
             {
                 "year": 2017,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 470700.0
             },
             {
                 "year": 2017,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 235350.0
             },
             {
                 "year": 2017,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 444550.0
             },
             {
                 "year": 2017,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 470700.0
             },
             {
                 "year": 2018,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 500000.0
             },
             {
                 "year": 2018,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 600000.0
             },
             {
                 "year": 2018,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 300000.0
             },
             {
                 "year": 2018,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 500000.0
             },
             {
                 "year": 2018,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 600000.0
             },
             {
                 "year": 2019,
-                "marital_status": "single",
-                "value": 511450.0
+                "MARS": "single",
+                "value": 511200.0
             },
             {
                 "year": 2019,
-                "marital_status": "joint",
-                "value": 613740.0
+                "MARS": "mjoint",
+                "value": 613440.0
             },
             {
                 "year": 2019,
-                "marital_status": "separate",
-                "value": 306870.0
+                "MARS": "mseparate",
+                "value": 306720.0
             },
             {
                 "year": 2019,
-                "marital_status": "headhousehold",
-                "value": 511450.0
+                "MARS": "headhh",
+                "value": 511200.0
             },
             {
                 "year": 2019,
-                "marital_status": "widow",
-                "value": 613740.0
+                "MARS": "widow",
+                "value": 613440.0
             },
             {
                 "year": 2020,
-                "marital_status": "single",
-                "value": 521627.86
+                "MARS": "single",
+                "value": 520708.32
             },
             {
                 "year": 2020,
-                "marital_status": "joint",
-                "value": 625953.43
+                "MARS": "mjoint",
+                "value": 624849.98
             },
             {
                 "year": 2020,
-                "marital_status": "separate",
-                "value": 312976.71
+                "MARS": "mseparate",
+                "value": 312424.99
             },
             {
                 "year": 2020,
-                "marital_status": "headhousehold",
-                "value": 521627.86
+                "MARS": "headhh",
+                "value": 520708.32
             },
             {
                 "year": 2020,
-                "marital_status": "widow",
-                "value": 625953.43
+                "MARS": "widow",
+                "value": 624849.98
             },
             {
                 "year": 2021,
-                "marital_status": "single",
-                "value": 533312.32
+                "MARS": "single",
+                "value": 532840.82
             },
             {
                 "year": 2021,
-                "marital_status": "joint",
-                "value": 639974.78
+                "MARS": "mjoint",
+                "value": 639408.99
             },
             {
                 "year": 2021,
-                "marital_status": "separate",
-                "value": 319987.39
+                "MARS": "mseparate",
+                "value": 319704.49
             },
             {
                 "year": 2021,
-                "marital_status": "headhousehold",
-                "value": 533312.32
+                "MARS": "headhh",
+                "value": 532840.82
             },
             {
                 "year": 2021,
-                "marital_status": "widow",
-                "value": 639974.78
+                "MARS": "widow",
+                "value": 639408.99
             },
             {
                 "year": 2022,
-                "marital_status": "single",
-                "value": 545418.51
+                "MARS": "single",
+                "value": 545042.88
             },
             {
                 "year": 2022,
-                "marital_status": "joint",
-                "value": 654502.21
+                "MARS": "mjoint",
+                "value": 654051.45
             },
             {
                 "year": 2022,
-                "marital_status": "separate",
-                "value": 327251.11
+                "MARS": "mseparate",
+                "value": 327025.73
             },
             {
                 "year": 2022,
-                "marital_status": "headhousehold",
-                "value": 545418.51
+                "MARS": "headhh",
+                "value": 545042.88
             },
             {
                 "year": 2022,
-                "marital_status": "widow",
-                "value": 654502.21
+                "MARS": "widow",
+                "value": 654051.45
             },
             {
                 "year": 2023,
-                "marital_status": "single",
-                "value": 557581.34
+                "MARS": "single",
+                "value": 557469.86
             },
             {
                 "year": 2023,
-                "marital_status": "joint",
-                "value": 669097.61
+                "MARS": "mjoint",
+                "value": 668963.83
             },
             {
                 "year": 2023,
-                "marital_status": "separate",
-                "value": 334548.8
+                "MARS": "mseparate",
+                "value": 334481.91
             },
             {
                 "year": 2023,
-                "marital_status": "headhousehold",
-                "value": 557581.34
+                "MARS": "headhh",
+                "value": 557469.86
             },
             {
                 "year": 2023,
-                "marital_status": "widow",
-                "value": 669097.61
+                "MARS": "widow",
+                "value": 668963.83
             },
             {
                 "year": 2024,
-                "marital_status": "single",
-                "value": 569736.61
+                "MARS": "single",
+                "value": 569789.94
             },
             {
                 "year": 2024,
-                "marital_status": "joint",
-                "value": 683683.94
+                "MARS": "mjoint",
+                "value": 683747.93
             },
             {
                 "year": 2024,
-                "marital_status": "separate",
-                "value": 341841.97
+                "MARS": "mseparate",
+                "value": 341873.96
             },
             {
                 "year": 2024,
-                "marital_status": "headhousehold",
-                "value": 569736.61
+                "MARS": "headhh",
+                "value": 569789.94
             },
             {
                 "year": 2024,
-                "marital_status": "widow",
-                "value": 683683.94
+                "MARS": "widow",
+                "value": 683747.93
             },
             {
                 "year": 2025,
-                "marital_status": "single",
-                "value": 581985.95
+                "MARS": "single",
+                "value": 581812.51
             },
             {
                 "year": 2025,
-                "marital_status": "joint",
-                "value": 698383.14
+                "MARS": "mjoint",
+                "value": 698175.01
             },
             {
                 "year": 2025,
-                "marital_status": "separate",
-                "value": 349191.57
+                "MARS": "mseparate",
+                "value": 349087.5
             },
             {
                 "year": 2025,
-                "marital_status": "headhousehold",
-                "value": 581985.95
+                "MARS": "headhh",
+                "value": 581812.51
             },
             {
                 "year": 2025,
-                "marital_status": "widow",
-                "value": 698383.14
+                "MARS": "widow",
+                "value": 698175.01
             },
             {
                 "year": 2026,
-                "marital_status": "single",
-                "value": 506680.0
+                "MARS": "single",
+                "value": 506331.0
             },
             {
                 "year": 2026,
-                "marital_status": "joint",
-                "value": 570015.0
+                "MARS": "mjoint",
+                "value": 569622.0
             },
             {
                 "year": 2026,
-                "marital_status": "separate",
-                "value": 285008.0
+                "MARS": "mseparate",
+                "value": 284811.0
             },
             {
                 "year": 2026,
-                "marital_status": "headhousehold",
-                "value": 538348.0
+                "MARS": "headhh",
+                "value": 537976.0
             },
             {
                 "year": 2026,
-                "marital_status": "widow",
-                "value": 570015.0
+                "MARS": "widow",
+                "value": 569622.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Pass-through income tax bracket (upper threshold) 6",
         "type": "float",
         "validators": {
             "range": {
-                "min": "_PT_brk5",
-                "max": "_PT_brk7"
+                "min": "PT_brk5",
+                "max": "PT_brk7"
             }
-        }
-    },
-    "_PT_rt7": {
-        "description": "The highest tax rate, applied to the portion of income from sole proprietorships, partnerships and S-corporations below tax bracket 7 and above tax bracket 6.",
+        },
         "section_1": "Personal Income",
         "section_2": "Pass-Through",
-        "irs_ref": "Form 1040, line 11, instruction (Schedule XYZ)",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": true,
+        "description": "Income from sole proprietorships, partnerships and S-corporations below this threshold and above tax bracket 5 is taxed at tax rate 6.",
+        "notes": ""
+    },
+    "PT_rt7": {
         "value": [
             {
                 "year": 2013,
@@ -14018,10 +13248,6 @@
                 "value": 0.396
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Pass-through income tax rate 7",
         "type": "float",
         "validators": {
@@ -14029,401 +13255,387 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_PT_brk7": {
-        "description": "Income from sole proprietorships, partnerships and S-corporations below this threshold and above tax bracket 6 is taxed at tax rate 7. Default value is essentially infinity.",
+        },
         "section_1": "Personal Income",
         "section_2": "Pass-Through",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+        "indexed": false,
+        "description": "The highest tax rate, applied to the portion of income from sole proprietorships, partnerships and S-corporations below tax bracket 7 and above tax bracket 6.",
+        "notes": ""
+    },
+    "PT_brk7": {
         "value": [
             {
                 "year": 2013,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2013,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2013,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2013,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2013,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2019,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2019,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2019,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2019,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2019,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2020,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2020,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2020,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2020,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2020,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2021,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2021,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2021,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2021,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2021,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2022,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2022,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2022,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2022,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2022,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2023,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2023,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2023,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2023,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2023,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2024,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2024,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2024,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2024,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2024,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2025,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2025,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2025,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2025,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2025,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2026,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2026,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2026,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2026,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2026,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Extra pass-through income tax bracket",
         "type": "float",
         "validators": {
             "range": {
-                "min": "_PT_brk6",
+                "min": "PT_brk6",
                 "max": 9e+99
             }
-        }
-    },
-    "_PT_rt8": {
-        "description": "The extra tax rate, applied to the portion of income from sole proprietorships, partnerships and S-corporations above the tax bracket 7.",
+        },
         "section_1": "Personal Income",
         "section_2": "Pass-Through",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": true,
+        "description": "Income from sole proprietorships, partnerships and S-corporations below this threshold and above tax bracket 6 is taxed at tax rate 7. Default value is essentially infinity.",
+        "notes": ""
+    },
+    "PT_rt8": {
         "value": [
             {
                 "year": 2013,
                 "value": 1.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Extra pass-through income tax rate",
         "type": "float",
         "validators": {
@@ -14431,27 +13643,20 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_PT_EligibleRate_active": {
-        "description": "Eligibility rate of active business income for separate pass-through rates.",
+        },
         "section_1": "Personal Income",
         "section_2": "Pass-Through",
-        "irs_ref": "",
-        "notes": "Active business income defined as e00900 + e26270",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "The extra tax rate, applied to the portion of income from sole proprietorships, partnerships and S-corporations above the tax bracket 7.",
+        "notes": ""
+    },
+    "PT_EligibleRate_active": {
         "value": [
             {
                 "year": 2013,
                 "value": 1.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Share of active business income eligible for PT rate schedule",
         "type": "float",
         "validators": {
@@ -14459,27 +13664,20 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_PT_EligibleRate_passive": {
-        "description": "Eligibility rate of passive business income for separate pass-through rates.",
+        },
         "section_1": "Personal Income",
         "section_2": "Pass-Through",
-        "irs_ref": "",
-        "notes": "Passive business income defined as e02000 - e26270",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "Eligibility rate of active business income for separate pass-through rates.",
+        "notes": "Active business income defined as e00900 + e26270"
+    },
+    "PT_EligibleRate_passive": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": false
-        },
         "title": "Share of passive business income eligible for PT rate schedule",
         "type": "float",
         "validators": {
@@ -14487,27 +13685,20 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_PT_wages_active_income": {
-        "description": "Whether active business income eligibility base for PT schedule for includes wages.",
+        },
         "section_1": "Personal Income",
         "section_2": "Pass-Through",
-        "irs_ref": "",
-        "notes": "Only applies if active business income is positive",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "Eligibility rate of passive business income for mseparate pass-through rates.",
+        "notes": "Passive business income defined as e02000 - e26270"
+    },
+    "PT_wages_active_income": {
         "value": [
             {
                 "year": 2013,
                 "value": false
             }
         ],
-        "compatible_data": {
-            "puf": false,
-            "cps": false
-        },
         "title": "Wages included in (positive) active business income eligible for PT rates",
         "type": "bool",
         "validators": {
@@ -14515,27 +13706,20 @@
                 "min": false,
                 "max": true
             }
-        }
-    },
-    "_PT_top_stacking": {
-        "description": "Whether taxable income eligible for PT rate schedule is stacked on top of regular taxable income.",
+        },
         "section_1": "Personal Income",
         "section_2": "Pass-Through",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "Whether active business income eligibility base for PT schedule for includes wages.",
+        "notes": "Only applies if active business income is positive"
+    },
+    "PT_top_stacking": {
         "value": [
             {
                 "year": 2013,
                 "value": true
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "PT taxable income stacked on top of regular taxable income",
         "type": "bool",
         "validators": {
@@ -14543,17 +13727,14 @@
                 "min": false,
                 "max": true
             }
-        }
-    },
-    "_PT_excl_rt": {
-        "description": "Fraction of qualified business income excluded from taxable income.",
+        },
         "section_1": "Personal Income",
         "section_2": "Pass-Through",
-        "irs_ref": "",
-        "notes": "Applies to e00900 + e26270",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "Whether taxable income eligible for PT rate schedule is stacked on top of regular taxable income.",
+        "notes": ""
+    },
+    "PT_qbid_rt": {
         "value": [
             {
                 "year": 2013,
@@ -14612,1213 +13793,1326 @@
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
-        "title": "Pass-through income exclusion rate",
+        "title": "Pass-through qualified business income deduction rate",
         "type": "float",
         "validators": {
             "range": {
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_PT_excl_wagelim_rt": {
-        "description": "If taxpayer has partnership/S-corporation income, the amount of business income excluded from taxable income may not exceed this fraction of wages.",
+        },
         "section_1": "Personal Income",
         "section_2": "Pass-Through",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "Fraction of pass-through business income that may be excluded from taxable income.",
+        "notes": "Applies to e00900 + e26270"
+    },
+    "PT_qbid_taxinc_thd": {
         "value": [
             {
                 "year": 2013,
-                "value": 9e+99
+                "MARS": "single",
+                "value": 0.0
+            },
+            {
+                "year": 2013,
+                "MARS": "mjoint",
+                "value": 0.0
+            },
+            {
+                "year": 2013,
+                "MARS": "mseparate",
+                "value": 0.0
+            },
+            {
+                "year": 2013,
+                "MARS": "headhh",
+                "value": 0.0
+            },
+            {
+                "year": 2013,
+                "MARS": "widow",
+                "value": 0.0
             },
             {
                 "year": 2014,
-                "value": 9e+99
+                "MARS": "single",
+                "value": 0.0
+            },
+            {
+                "year": 2014,
+                "MARS": "mjoint",
+                "value": 0.0
+            },
+            {
+                "year": 2014,
+                "MARS": "mseparate",
+                "value": 0.0
+            },
+            {
+                "year": 2014,
+                "MARS": "headhh",
+                "value": 0.0
+            },
+            {
+                "year": 2014,
+                "MARS": "widow",
+                "value": 0.0
             },
             {
                 "year": 2015,
-                "value": 9e+99
+                "MARS": "single",
+                "value": 0.0
+            },
+            {
+                "year": 2015,
+                "MARS": "mjoint",
+                "value": 0.0
+            },
+            {
+                "year": 2015,
+                "MARS": "mseparate",
+                "value": 0.0
+            },
+            {
+                "year": 2015,
+                "MARS": "headhh",
+                "value": 0.0
+            },
+            {
+                "year": 2015,
+                "MARS": "widow",
+                "value": 0.0
             },
             {
                 "year": 2016,
-                "value": 9e+99
+                "MARS": "single",
+                "value": 0.0
+            },
+            {
+                "year": 2016,
+                "MARS": "mjoint",
+                "value": 0.0
+            },
+            {
+                "year": 2016,
+                "MARS": "mseparate",
+                "value": 0.0
+            },
+            {
+                "year": 2016,
+                "MARS": "headhh",
+                "value": 0.0
+            },
+            {
+                "year": 2016,
+                "MARS": "widow",
+                "value": 0.0
             },
             {
                 "year": 2017,
-                "value": 9e+99
+                "MARS": "single",
+                "value": 0.0
+            },
+            {
+                "year": 2017,
+                "MARS": "mjoint",
+                "value": 0.0
+            },
+            {
+                "year": 2017,
+                "MARS": "mseparate",
+                "value": 0.0
+            },
+            {
+                "year": 2017,
+                "MARS": "headhh",
+                "value": 0.0
+            },
+            {
+                "year": 2017,
+                "MARS": "widow",
+                "value": 0.0
             },
             {
                 "year": 2018,
-                "value": 0.5
+                "MARS": "single",
+                "value": 157500.0
+            },
+            {
+                "year": 2018,
+                "MARS": "mjoint",
+                "value": 315000.0
+            },
+            {
+                "year": 2018,
+                "MARS": "mseparate",
+                "value": 157500.0
+            },
+            {
+                "year": 2018,
+                "MARS": "headhh",
+                "value": 157500.0
+            },
+            {
+                "year": 2018,
+                "MARS": "widow",
+                "value": 315000.0
             },
             {
                 "year": 2019,
-                "value": 0.5
+                "MARS": "single",
+                "value": 161028.0
+            },
+            {
+                "year": 2019,
+                "MARS": "mjoint",
+                "value": 322056.0
+            },
+            {
+                "year": 2019,
+                "MARS": "mseparate",
+                "value": 161028.0
+            },
+            {
+                "year": 2019,
+                "MARS": "headhh",
+                "value": 161028.0
+            },
+            {
+                "year": 2019,
+                "MARS": "widow",
+                "value": 322056.0
             },
             {
                 "year": 2020,
-                "value": 0.5
+                "MARS": "single",
+                "value": 164023.12
+            },
+            {
+                "year": 2020,
+                "MARS": "mjoint",
+                "value": 328046.24
+            },
+            {
+                "year": 2020,
+                "MARS": "mseparate",
+                "value": 164023.12
+            },
+            {
+                "year": 2020,
+                "MARS": "headhh",
+                "value": 164023.12
+            },
+            {
+                "year": 2020,
+                "MARS": "widow",
+                "value": 328046.24
             },
             {
                 "year": 2021,
-                "value": 0.5
+                "MARS": "single",
+                "value": 167844.86
+            },
+            {
+                "year": 2021,
+                "MARS": "mjoint",
+                "value": 335689.72
+            },
+            {
+                "year": 2021,
+                "MARS": "mseparate",
+                "value": 167844.86
+            },
+            {
+                "year": 2021,
+                "MARS": "headhh",
+                "value": 167844.86
+            },
+            {
+                "year": 2021,
+                "MARS": "widow",
+                "value": 335689.72
             },
             {
                 "year": 2022,
-                "value": 0.5
+                "MARS": "single",
+                "value": 171688.51
+            },
+            {
+                "year": 2022,
+                "MARS": "mjoint",
+                "value": 343377.01
+            },
+            {
+                "year": 2022,
+                "MARS": "mseparate",
+                "value": 171688.51
+            },
+            {
+                "year": 2022,
+                "MARS": "headhh",
+                "value": 171688.51
+            },
+            {
+                "year": 2022,
+                "MARS": "widow",
+                "value": 343377.01
             },
             {
                 "year": 2023,
-                "value": 0.5
+                "MARS": "single",
+                "value": 175603.0
+            },
+            {
+                "year": 2023,
+                "MARS": "mjoint",
+                "value": 351206.01
+            },
+            {
+                "year": 2023,
+                "MARS": "mseparate",
+                "value": 175603.0
+            },
+            {
+                "year": 2023,
+                "MARS": "headhh",
+                "value": 175603.0
+            },
+            {
+                "year": 2023,
+                "MARS": "widow",
+                "value": 351206.01
             },
             {
                 "year": 2024,
-                "value": 0.5
+                "MARS": "single",
+                "value": 179483.83
+            },
+            {
+                "year": 2024,
+                "MARS": "mjoint",
+                "value": 358967.66
+            },
+            {
+                "year": 2024,
+                "MARS": "mseparate",
+                "value": 179483.83
+            },
+            {
+                "year": 2024,
+                "MARS": "headhh",
+                "value": 179483.83
+            },
+            {
+                "year": 2024,
+                "MARS": "widow",
+                "value": 358967.66
             },
             {
                 "year": 2025,
-                "value": 0.5
+                "MARS": "single",
+                "value": 183270.94
+            },
+            {
+                "year": 2025,
+                "MARS": "mjoint",
+                "value": 366541.88
+            },
+            {
+                "year": 2025,
+                "MARS": "mseparate",
+                "value": 183270.94
+            },
+            {
+                "year": 2025,
+                "MARS": "headhh",
+                "value": 183270.94
+            },
+            {
+                "year": 2025,
+                "MARS": "widow",
+                "value": 366541.88
             },
             {
                 "year": 2026,
-                "value": 9e+99
+                "MARS": "single",
+                "value": 0.0
+            },
+            {
+                "year": 2026,
+                "MARS": "mjoint",
+                "value": 0.0
+            },
+            {
+                "year": 2026,
+                "MARS": "mseparate",
+                "value": 0.0
+            },
+            {
+                "year": 2026,
+                "MARS": "headhh",
+                "value": 0.0
+            },
+            {
+                "year": 2026,
+                "MARS": "widow",
+                "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
-        "title": "Wage limit rate on pass-through income exclusion",
+        "title": "Lower threshold of pre-QBID taxable income",
         "type": "float",
         "validators": {
             "range": {
                 "min": 0,
                 "max": 9e+99
             }
-        }
-    },
-    "_PT_excl_wagelim_thd": {
-        "description": "If taxpayer has partnership/S-corporation income, the amount of business income excluded from taxable income is limited by wages if taxable income exceeds this threshold.",
+        },
         "section_1": "Personal Income",
         "section_2": "Pass-Through",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+        "indexed": true,
+        "description": "Pre-QBID taxable income above this lower threshold implies the QBID amount begins to be limited.",
+        "notes": ""
+    },
+    "PT_qbid_taxinc_gap": {
         "value": [
             {
                 "year": 2013,
-                "marital_status": "single",
-                "value": 0.0
+                "MARS": "single",
+                "value": 1.0
             },
             {
                 "year": 2013,
-                "marital_status": "joint",
-                "value": 0.0
+                "MARS": "mjoint",
+                "value": 1.0
             },
             {
                 "year": 2013,
-                "marital_status": "separate",
-                "value": 0.0
+                "MARS": "mseparate",
+                "value": 1.0
             },
             {
                 "year": 2013,
-                "marital_status": "headhousehold",
-                "value": 0.0
+                "MARS": "headhh",
+                "value": 1.0
             },
             {
                 "year": 2013,
-                "marital_status": "widow",
-                "value": 0.0
+                "MARS": "widow",
+                "value": 1.0
             },
             {
                 "year": 2014,
-                "marital_status": "single",
-                "value": 0.0
+                "MARS": "single",
+                "value": 1.0
             },
             {
                 "year": 2014,
-                "marital_status": "joint",
-                "value": 0.0
+                "MARS": "mjoint",
+                "value": 1.0
             },
             {
                 "year": 2014,
-                "marital_status": "separate",
-                "value": 0.0
+                "MARS": "mseparate",
+                "value": 1.0
             },
             {
                 "year": 2014,
-                "marital_status": "headhousehold",
-                "value": 0.0
+                "MARS": "headhh",
+                "value": 1.0
             },
             {
                 "year": 2014,
-                "marital_status": "widow",
-                "value": 0.0
+                "MARS": "widow",
+                "value": 1.0
             },
             {
                 "year": 2015,
-                "marital_status": "single",
-                "value": 0.0
+                "MARS": "single",
+                "value": 1.0
             },
             {
                 "year": 2015,
-                "marital_status": "joint",
-                "value": 0.0
+                "MARS": "mjoint",
+                "value": 1.0
             },
             {
                 "year": 2015,
-                "marital_status": "separate",
-                "value": 0.0
+                "MARS": "mseparate",
+                "value": 1.0
             },
             {
                 "year": 2015,
-                "marital_status": "headhousehold",
-                "value": 0.0
+                "MARS": "headhh",
+                "value": 1.0
             },
             {
                 "year": 2015,
-                "marital_status": "widow",
-                "value": 0.0
+                "MARS": "widow",
+                "value": 1.0
             },
             {
                 "year": 2016,
-                "marital_status": "single",
-                "value": 0.0
+                "MARS": "single",
+                "value": 1.0
             },
             {
                 "year": 2016,
-                "marital_status": "joint",
-                "value": 0.0
+                "MARS": "mjoint",
+                "value": 1.0
             },
             {
                 "year": 2016,
-                "marital_status": "separate",
-                "value": 0.0
+                "MARS": "mseparate",
+                "value": 1.0
             },
             {
                 "year": 2016,
-                "marital_status": "headhousehold",
-                "value": 0.0
+                "MARS": "headhh",
+                "value": 1.0
             },
             {
                 "year": 2016,
-                "marital_status": "widow",
-                "value": 0.0
+                "MARS": "widow",
+                "value": 1.0
             },
             {
                 "year": 2017,
-                "marital_status": "single",
-                "value": 0.0
+                "MARS": "single",
+                "value": 1.0
             },
             {
                 "year": 2017,
-                "marital_status": "joint",
-                "value": 0.0
+                "MARS": "mjoint",
+                "value": 1.0
             },
             {
                 "year": 2017,
-                "marital_status": "separate",
-                "value": 0.0
+                "MARS": "mseparate",
+                "value": 1.0
             },
             {
                 "year": 2017,
-                "marital_status": "headhousehold",
-                "value": 0.0
+                "MARS": "headhh",
+                "value": 1.0
             },
             {
                 "year": 2017,
-                "marital_status": "widow",
-                "value": 0.0
+                "MARS": "widow",
+                "value": 1.0
             },
             {
                 "year": 2018,
-                "marital_status": "single",
-                "value": 157500.0
+                "MARS": "single",
+                "value": 50000.0
             },
             {
                 "year": 2018,
-                "marital_status": "joint",
-                "value": 315000.0
+                "MARS": "mjoint",
+                "value": 100000.0
             },
             {
                 "year": 2018,
-                "marital_status": "separate",
-                "value": 157500.0
+                "MARS": "mseparate",
+                "value": 50000.0
             },
             {
                 "year": 2018,
-                "marital_status": "headhousehold",
-                "value": 157500.0
+                "MARS": "headhh",
+                "value": 50000.0
             },
             {
                 "year": 2018,
-                "marital_status": "widow",
-                "value": 315000.0
+                "MARS": "widow",
+                "value": 100000.0
             },
             {
                 "year": 2019,
-                "marital_status": "single",
-                "value": 161106.75
+                "MARS": "single",
+                "value": 50000.0
             },
             {
                 "year": 2019,
-                "marital_status": "joint",
-                "value": 322213.5
+                "MARS": "mjoint",
+                "value": 100000.0
             },
             {
                 "year": 2019,
-                "marital_status": "separate",
-                "value": 161106.75
+                "MARS": "mseparate",
+                "value": 50000.0
             },
             {
                 "year": 2019,
-                "marital_status": "headhousehold",
-                "value": 161106.75
+                "MARS": "headhh",
+                "value": 50000.0
             },
             {
                 "year": 2019,
-                "marital_status": "widow",
-                "value": 322213.5
+                "MARS": "widow",
+                "value": 100000.0
             },
             {
                 "year": 2020,
-                "marital_status": "single",
-                "value": 164312.77
+                "MARS": "single",
+                "value": 50000.0
             },
             {
                 "year": 2020,
-                "marital_status": "joint",
-                "value": 328625.55
+                "MARS": "mjoint",
+                "value": 100000.0
             },
             {
                 "year": 2020,
-                "marital_status": "separate",
-                "value": 164312.77
+                "MARS": "mseparate",
+                "value": 50000.0
             },
             {
                 "year": 2020,
-                "marital_status": "headhousehold",
-                "value": 164312.77
+                "MARS": "headhh",
+                "value": 50000.0
             },
             {
                 "year": 2020,
-                "marital_status": "widow",
-                "value": 328625.55
+                "MARS": "widow",
+                "value": 100000.0
             },
             {
                 "year": 2021,
-                "marital_status": "single",
-                "value": 167993.38
+                "MARS": "single",
+                "value": 50000.0
             },
             {
                 "year": 2021,
-                "marital_status": "joint",
-                "value": 335986.76
+                "MARS": "mjoint",
+                "value": 100000.0
             },
             {
                 "year": 2021,
-                "marital_status": "separate",
-                "value": 167993.38
+                "MARS": "mseparate",
+                "value": 50000.0
             },
             {
                 "year": 2021,
-                "marital_status": "headhousehold",
-                "value": 167993.38
+                "MARS": "headhh",
+                "value": 50000.0
             },
             {
                 "year": 2021,
-                "marital_status": "widow",
-                "value": 335986.76
+                "MARS": "widow",
+                "value": 100000.0
             },
             {
                 "year": 2022,
-                "marital_status": "single",
-                "value": 171806.83
+                "MARS": "single",
+                "value": 50000.0
             },
             {
                 "year": 2022,
-                "marital_status": "joint",
-                "value": 343613.66
+                "MARS": "mjoint",
+                "value": 100000.0
             },
             {
                 "year": 2022,
-                "marital_status": "separate",
-                "value": 171806.83
+                "MARS": "mseparate",
+                "value": 50000.0
             },
             {
                 "year": 2022,
-                "marital_status": "headhousehold",
-                "value": 171806.83
+                "MARS": "headhh",
+                "value": 50000.0
             },
             {
                 "year": 2022,
-                "marital_status": "widow",
-                "value": 343613.66
+                "MARS": "widow",
+                "value": 100000.0
             },
             {
                 "year": 2023,
-                "marital_status": "single",
-                "value": 175638.12
+                "MARS": "single",
+                "value": 50000.0
             },
             {
                 "year": 2023,
-                "marital_status": "joint",
-                "value": 351276.25
+                "MARS": "mjoint",
+                "value": 100000.0
             },
             {
                 "year": 2023,
-                "marital_status": "separate",
-                "value": 175638.12
+                "MARS": "mseparate",
+                "value": 50000.0
             },
             {
                 "year": 2023,
-                "marital_status": "headhousehold",
-                "value": 175638.12
+                "MARS": "headhh",
+                "value": 50000.0
             },
             {
                 "year": 2023,
-                "marital_status": "widow",
-                "value": 351276.25
+                "MARS": "widow",
+                "value": 100000.0
             },
             {
                 "year": 2024,
-                "marital_status": "single",
-                "value": 179467.03
+                "MARS": "single",
+                "value": 50000.0
             },
             {
                 "year": 2024,
-                "marital_status": "joint",
-                "value": 358934.07
+                "MARS": "mjoint",
+                "value": 100000.0
             },
             {
                 "year": 2024,
-                "marital_status": "separate",
-                "value": 179467.03
+                "MARS": "mseparate",
+                "value": 50000.0
             },
             {
                 "year": 2024,
-                "marital_status": "headhousehold",
-                "value": 179467.03
+                "MARS": "headhh",
+                "value": 50000.0
             },
             {
                 "year": 2024,
-                "marital_status": "widow",
-                "value": 358934.07
+                "MARS": "widow",
+                "value": 100000.0
             },
             {
                 "year": 2025,
-                "marital_status": "single",
-                "value": 183325.57
+                "MARS": "single",
+                "value": 50000.0
             },
             {
                 "year": 2025,
-                "marital_status": "joint",
-                "value": 366651.15
+                "MARS": "mjoint",
+                "value": 100000.0
             },
             {
                 "year": 2025,
-                "marital_status": "separate",
-                "value": 183325.57
+                "MARS": "mseparate",
+                "value": 50000.0
             },
             {
                 "year": 2025,
-                "marital_status": "headhousehold",
-                "value": 183325.57
+                "MARS": "headhh",
+                "value": 50000.0
             },
             {
                 "year": 2025,
-                "marital_status": "widow",
-                "value": 366651.15
+                "MARS": "widow",
+                "value": 100000.0
             },
             {
                 "year": 2026,
-                "marital_status": "single",
-                "value": 0.0
+                "MARS": "single",
+                "value": 1.0
             },
             {
                 "year": 2026,
-                "marital_status": "joint",
-                "value": 0.0
+                "MARS": "mjoint",
+                "value": 1.0
             },
             {
                 "year": 2026,
-                "marital_status": "separate",
-                "value": 0.0
+                "MARS": "mseparate",
+                "value": 1.0
             },
             {
                 "year": 2026,
-                "marital_status": "headhousehold",
-                "value": 0.0
+                "MARS": "headhh",
+                "value": 1.0
             },
             {
                 "year": 2026,
-                "marital_status": "widow",
-                "value": 0.0
+                "MARS": "widow",
+                "value": 1.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
-        "title": "Phase-in threshold of wage limit on pass-through income exclusion",
+        "title": "Dollar gap between upper and lower threshold of pre-QBID taxable income",
         "type": "float",
         "validators": {
             "range": {
-                "min": 0,
+                "min": 1,
                 "max": 9e+99
             }
-        }
-    },
-    "_PT_excl_wagelim_prt": {
-        "description": "If taxpayer has partnership/S-corporation income, the wage limitation on the amount of business income excluded from taxable income is phased in at this rate.",
+        },
         "section_1": "Personal Income",
         "section_2": "Pass-Through",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "Pre-QBID taxable income above this upper threshold implies the QBID amount is even more limited.",
+        "notes": ""
+    },
+    "PT_qbid_w2_wages_rt": {
         "value": [
             {
                 "year": 2013,
-                "marital_status": "single",
-                "value": 0.0
-            },
-            {
-                "year": 2013,
-                "marital_status": "joint",
-                "value": 0.0
-            },
-            {
-                "year": 2013,
-                "marital_status": "separate",
-                "value": 0.0
-            },
-            {
-                "year": 2013,
-                "marital_status": "headhousehold",
-                "value": 0.0
-            },
-            {
-                "year": 2013,
-                "marital_status": "widow",
                 "value": 0.0
             },
             {
                 "year": 2014,
-                "marital_status": "single",
-                "value": 0.0
-            },
-            {
-                "year": 2014,
-                "marital_status": "joint",
-                "value": 0.0
-            },
-            {
-                "year": 2014,
-                "marital_status": "separate",
-                "value": 0.0
-            },
-            {
-                "year": 2014,
-                "marital_status": "headhousehold",
-                "value": 0.0
-            },
-            {
-                "year": 2014,
-                "marital_status": "widow",
                 "value": 0.0
             },
             {
                 "year": 2015,
-                "marital_status": "single",
-                "value": 0.0
-            },
-            {
-                "year": 2015,
-                "marital_status": "joint",
-                "value": 0.0
-            },
-            {
-                "year": 2015,
-                "marital_status": "separate",
-                "value": 0.0
-            },
-            {
-                "year": 2015,
-                "marital_status": "headhousehold",
-                "value": 0.0
-            },
-            {
-                "year": 2015,
-                "marital_status": "widow",
                 "value": 0.0
             },
             {
                 "year": 2016,
-                "marital_status": "single",
-                "value": 0.0
-            },
-            {
-                "year": 2016,
-                "marital_status": "joint",
-                "value": 0.0
-            },
-            {
-                "year": 2016,
-                "marital_status": "separate",
-                "value": 0.0
-            },
-            {
-                "year": 2016,
-                "marital_status": "headhousehold",
-                "value": 0.0
-            },
-            {
-                "year": 2016,
-                "marital_status": "widow",
                 "value": 0.0
             },
             {
                 "year": 2017,
-                "marital_status": "single",
-                "value": 0.0
-            },
-            {
-                "year": 2017,
-                "marital_status": "joint",
-                "value": 0.0
-            },
-            {
-                "year": 2017,
-                "marital_status": "separate",
-                "value": 0.0
-            },
-            {
-                "year": 2017,
-                "marital_status": "headhousehold",
-                "value": 0.0
-            },
-            {
-                "year": 2017,
-                "marital_status": "widow",
                 "value": 0.0
             },
             {
                 "year": 2018,
-                "marital_status": "single",
-                "value": 2e-05
-            },
-            {
-                "year": 2018,
-                "marital_status": "joint",
-                "value": 1e-05
-            },
-            {
-                "year": 2018,
-                "marital_status": "separate",
-                "value": 2e-05
-            },
-            {
-                "year": 2018,
-                "marital_status": "headhousehold",
-                "value": 2e-05
-            },
-            {
-                "year": 2018,
-                "marital_status": "widow",
-                "value": 1e-05
+                "value": 0.5
             },
             {
                 "year": 2019,
-                "marital_status": "single",
-                "value": 2e-05
-            },
-            {
-                "year": 2019,
-                "marital_status": "joint",
-                "value": 1e-05
-            },
-            {
-                "year": 2019,
-                "marital_status": "separate",
-                "value": 2e-05
-            },
-            {
-                "year": 2019,
-                "marital_status": "headhousehold",
-                "value": 2e-05
-            },
-            {
-                "year": 2019,
-                "marital_status": "widow",
-                "value": 1e-05
+                "value": 0.5
             },
             {
                 "year": 2020,
-                "marital_status": "single",
-                "value": 2e-05
-            },
-            {
-                "year": 2020,
-                "marital_status": "joint",
-                "value": 1e-05
-            },
-            {
-                "year": 2020,
-                "marital_status": "separate",
-                "value": 2e-05
-            },
-            {
-                "year": 2020,
-                "marital_status": "headhousehold",
-                "value": 2e-05
-            },
-            {
-                "year": 2020,
-                "marital_status": "widow",
-                "value": 1e-05
+                "value": 0.5
             },
             {
                 "year": 2021,
-                "marital_status": "single",
-                "value": 2e-05
-            },
-            {
-                "year": 2021,
-                "marital_status": "joint",
-                "value": 1e-05
-            },
-            {
-                "year": 2021,
-                "marital_status": "separate",
-                "value": 2e-05
-            },
-            {
-                "year": 2021,
-                "marital_status": "headhousehold",
-                "value": 2e-05
-            },
-            {
-                "year": 2021,
-                "marital_status": "widow",
-                "value": 1e-05
+                "value": 0.5
             },
             {
                 "year": 2022,
-                "marital_status": "single",
-                "value": 2e-05
-            },
-            {
-                "year": 2022,
-                "marital_status": "joint",
-                "value": 1e-05
-            },
-            {
-                "year": 2022,
-                "marital_status": "separate",
-                "value": 2e-05
-            },
-            {
-                "year": 2022,
-                "marital_status": "headhousehold",
-                "value": 2e-05
-            },
-            {
-                "year": 2022,
-                "marital_status": "widow",
-                "value": 1e-05
+                "value": 0.5
             },
             {
                 "year": 2023,
-                "marital_status": "single",
-                "value": 2e-05
-            },
-            {
-                "year": 2023,
-                "marital_status": "joint",
-                "value": 1e-05
-            },
-            {
-                "year": 2023,
-                "marital_status": "separate",
-                "value": 2e-05
-            },
-            {
-                "year": 2023,
-                "marital_status": "headhousehold",
-                "value": 2e-05
-            },
-            {
-                "year": 2023,
-                "marital_status": "widow",
-                "value": 1e-05
+                "value": 0.5
             },
             {
                 "year": 2024,
-                "marital_status": "single",
-                "value": 2e-05
-            },
-            {
-                "year": 2024,
-                "marital_status": "joint",
-                "value": 1e-05
-            },
-            {
-                "year": 2024,
-                "marital_status": "separate",
-                "value": 2e-05
-            },
-            {
-                "year": 2024,
-                "marital_status": "headhousehold",
-                "value": 2e-05
-            },
-            {
-                "year": 2024,
-                "marital_status": "widow",
-                "value": 1e-05
+                "value": 0.5
             },
             {
                 "year": 2025,
-                "marital_status": "single",
-                "value": 2e-05
-            },
-            {
-                "year": 2025,
-                "marital_status": "joint",
-                "value": 1e-05
-            },
-            {
-                "year": 2025,
-                "marital_status": "separate",
-                "value": 2e-05
-            },
-            {
-                "year": 2025,
-                "marital_status": "headhousehold",
-                "value": 2e-05
-            },
-            {
-                "year": 2025,
-                "marital_status": "widow",
-                "value": 1e-05
+                "value": 0.5
             },
             {
                 "year": 2026,
-                "marital_status": "single",
-                "value": 0.0
-            },
-            {
-                "year": 2026,
-                "marital_status": "joint",
-                "value": 0.0
-            },
-            {
-                "year": 2026,
-                "marital_status": "separate",
-                "value": 0.0
-            },
-            {
-                "year": 2026,
-                "marital_status": "headhousehold",
-                "value": 0.0
-            },
-            {
-                "year": 2026,
-                "marital_status": "widow",
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
-        "title": "Phase-in rate of wage limit on pass-through income exclusion",
+        "title": "QBID cap rate on pass-through business W-2 wages paid",
         "type": "float",
         "validators": {
             "range": {
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_AMT_em": {
-        "description": "The amount of AMT taxable income exempted from AMT.",
+        },
         "section_1": "Personal Income",
-        "section_2": "Alternative Minimum Tax",
-        "section_3": "Exemption",
-        "irs_ref": "Form 1040 (Schedule 2), line 45, instruction (Worksheet).",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+        "section_2": "Pass-Through",
+        "indexed": false,
+        "description": "QBID is capped at this fraction of W-2 wages paid by the pass-through business if pre-QBID taxable income is above the QBID thresholds.",
+        "notes": ""
+    },
+    "PT_qbid_alt_w2_wages_rt": {
         "value": [
             {
                 "year": 2013,
-                "marital_status": "single",
+                "value": 0.0
+            },
+            {
+                "year": 2014,
+                "value": 0.0
+            },
+            {
+                "year": 2015,
+                "value": 0.0
+            },
+            {
+                "year": 2016,
+                "value": 0.0
+            },
+            {
+                "year": 2017,
+                "value": 0.0
+            },
+            {
+                "year": 2018,
+                "value": 0.25
+            },
+            {
+                "year": 2019,
+                "value": 0.25
+            },
+            {
+                "year": 2020,
+                "value": 0.25
+            },
+            {
+                "year": 2021,
+                "value": 0.25
+            },
+            {
+                "year": 2022,
+                "value": 0.25
+            },
+            {
+                "year": 2023,
+                "value": 0.25
+            },
+            {
+                "year": 2024,
+                "value": 0.25
+            },
+            {
+                "year": 2025,
+                "value": 0.25
+            },
+            {
+                "year": 2026,
+                "value": 0.0
+            }
+        ],
+        "title": "Alternative QBID cap rate on pass-through business W-2 wages paid",
+        "type": "float",
+        "validators": {
+            "range": {
+                "min": 0,
+                "max": 1
+            }
+        },
+        "section_1": "Personal Income",
+        "section_2": "Pass-Through",
+        "indexed": false,
+        "description": "QBID is capped at this fraction of W-2 wages paid by the pass-through business plus some fraction of business property if pre-QBID taxable income is above the QBID thresholds and the alternative cap is higher than the main wage-only cap.",
+        "notes": ""
+    },
+    "PT_qbid_alt_property_rt": {
+        "value": [
+            {
+                "year": 2013,
+                "value": 0.0
+            },
+            {
+                "year": 2014,
+                "value": 0.0
+            },
+            {
+                "year": 2015,
+                "value": 0.0
+            },
+            {
+                "year": 2016,
+                "value": 0.0
+            },
+            {
+                "year": 2017,
+                "value": 0.0
+            },
+            {
+                "year": 2018,
+                "value": 0.025
+            },
+            {
+                "year": 2019,
+                "value": 0.025
+            },
+            {
+                "year": 2020,
+                "value": 0.025
+            },
+            {
+                "year": 2021,
+                "value": 0.025
+            },
+            {
+                "year": 2022,
+                "value": 0.025
+            },
+            {
+                "year": 2023,
+                "value": 0.025
+            },
+            {
+                "year": 2024,
+                "value": 0.025
+            },
+            {
+                "year": 2025,
+                "value": 0.025
+            },
+            {
+                "year": 2026,
+                "value": 0.0
+            }
+        ],
+        "title": "Alternative QBID cap rate on pass-through business property owned",
+        "type": "float",
+        "validators": {
+            "range": {
+                "min": 0,
+                "max": 1
+            }
+        },
+        "section_1": "Personal Income",
+        "section_2": "Pass-Through",
+        "indexed": false,
+        "description": "QBID is capped at this fraction of business property owned plus some fraction of W-2 wages paid by the pass-through business if pre-QBID taxable income is above the QBID thresholds and the alternative cap is higher than the main wage-only cap.",
+        "notes": ""
+    },
+    "AMT_em": {
+        "value": [
+            {
+                "year": 2013,
+                "MARS": "single",
                 "value": 51900.0
             },
             {
                 "year": 2013,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 80800.0
             },
             {
                 "year": 2013,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 40400.0
             },
             {
                 "year": 2013,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 51900.0
             },
             {
                 "year": 2013,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 80800.0
             },
             {
                 "year": 2014,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 52800.0
             },
             {
                 "year": 2014,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 82100.0
             },
             {
                 "year": 2014,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 41050.0
             },
             {
                 "year": 2014,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 52800.0
             },
             {
                 "year": 2014,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 82100.0
             },
             {
                 "year": 2015,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 53600.0
             },
             {
                 "year": 2015,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 83400.0
             },
             {
                 "year": 2015,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 41700.0
             },
             {
                 "year": 2015,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 53600.0
             },
             {
                 "year": 2015,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 83400.0
             },
             {
                 "year": 2016,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 53900.0
             },
             {
                 "year": 2016,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 83800.0
             },
             {
                 "year": 2016,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 41900.0
             },
             {
                 "year": 2016,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 53900.0
             },
             {
                 "year": 2016,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 83800.0
             },
             {
                 "year": 2017,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 54300.0
             },
             {
                 "year": 2017,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 84500.0
             },
             {
                 "year": 2017,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 42250.0
             },
             {
                 "year": 2017,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 54300.0
             },
             {
                 "year": 2017,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 84500.0
             },
             {
                 "year": 2018,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 70300.0
             },
             {
                 "year": 2018,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 109400.0
             },
             {
                 "year": 2018,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 54700.0
             },
             {
                 "year": 2018,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 70300.0
             },
             {
                 "year": 2018,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 109400.0
             },
             {
                 "year": 2019,
-                "marital_status": "single",
-                "value": 71909.87
+                "MARS": "single",
+                "value": 71874.72
             },
             {
                 "year": 2019,
-                "marital_status": "joint",
-                "value": 111905.26
+                "MARS": "mjoint",
+                "value": 111850.56
             },
             {
                 "year": 2019,
-                "marital_status": "separate",
-                "value": 55952.63
+                "MARS": "mseparate",
+                "value": 55925.28
             },
             {
                 "year": 2019,
-                "marital_status": "headhousehold",
-                "value": 71909.87
+                "MARS": "headhh",
+                "value": 71874.72
             },
             {
                 "year": 2019,
-                "marital_status": "widow",
-                "value": 111905.26
+                "MARS": "widow",
+                "value": 111850.56
             },
             {
                 "year": 2020,
-                "marital_status": "single",
-                "value": 73340.88
+                "MARS": "single",
+                "value": 73211.59
             },
             {
                 "year": 2020,
-                "marital_status": "joint",
-                "value": 114132.17
+                "MARS": "mjoint",
+                "value": 113930.98
             },
             {
                 "year": 2020,
-                "marital_status": "separate",
-                "value": 57066.09
+                "MARS": "mseparate",
+                "value": 56965.49
             },
             {
                 "year": 2020,
-                "marital_status": "headhousehold",
-                "value": 73340.88
+                "MARS": "headhh",
+                "value": 73211.59
             },
             {
                 "year": 2020,
-                "marital_status": "widow",
-                "value": 114132.17
+                "MARS": "widow",
+                "value": 113930.98
             },
             {
                 "year": 2021,
-                "marital_status": "single",
-                "value": 74983.71
+                "MARS": "single",
+                "value": 74917.42
             },
             {
                 "year": 2021,
-                "marital_status": "joint",
-                "value": 116688.74
+                "MARS": "mjoint",
+                "value": 116585.57
             },
             {
                 "year": 2021,
-                "marital_status": "separate",
-                "value": 58344.37
+                "MARS": "mseparate",
+                "value": 58292.79
             },
             {
                 "year": 2021,
-                "marital_status": "headhousehold",
-                "value": 74983.71
+                "MARS": "headhh",
+                "value": 74917.42
             },
             {
                 "year": 2021,
-                "marital_status": "widow",
-                "value": 116688.74
+                "MARS": "widow",
+                "value": 116585.57
             },
             {
                 "year": 2022,
-                "marital_status": "single",
-                "value": 76685.84
+                "MARS": "single",
+                "value": 76633.03
             },
             {
                 "year": 2022,
-                "marital_status": "joint",
-                "value": 119337.57
+                "MARS": "mjoint",
+                "value": 119255.38
             },
             {
                 "year": 2022,
-                "marital_status": "separate",
-                "value": 59668.78
+                "MARS": "mseparate",
+                "value": 59627.69
             },
             {
                 "year": 2022,
-                "marital_status": "headhousehold",
-                "value": 76685.84
+                "MARS": "headhh",
+                "value": 76633.03
             },
             {
                 "year": 2022,
-                "marital_status": "widow",
-                "value": 119337.57
+                "MARS": "widow",
+                "value": 119255.38
             },
             {
                 "year": 2023,
-                "marital_status": "single",
-                "value": 78395.94
+                "MARS": "single",
+                "value": 78380.26
             },
             {
                 "year": 2023,
-                "marital_status": "joint",
-                "value": 121998.8
+                "MARS": "mjoint",
+                "value": 121974.4
             },
             {
                 "year": 2023,
-                "marital_status": "separate",
-                "value": 60999.4
+                "MARS": "mseparate",
+                "value": 60987.2
             },
             {
                 "year": 2023,
-                "marital_status": "headhousehold",
-                "value": 78395.94
+                "MARS": "headhh",
+                "value": 78380.26
             },
             {
                 "year": 2023,
-                "marital_status": "widow",
-                "value": 121998.8
+                "MARS": "widow",
+                "value": 121974.4
             },
             {
                 "year": 2024,
-                "marital_status": "single",
-                "value": 80104.97
+                "MARS": "single",
+                "value": 80112.47
             },
             {
                 "year": 2024,
-                "marital_status": "joint",
-                "value": 124658.37
+                "MARS": "mjoint",
+                "value": 124670.04
             },
             {
                 "year": 2024,
-                "marital_status": "separate",
-                "value": 62329.19
+                "MARS": "mseparate",
+                "value": 62335.02
             },
             {
                 "year": 2024,
-                "marital_status": "headhousehold",
-                "value": 80104.97
+                "MARS": "headhh",
+                "value": 80112.47
             },
             {
                 "year": 2024,
-                "marital_status": "widow",
-                "value": 124658.37
+                "MARS": "widow",
+                "value": 124670.04
             },
             {
                 "year": 2025,
-                "marital_status": "single",
-                "value": 81827.22
+                "MARS": "single",
+                "value": 81802.84
             },
             {
                 "year": 2025,
-                "marital_status": "joint",
-                "value": 127338.53
+                "MARS": "mjoint",
+                "value": 127300.58
             },
             {
                 "year": 2025,
-                "marital_status": "separate",
-                "value": 63669.26
+                "MARS": "mseparate",
+                "value": 63650.29
             },
             {
                 "year": 2025,
-                "marital_status": "headhousehold",
-                "value": 81827.22
+                "MARS": "headhh",
+                "value": 81802.84
             },
             {
                 "year": 2025,
-                "marital_status": "widow",
-                "value": 127338.53
+                "MARS": "widow",
+                "value": 127300.58
             },
             {
                 "year": 2026,
-                "marital_status": "single",
-                "value": 65757.0
+                "MARS": "single",
+                "value": 65712.0
             },
             {
                 "year": 2026,
-                "marital_status": "joint",
-                "value": 102329.0
+                "MARS": "mjoint",
+                "value": 102258.0
             },
             {
                 "year": 2026,
-                "marital_status": "separate",
-                "value": 51165.0
+                "MARS": "mseparate",
+                "value": 51129.0
             },
             {
                 "year": 2026,
-                "marital_status": "headhousehold",
-                "value": 65757.0
+                "MARS": "headhh",
+                "value": 65712.0
             },
             {
                 "year": 2026,
-                "marital_status": "widow",
-                "value": 102329.0
+                "MARS": "widow",
+                "value": 102258.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "AMT exemption amount",
         "type": "float",
         "validators": {
@@ -15826,28 +15120,20 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
-    },
-    "_AMT_prt": {
-        "description": "AMT exemption will decrease at this rate for each dollar of AMT taxable income exceeding AMT phaseout start.",
+        },
         "section_1": "Personal Income",
         "section_2": "Alternative Minimum Tax",
-        "section_3": "Exemption",
-        "irs_ref": "Form 1040 (Schedule 2), line 45, instruction (Worksheet).",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": true,
+        "description": "The amount of AMT taxable income exempted from AMT.",
+        "notes": ""
+    },
+    "AMT_prt": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.25
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "AMT exemption phaseout rate",
         "type": "float",
         "validators": {
@@ -15855,374 +15141,366 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_AMT_em_ps": {
-        "description": "AMT exemption starts to decrease when AMT taxable income goes beyond this threshold.",
+        },
         "section_1": "Personal Income",
         "section_2": "Alternative Minimum Tax",
-        "section_3": "Exemption",
-        "irs_ref": "Form 1040 (Schedule 2), line 45, instruction (Worksheet).",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+        "indexed": false,
+        "description": "AMT exemption will decrease at this rate for each dollar of AMT taxable income exceeding AMT phaseout start.",
+        "notes": ""
+    },
+    "AMT_em_ps": {
         "value": [
             {
                 "year": 2013,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 115400.0
             },
             {
                 "year": 2013,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 153900.0
             },
             {
                 "year": 2013,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 76950.0
             },
             {
                 "year": 2013,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 115400.0
             },
             {
                 "year": 2013,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 153900.0
             },
             {
                 "year": 2014,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 117300.0
             },
             {
                 "year": 2014,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 156500.0
             },
             {
                 "year": 2014,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 78250.0
             },
             {
                 "year": 2014,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 117300.0
             },
             {
                 "year": 2014,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 156500.0
             },
             {
                 "year": 2015,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 119200.0
             },
             {
                 "year": 2015,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 158900.0
             },
             {
                 "year": 2015,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 79450.0
             },
             {
                 "year": 2015,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 119200.0
             },
             {
                 "year": 2015,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 158900.0
             },
             {
                 "year": 2016,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 119700.0
             },
             {
                 "year": 2016,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 159700.0
             },
             {
                 "year": 2016,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 79850.0
             },
             {
                 "year": 2016,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 119700.0
             },
             {
                 "year": 2016,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 159700.0
             },
             {
                 "year": 2017,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 120700.0
             },
             {
                 "year": 2017,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 160900.0
             },
             {
                 "year": 2017,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 80450.0
             },
             {
                 "year": 2017,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 120700.0
             },
             {
                 "year": 2017,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 160900.0
             },
             {
                 "year": 2018,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 500000.0
             },
             {
                 "year": 2018,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 1000000.0
             },
             {
                 "year": 2018,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 500000.0
             },
             {
                 "year": 2018,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 500000.0
             },
             {
                 "year": 2018,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 1000000.0
             },
             {
                 "year": 2019,
-                "marital_status": "single",
-                "value": 511450.0
+                "MARS": "single",
+                "value": 511200.0
             },
             {
                 "year": 2019,
-                "marital_status": "joint",
-                "value": 1022900.0
+                "MARS": "mjoint",
+                "value": 1022400.0
             },
             {
                 "year": 2019,
-                "marital_status": "separate",
-                "value": 511450.0
+                "MARS": "mseparate",
+                "value": 511200.0
             },
             {
                 "year": 2019,
-                "marital_status": "headhousehold",
-                "value": 511450.0
+                "MARS": "headhh",
+                "value": 511200.0
             },
             {
                 "year": 2019,
-                "marital_status": "widow",
-                "value": 1022900.0
+                "MARS": "widow",
+                "value": 1022400.0
             },
             {
                 "year": 2020,
-                "marital_status": "single",
-                "value": 521627.86
+                "MARS": "single",
+                "value": 520708.32
             },
             {
                 "year": 2020,
-                "marital_status": "joint",
-                "value": 1043255.71
+                "MARS": "mjoint",
+                "value": 1041416.64
             },
             {
                 "year": 2020,
-                "marital_status": "separate",
-                "value": 521627.86
+                "MARS": "mseparate",
+                "value": 520708.32
             },
             {
                 "year": 2020,
-                "marital_status": "headhousehold",
-                "value": 521627.86
+                "MARS": "headhh",
+                "value": 520708.32
             },
             {
                 "year": 2020,
-                "marital_status": "widow",
-                "value": 1043255.71
+                "MARS": "widow",
+                "value": 1041416.64
             },
             {
                 "year": 2021,
-                "marital_status": "single",
-                "value": 533312.32
+                "MARS": "single",
+                "value": 532840.82
             },
             {
                 "year": 2021,
-                "marital_status": "joint",
-                "value": 1066624.64
+                "MARS": "mjoint",
+                "value": 1065681.65
             },
             {
                 "year": 2021,
-                "marital_status": "separate",
-                "value": 533312.32
+                "MARS": "mseparate",
+                "value": 532840.82
             },
             {
                 "year": 2021,
-                "marital_status": "headhousehold",
-                "value": 533312.32
+                "MARS": "headhh",
+                "value": 532840.82
             },
             {
                 "year": 2021,
-                "marital_status": "widow",
-                "value": 1066624.64
+                "MARS": "widow",
+                "value": 1065681.65
             },
             {
                 "year": 2022,
-                "marital_status": "single",
-                "value": 545418.51
+                "MARS": "single",
+                "value": 545042.88
             },
             {
                 "year": 2022,
-                "marital_status": "joint",
-                "value": 1090837.02
+                "MARS": "mjoint",
+                "value": 1090085.76
             },
             {
                 "year": 2022,
-                "marital_status": "separate",
-                "value": 545418.51
+                "MARS": "mseparate",
+                "value": 545042.88
             },
             {
                 "year": 2022,
-                "marital_status": "headhousehold",
-                "value": 545418.51
+                "MARS": "headhh",
+                "value": 545042.88
             },
             {
                 "year": 2022,
-                "marital_status": "widow",
-                "value": 1090837.02
+                "MARS": "widow",
+                "value": 1090085.76
             },
             {
                 "year": 2023,
-                "marital_status": "single",
-                "value": 557581.34
+                "MARS": "single",
+                "value": 557469.86
             },
             {
                 "year": 2023,
-                "marital_status": "joint",
-                "value": 1115162.68
+                "MARS": "mjoint",
+                "value": 1114939.71
             },
             {
                 "year": 2023,
-                "marital_status": "separate",
-                "value": 557581.34
+                "MARS": "mseparate",
+                "value": 557469.86
             },
             {
                 "year": 2023,
-                "marital_status": "headhousehold",
-                "value": 557581.34
+                "MARS": "headhh",
+                "value": 557469.86
             },
             {
                 "year": 2023,
-                "marital_status": "widow",
-                "value": 1115162.68
+                "MARS": "widow",
+                "value": 1114939.71
             },
             {
                 "year": 2024,
-                "marital_status": "single",
-                "value": 569736.61
+                "MARS": "single",
+                "value": 569789.94
             },
             {
                 "year": 2024,
-                "marital_status": "joint",
-                "value": 1139473.23
+                "MARS": "mjoint",
+                "value": 1139579.88
             },
             {
                 "year": 2024,
-                "marital_status": "separate",
-                "value": 569736.61
+                "MARS": "mseparate",
+                "value": 569789.94
             },
             {
                 "year": 2024,
-                "marital_status": "headhousehold",
-                "value": 569736.61
+                "MARS": "headhh",
+                "value": 569789.94
             },
             {
                 "year": 2024,
-                "marital_status": "widow",
-                "value": 1139473.23
+                "MARS": "widow",
+                "value": 1139579.88
             },
             {
                 "year": 2025,
-                "marital_status": "single",
-                "value": 581985.95
+                "MARS": "single",
+                "value": 581812.51
             },
             {
                 "year": 2025,
-                "marital_status": "joint",
-                "value": 1163971.9
+                "MARS": "mjoint",
+                "value": 1163625.02
             },
             {
                 "year": 2025,
-                "marital_status": "separate",
-                "value": 581985.95
+                "MARS": "mseparate",
+                "value": 581812.51
             },
             {
                 "year": 2025,
-                "marital_status": "headhousehold",
-                "value": 581985.95
+                "MARS": "headhh",
+                "value": 581812.51
             },
             {
                 "year": 2025,
-                "marital_status": "widow",
-                "value": 1163971.9
+                "MARS": "widow",
+                "value": 1163625.02
             },
             {
                 "year": 2026,
-                "marital_status": "single",
-                "value": 146167.0
+                "MARS": "single",
+                "value": 146066.0
             },
             {
                 "year": 2026,
-                "marital_status": "joint",
-                "value": 194849.0
+                "MARS": "mjoint",
+                "value": 194715.0
             },
             {
                 "year": 2026,
-                "marital_status": "separate",
-                "value": 97425.0
+                "MARS": "mseparate",
+                "value": 97357.0
             },
             {
                 "year": 2026,
-                "marital_status": "headhousehold",
-                "value": 146167.0
+                "MARS": "headhh",
+                "value": 146066.0
             },
             {
                 "year": 2026,
-                "marital_status": "widow",
-                "value": 194849.0
+                "MARS": "widow",
+                "value": 194715.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "AMT exemption phaseout start",
         "type": "float",
         "validators": {
@@ -16230,17 +15508,14 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
+        },
+        "section_1": "Personal Income",
+        "section_2": "Alternative Minimum Tax",
+        "indexed": true,
+        "description": "AMT exemption starts to decrease when AMT taxable income goes beyond this threshold.",
+        "notes": ""
     },
-    "_AMT_child_em": {
-        "description": "The child's AMT exemption is capped by this amount plus the child's earned income.",
-        "section_1": "",
-        "section_2": "",
-        "irs_ref": "Form 6251, line 5, instruction.",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+    "AMT_child_em": {
         "value": [
             {
                 "year": 2013,
@@ -16267,10 +15542,6 @@
                 "value": 7600.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Child AMT exemption additional income base",
         "type": "float",
         "validators": {
@@ -16278,27 +15549,20 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
-    },
-    "_AMT_child_em_c_age": {
-        "description": "Individuals under this age must use the child AMT exemption rules.",
+        },
         "section_1": "",
         "section_2": "",
-        "irs_ref": "Form 6251, line 5, instruction.",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": true,
+        "description": "The child's AMT exemption is capped by this amount plus the child's earned income.",
+        "notes": ""
+    },
+    "AMT_child_em_c_age": {
         "value": [
             {
                 "year": 2013,
                 "value": 18
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Age ceiling for special AMT exemption",
         "type": "int",
         "validators": {
@@ -16306,28 +15570,20 @@
                 "min": 0,
                 "max": 30
             }
-        }
+        },
+        "section_1": "",
+        "section_2": "",
+        "indexed": false,
+        "description": "Individuals under this age must use the child AMT exemption rules.",
+        "notes": ""
     },
-    "_AMT_rt1": {
-        "description": "The tax rate applied to the portion of AMT taxable income below the surtax threshold, AMT bracket 1.",
-        "section_1": "Personal Income",
-        "section_2": "Alternative Minimum Tax",
-        "section_3": "Tax rates",
-        "irs_ref": "Form 6251, line 7, in-line. ",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+    "AMT_rt1": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.26
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "AMT rate 1",
         "type": "float",
         "validators": {
@@ -16335,18 +15591,14 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_AMT_brk1": {
-        "description": "AMT taxable income below this is subject to AMT rate 1 and above it is subject to AMT rate 1 + the additional AMT rate.",
+        },
         "section_1": "Personal Income",
         "section_2": "Alternative Minimum Tax",
-        "section_3": "Tax rates",
-        "irs_ref": "Form 6251, line 7, instruction.",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+        "indexed": false,
+        "description": "The tax rate applied to the portion of AMT taxable income below the surtax threshold, AMT bracket 1.",
+        "notes": ""
+    },
+    "AMT_brk1": {
         "value": [
             {
                 "year": 2013,
@@ -16373,10 +15625,6 @@
                 "value": 191100.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "AMT bracket 1 (upper threshold)",
         "type": "float",
         "validators": {
@@ -16384,28 +15632,20 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
-    },
-    "_AMT_rt2": {
-        "description": "The additional tax rate applied to the portion of AMT income above the AMT bracket 1.",
+        },
         "section_1": "Personal Income",
         "section_2": "Alternative Minimum Tax",
-        "section_3": "Tax rates",
-        "irs_ref": "Form 6251, line 7, in-line. ",
-        "notes": "This is the additional tax rate (on top of AMT rate 1) for AMT income above AMT bracket 1.",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": true,
+        "description": "AMT taxable income below this is subject to AMT rate 1 and above it is subject to AMT rate 1 + the additional AMT rate.",
+        "notes": ""
+    },
+    "AMT_rt2": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.02
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Additional AMT rate for AMT taxable income above AMT bracket 1",
         "type": "float",
         "validators": {
@@ -16413,17 +15653,14 @@
                 "min": 0,
                 "max": 1
             }
-        }
+        },
+        "section_1": "Personal Income",
+        "section_2": "Alternative Minimum Tax",
+        "indexed": false,
+        "description": "The additional tax rate applied to the portion of AMT income above the AMT bracket 1.",
+        "notes": "This is the additional tax rate (on top of AMT rate 1) for AMT income above AMT bracket 1."
     },
-    "_AMT_em_pe": {
-        "description": "The AMT exemption is entirely disallowed beyond this AMT taxable income level for individuals who are married but filing separately.",
-        "section_1": "",
-        "section_2": "",
-        "irs_ref": "Form 6251, line 4, instruction.",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+    "AMT_em_pe": {
         "value": [
             {
                 "year": 2013,
@@ -16451,41 +15688,37 @@
             },
             {
                 "year": 2019,
-                "value": 735260.52
+                "value": 734901.12
             },
             {
                 "year": 2020,
-                "value": 749892.2
+                "value": 748570.28
             },
             {
                 "year": 2021,
-                "value": 766689.79
+                "value": 766011.97
             },
             {
                 "year": 2022,
-                "value": 784093.65
+                "value": 783553.64
             },
             {
                 "year": 2023,
-                "value": 801578.94
+                "value": 801418.67
             },
             {
                 "year": 2024,
-                "value": 819053.36
+                "value": 819130.02
             },
             {
                 "year": 2025,
-                "value": 836663.0
+                "value": 836413.66
             },
             {
                 "year": 2026,
-                "value": 302083.0
+                "value": 301874.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": false
-        },
         "title": "AMT exemption phaseout ending AMT taxable income for Married filling Separately",
         "type": "float",
         "validators": {
@@ -16493,27 +15726,20 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
+        },
+        "section_1": "",
+        "section_2": "",
+        "indexed": true,
+        "description": "The AMT exemption is entirely disallowed beyond this AMT taxable income level for individuals who are married but filing separately.",
+        "notes": ""
     },
-    "_CDCC_c": {
-        "description": "The maximum amount of credit allowed for each qualifying dependent.",
-        "section_1": "Nonrefundable Credits",
-        "section_2": "Child And Dependent Care",
-        "irs_ref": "Form 2441, line 3, in-line.",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": false,
+    "CDCC_c": {
         "value": [
             {
                 "year": 2013,
                 "value": 3000.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Maximum child & dependent care credit per dependent",
         "type": "float",
         "validators": {
@@ -16521,26 +15747,20 @@
                 "min": 0,
                 "max": 3000
             }
-        }
-    },
-    "_CDCC_ps": {
-        "description": "For taxpayers with AGI over this amount, the credit is reduced by one percentage point each $2000 of AGI over this amount.",
+        },
         "section_1": "Nonrefundable Credits",
         "section_2": "Child And Dependent Care",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "The maximum amount of credit allowed for each qualifying dependent.",
+        "notes": ""
+    },
+    "CDCC_ps": {
         "value": [
             {
                 "year": 2013,
                 "value": 15000.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Child & dependent care credit phaseout start",
         "type": "float",
         "validators": {
@@ -16548,27 +15768,20 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
-    },
-    "_CDCC_crt": {
-        "description": "The maximum percentage rate in the AGI phaseout; this percentage rate decreases as AGI rises above the _CDCC_ps level.",
+        },
         "section_1": "Nonrefundable Credits",
         "section_2": "Child And Dependent Care",
-        "irs_ref": "Form 2241, line 8, in-line.",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "For taxpayers with AGI over this amount, the credit is reduced by one percentage point each $2000 of AGI over this amount.",
+        "notes": ""
+    },
+    "CDCC_crt": {
         "value": [
             {
                 "year": 2013,
                 "value": 35.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Child & dependent care credit phaseout percentage rate ceiling",
         "type": "float",
         "validators": {
@@ -16576,17 +15789,14 @@
                 "min": 0,
                 "max": 100
             }
-        }
+        },
+        "section_1": "Nonrefundable Credits",
+        "section_2": "Child And Dependent Care",
+        "indexed": false,
+        "description": "The maximum percentage rate in the AGI phaseout; this percentage rate decreases as AGI rises above the CDCC_ps level.",
+        "notes": ""
     },
-    "_CTC_c": {
-        "description": "The maximum nonrefundable credit allowed for each child.",
-        "section_1": "Child/Dependent Credits",
-        "section_2": "Child Tax Credit",
-        "irs_ref": "Form 1040, line 12, worksheet, line 1.",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": false,
+    "CTC_c": {
         "value": [
             {
                 "year": 2013,
@@ -16645,10 +15855,6 @@
                 "value": 1000.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Maximum nonrefundable child tax credit per child",
         "type": "float",
         "validators": {
@@ -16656,27 +15862,20 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
-    },
-    "_CTC_c_under5_bonus": {
-        "description": "The maximum amount of child tax credit allowed for each child is increased by this amount for qualifying children under 5 years old.",
+        },
         "section_1": "Child/Dependent Credits",
         "section_2": "Child Tax Credit",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "The maximum nonrefundable credit allowed for each child.",
+        "notes": ""
+    },
+    "CTC_c_under5_bonus": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Bonus child tax credit maximum for qualifying children under five",
         "type": "float",
         "validators": {
@@ -16684,373 +15883,366 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
-    },
-    "_CTC_ps": {
-        "description": "Child tax credit begins to decrease when MAGI is above this level; read descriptions of the dependent credit amounts for how they phase out when MAGI is above this level.",
+        },
         "section_1": "Child/Dependent Credits",
         "section_2": "Child Tax Credit",
-        "irs_ref": "Form 1040, line 12, worksheet, line 5.",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "The maximum amount of child tax credit allowed for each child is increased by this amount for qualifying children under 5 years old.",
+        "notes": ""
+    },
+    "CTC_ps": {
         "value": [
             {
                 "year": 2013,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 75000.0
             },
             {
                 "year": 2013,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 110000.0
             },
             {
                 "year": 2013,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 55000.0
             },
             {
                 "year": 2013,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 75000.0
             },
             {
                 "year": 2013,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 75000.0
             },
             {
                 "year": 2014,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 75000.0
             },
             {
                 "year": 2014,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 110000.0
             },
             {
                 "year": 2014,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 55000.0
             },
             {
                 "year": 2014,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 75000.0
             },
             {
                 "year": 2014,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 75000.0
             },
             {
                 "year": 2015,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 75000.0
             },
             {
                 "year": 2015,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 110000.0
             },
             {
                 "year": 2015,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 55000.0
             },
             {
                 "year": 2015,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 75000.0
             },
             {
                 "year": 2015,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 75000.0
             },
             {
                 "year": 2016,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 75000.0
             },
             {
                 "year": 2016,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 110000.0
             },
             {
                 "year": 2016,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 55000.0
             },
             {
                 "year": 2016,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 75000.0
             },
             {
                 "year": 2016,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 75000.0
             },
             {
                 "year": 2017,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 75000.0
             },
             {
                 "year": 2017,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 110000.0
             },
             {
                 "year": 2017,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 55000.0
             },
             {
                 "year": 2017,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 75000.0
             },
             {
                 "year": 2017,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 75000.0
             },
             {
                 "year": 2018,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 200000.0
             },
             {
                 "year": 2018,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 400000.0
             },
             {
                 "year": 2018,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 200000.0
             },
             {
                 "year": 2018,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 200000.0
             },
             {
                 "year": 2018,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 400000.0
             },
             {
                 "year": 2019,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 200000.0
             },
             {
                 "year": 2019,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 400000.0
             },
             {
                 "year": 2019,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 200000.0
             },
             {
                 "year": 2019,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 200000.0
             },
             {
                 "year": 2019,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 400000.0
             },
             {
                 "year": 2020,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 200000.0
             },
             {
                 "year": 2020,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 400000.0
             },
             {
                 "year": 2020,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 200000.0
             },
             {
                 "year": 2020,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 200000.0
             },
             {
                 "year": 2020,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 400000.0
             },
             {
                 "year": 2021,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 200000.0
             },
             {
                 "year": 2021,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 400000.0
             },
             {
                 "year": 2021,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 200000.0
             },
             {
                 "year": 2021,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 200000.0
             },
             {
                 "year": 2021,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 400000.0
             },
             {
                 "year": 2022,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 200000.0
             },
             {
                 "year": 2022,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 400000.0
             },
             {
                 "year": 2022,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 200000.0
             },
             {
                 "year": 2022,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 200000.0
             },
             {
                 "year": 2022,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 400000.0
             },
             {
                 "year": 2023,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 200000.0
             },
             {
                 "year": 2023,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 400000.0
             },
             {
                 "year": 2023,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 200000.0
             },
             {
                 "year": 2023,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 200000.0
             },
             {
                 "year": 2023,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 400000.0
             },
             {
                 "year": 2024,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 200000.0
             },
             {
                 "year": 2024,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 400000.0
             },
             {
                 "year": 2024,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 200000.0
             },
             {
                 "year": 2024,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 200000.0
             },
             {
                 "year": 2024,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 400000.0
             },
             {
                 "year": 2025,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 200000.0
             },
             {
                 "year": 2025,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 400000.0
             },
             {
                 "year": 2025,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 200000.0
             },
             {
                 "year": 2025,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 200000.0
             },
             {
                 "year": 2025,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 400000.0
             },
             {
                 "year": 2026,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 75000.0
             },
             {
                 "year": 2026,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 110000.0
             },
             {
                 "year": 2026,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 55000.0
             },
             {
                 "year": 2026,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 75000.0
             },
             {
                 "year": 2026,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 75000.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Child tax credit phaseout MAGI start",
         "type": "float",
         "validators": {
@@ -17058,27 +16250,20 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
-    },
-    "_CTC_prt": {
-        "description": "The amount of the credit starts to decrease at this rate if MAGI is higher than child tax credit phaseout start.",
+        },
         "section_1": "Child/Dependent Credits",
         "section_2": "Child Tax Credit",
-        "irs_ref": "Form 1040, line 12, instruction (child tax credit worksheet, line 7)",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "Child tax credit begins to decrease when MAGI is above this level; read descriptions of the dependent credit amounts for how they phase out when MAGI is above this level.",
+        "notes": ""
+    },
+    "CTC_prt": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.05
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Child and dependent tax credit phaseout rate",
         "type": "float",
         "validators": {
@@ -17086,17 +16271,14 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_ACTC_c": {
-        "description": "This refundable credit is applied to child dependents and phases out exactly like the CTC amount.",
+        },
         "section_1": "Child/Dependent Credits",
-        "section_2": "Additional Child Tax Credit",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": false,
+        "section_2": "Child Tax Credit",
+        "indexed": false,
+        "description": "The amount of the credit starts to decrease at this rate if MAGI is higher than child tax credit phaseout start.",
+        "notes": ""
+    },
+    "ACTC_c": {
         "value": [
             {
                 "year": 2013,
@@ -17155,28 +16337,21 @@
                 "value": 1000.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Maximum refundable additional child tax credit",
         "type": "float",
         "validators": {
             "range": {
                 "min": 0,
-                "max": "_CTC_c"
+                "max": "CTC_c"
             }
-        }
-    },
-    "_ODC_c": {
-        "description": "This nonrefundable credit is applied to non-child dependents and phases out along with the CTC amount.",
+        },
         "section_1": "Child/Dependent Credits",
-        "section_2": "Other Dependent Tax Credit",
-        "irs_ref": "Form 1040, line 12, instruction (child tax credit worksheet, line 2)",
-        "notes": "Became current-law policy with passage of TCJA",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": false,
+        "section_2": "Additional Child Tax Credit",
+        "indexed": false,
+        "description": "This refundable credit is applied to child dependents and phases out exactly like the CTC amount.",
+        "notes": ""
+    },
+    "ODC_c": {
         "value": [
             {
                 "year": 2013,
@@ -17235,10 +16410,6 @@
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Maximum nonrefundable other-dependent credit",
         "type": "float",
         "validators": {
@@ -17246,48 +16417,41 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
+        },
+        "section_1": "Child/Dependent Credits",
+        "section_2": "Other Dependent Tax Credit",
+        "indexed": false,
+        "description": "This nonrefundable credit is applied to non-child dependents and phases out along with the CTC amount.",
+        "notes": "Became current-law policy with passage of TCJA"
     },
-    "_NIIT_thd": {
-        "description": "If modified AGI is more than this threshold, filing unit is subject to the Net Investment Income Tax.",
-        "section_1": "Other Taxes",
-        "section_2": "Net Investment Income Tax",
-        "irs_ref": "Form 8960, line 14, instructions. ",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": false,
+    "NIIT_thd": {
         "value": [
             {
                 "year": 2013,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 200000.0
             },
             {
                 "year": 2013,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 250000.0
             },
             {
                 "year": 2013,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 125000.0
             },
             {
                 "year": 2013,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 200000.0
             },
             {
                 "year": 2013,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 250000.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Net Investment Income Tax modified AGI threshold",
         "type": "float",
         "validators": {
@@ -17295,27 +16459,20 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
-    },
-    "_NIIT_PT_taxed": {
-        "description": "false ==> partnership and S-corp income excluded from NIIT base; true ==> partnership and S-corp income is in NIIT base.",
+        },
         "section_1": "Other Taxes",
         "section_2": "Net Investment Income Tax",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "If modified AGI is more than this threshold, filing unit is subject to the Net Investment Income Tax.",
+        "notes": ""
+    },
+    "NIIT_PT_taxed": {
         "value": [
             {
                 "year": 2013,
                 "value": false
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": false
-        },
         "title": "Whether or not partnership and S-corp income is in NIIT base",
         "type": "bool",
         "validators": {
@@ -17323,27 +16480,20 @@
                 "min": false,
                 "max": true
             }
-        }
-    },
-    "_NIIT_rt": {
-        "description": "If modified AGI exceeds _NIIT_thd, all net investment income is taxed at this rate.",
+        },
         "section_1": "Other Taxes",
         "section_2": "Net Investment Income Tax",
-        "irs_ref": "Form 8960, line 21, in-line. ",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "false ==> partnership and S-corp income excluded from NIIT base; true ==> partnership and S-corp income is in NIIT base.",
+        "notes": ""
+    },
+    "NIIT_rt": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.038
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Net Investment Income Tax rate",
         "type": "float",
         "validators": {
@@ -17351,17 +16501,14 @@
                 "min": 0,
                 "max": 1
             }
-        }
+        },
+        "section_1": "Other Taxes",
+        "section_2": "Net Investment Income Tax",
+        "indexed": false,
+        "description": "If modified AGI exceeds NIIT_thd, all net investment income is taxed at this rate.",
+        "notes": ""
     },
-    "_EITC_c": {
-        "description": "This is the maximum amount of earned income credit taxpayers are eligible for; it depends on how many kids they have.",
-        "section_1": "Refundable Credits",
-        "section_2": "Earned Income Tax Credit",
-        "irs_ref": "Form 1040, line 17, instruction (table).",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+    "EITC_c": {
         "value": [
             {
                 "year": 2013,
@@ -17484,10 +16631,6 @@
                 "value": 6431.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Maximum earned income credit",
         "type": "float",
         "validators": {
@@ -17495,17 +16638,14 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
-    },
-    "_EITC_rt": {
-        "description": "Pre-phaseout credit is minimum of this rate times earnings and the maximum earned income credit.",
+        },
         "section_1": "Refundable Credits",
         "section_2": "Earned Income Tax Credit",
-        "irs_ref": "Form 1040, line 17, calculation (table: Max_EIC/Max_EIC_base_income).",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": true,
+        "description": "This is the maximum amount of earned income credit taxpayers are eligible for; it depends on how many kids they have.",
+        "notes": ""
+    },
+    "EITC_rt": {
         "value": [
             {
                 "year": 2013,
@@ -17528,10 +16668,6 @@
                 "value": 0.45
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Earned income credit phasein rate",
         "type": "float",
         "validators": {
@@ -17539,17 +16675,14 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
-    },
-    "_EITC_basic_frac": {
-        "description": "This fraction of _EITC_c is always paid as a credit and one minus this fraction is applied to the phasein rate, _EITC_rt.  This fraction is zero under current law.",
+        },
         "section_1": "Refundable Credits",
         "section_2": "Earned Income Tax Credit",
-        "irs_ref": "Form 1040, line 17, instruction (table).",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "Pre-phaseout credit is minimum of this rate times earnings and the maximum earned income credit.",
+        "notes": ""
+    },
+    "EITC_basic_frac": {
         "value": [
             {
                 "year": 2013,
@@ -17576,10 +16709,6 @@
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Fraction of maximum earned income credit paid at zero earnings",
         "type": "float",
         "validators": {
@@ -17587,17 +16716,14 @@
                 "min": 0.0,
                 "max": 1.0
             }
-        }
-    },
-    "_EITC_prt": {
-        "description": "Earned income credit begins to decrease at the this rate when AGI is higher than earned income credit phaseout start AGI.",
+        },
         "section_1": "Refundable Credits",
         "section_2": "Earned Income Tax Credit",
-        "irs_ref": "Form 1040, line 17, calculation (table: Max_EIC_base_income/Phaseout_Base).",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "This fraction of EITC_c is always paid as a credit and one minus this fraction is applied to the phasein rate, EITC_rt.  This fraction is zero under current law.",
+        "notes": ""
+    },
+    "EITC_prt": {
         "value": [
             {
                 "year": 2013,
@@ -17620,10 +16746,6 @@
                 "value": 0.2106
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Earned income credit phaseout rate",
         "type": "float",
         "validators": {
@@ -17631,17 +16753,14 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
-    },
-    "_EITC_ps": {
-        "description": "If AGI is higher than this threshold, the amount of EITC will start to decrease at the phaseout rate.",
+        },
         "section_1": "Refundable Credits",
         "section_2": "Earned Income Tax Credit",
-        "irs_ref": "Form 1040, line 17, instructions.",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+        "indexed": false,
+        "description": "Earned income credit begins to decrease at the this rate when AGI is higher than earned income credit phaseout start AGI.",
+        "notes": ""
+    },
+    "EITC_ps": {
         "value": [
             {
                 "year": 2013,
@@ -17764,10 +16883,6 @@
                 "value": 18660.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Earned income credit phaseout start AGI",
         "type": "float",
         "validators": {
@@ -17775,17 +16890,14 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
-    },
-    "_EITC_ps_MarriedJ": {
-        "description": "This is the additional amount added on the regular phaseout start amount for taxpayers with filling status of married filling jointly.",
+        },
         "section_1": "Refundable Credits",
         "section_2": "Earned Income Tax Credit",
-        "irs_ref": "Form 1040, line 17, calculation (the difference between EIC phaseout bases of married jointly fillers and other fillers).",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+        "indexed": true,
+        "description": "If AGI is higher than this threshold, the amount of EITC will start to decrease at the phaseout rate.",
+        "notes": ""
+    },
+    "EITC_ps_MarriedJ": {
         "value": [
             {
                 "year": 2013,
@@ -17870,22 +16982,22 @@
             {
                 "year": 2017,
                 "EIC": "0kids",
-                "value": 5600.0
+                "value": 5590.0
             },
             {
                 "year": 2017,
                 "EIC": "1kid",
-                "value": 5600.0
+                "value": 5590.0
             },
             {
                 "year": 2017,
                 "EIC": "2kids",
-                "value": 5600.0
+                "value": 5590.0
             },
             {
                 "year": 2017,
                 "EIC": "3+kids",
-                "value": 5600.0
+                "value": 5590.0
             },
             {
                 "year": 2018,
@@ -17908,10 +17020,6 @@
                 "value": 5690.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Extra earned income credit phaseout start AGI for married filling jointly",
         "type": "float",
         "validators": {
@@ -17919,27 +17027,20 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
-    },
-    "_EITC_MinEligAge": {
-        "description": "For a childless filling unit, at least one individual's age needs to be no less than this age (but no greater than the EITC_MaxEligAge) in order to be eligible for an earned income tax credit.",
+        },
         "section_1": "Refundable Credits",
         "section_2": "Earned Income Tax Credit",
-        "irs_ref": "Form 1040, line 17, step 4, instructions.",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": true,
+        "description": "This is the additional amount added on the regular phaseout start amount for taxpayers with filling status of married filling jointly.",
+        "notes": ""
+    },
+    "EITC_MinEligAge": {
         "value": [
             {
                 "year": 2013,
                 "value": 25
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Minimum Age for Childless EITC Eligibility",
         "type": "int",
         "validators": {
@@ -17947,27 +17048,20 @@
                 "min": 0,
                 "max": 125
             }
-        }
-    },
-    "_EITC_MaxEligAge": {
-        "description": "For a childless filling unit, at least one individual's age needs to be no greater than this age (but no less than the EITC_MinEligAge) in order to be eligible for an earned income tax credit.",
+        },
         "section_1": "Refundable Credits",
         "section_2": "Earned Income Tax Credit",
-        "irs_ref": "Form 1040, line 17, step 4, instructions.",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "For a childless filling unit, at least one individual's age needs to be no less than this age (but no greater than the EITC_MaxEligAge) in order to be eligible for an earned income tax credit.",
+        "notes": ""
+    },
+    "EITC_MaxEligAge": {
         "value": [
             {
                 "year": 2013,
                 "value": 64
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Maximum Age for Childless EITC Eligibility",
         "type": "int",
         "validators": {
@@ -17975,17 +17069,14 @@
                 "min": 0,
                 "max": 125
             }
-        }
-    },
-    "_EITC_InvestIncome_c": {
-        "description": "The EITC amount is reduced when investment income exceeds this ceiling.",
+        },
         "section_1": "Refundable Credits",
         "section_2": "Earned Income Tax Credit",
-        "irs_ref": "Form 1040, line 17, instruction(step2)",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+        "indexed": false,
+        "description": "For a childless filling unit, at least one individual's age needs to be no greater than this age (but no less than the EITC_MinEligAge) in order to be eligible for an earned income tax credit.",
+        "notes": ""
+    },
+    "EITC_InvestIncome_c": {
         "value": [
             {
                 "year": 2013,
@@ -18012,10 +17103,6 @@
                 "value": 3500.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Maximum investment income before EITC reduction",
         "type": "float",
         "validators": {
@@ -18023,27 +17110,20 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
-    },
-    "_EITC_excess_InvestIncome_rt": {
-        "description": "The EITC amount is reduced at this rate per dollar of investment income exceeding the ceiling.",
+        },
         "section_1": "Refundable Credits",
         "section_2": "Earned Income Tax Credit",
-        "irs_ref": "Form 1040, line 17, instruction(step2)",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": true,
+        "description": "The EITC amount is reduced when investment income exceeds this ceiling.",
+        "notes": ""
+    },
+    "EITC_excess_InvestIncome_rt": {
         "value": [
             {
                 "year": 2013,
                 "value": 9e+99
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Rate of EITC reduction when investment income exceeds ceiling",
         "type": "float",
         "validators": {
@@ -18051,55 +17131,62 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
-    },
-    "_EITC_indiv": {
-        "description": "Current-law value is false implying EITC is filing-unit based; a value of true implies EITC is computed for each individual wage earner.  The phase-out of the credit works slightly differently between the two.  Individual-based calculation ignore investment income and age eligibilty rules used in filing-unit-based calculations.",
+        },
         "section_1": "Refundable Credits",
         "section_2": "Earned Income Tax Credit",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "The EITC amount is reduced at this rate per dollar of investment income exceeding the ceiling.",
+        "notes": ""
+    },
+    "EITC_indiv": {
         "value": [
             {
                 "year": 2013,
                 "value": false
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
-        "title": "EITC is individual-based rather than filing-unit based",
+        "title": "EITC is computed for each spouse based on individual earnings",
         "type": "bool",
         "validators": {
             "range": {
                 "min": false,
                 "max": true
             }
-        }
+        },
+        "section_1": "Refundable Credits",
+        "section_2": "Earned Income Tax Credit",
+        "indexed": false,
+        "description": "Current-law value is false implying EITC is filing-unit based; a value of true implies EITC is computed for each individual wage earner.  The additional phaseout start for joint filers is not affected by this parameter, nor are investment income and age eligibilty rules.",
+        "notes": ""
     },
-    "_LLC_Expense_c": {
-        "description": "The maximum expense eligible for lifetime learning credit, per child.",
-        "section_1": "",
-        "section_2": "",
-        "irs_ref": "Form 8863, line 11, in-line.",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": false,
+    "EITC_sep_filers_elig": {
+        "value": [
+            {
+                "year": 2013,
+                "value": false
+            }
+        ],
+        "title": "Separate filers are eligibile for the EITC",
+        "type": "bool",
+        "validators": {
+            "range": {
+                "min": false,
+                "max": true
+            }
+        },
+        "section_1": "Refundable Credits",
+        "section_2": "Earned Income Tax Credit",
+        "indexed": false,
+        "description": "Current-law value is false, implying ineligibility.",
+        "notes": ""
+    },
+    "LLC_Expense_c": {
         "value": [
             {
                 "year": 2013,
                 "value": 10000.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": false
-        },
         "title": "Lifetime learning credit expense limit",
         "type": "float",
         "validators": {
@@ -18107,17 +17194,14 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
-    },
-    "_ETC_pe_Single": {
-        "description": "The education tax credit will be zero for those taxpayers of single filing status with modified AGI (in thousands) higher than this level.",
+        },
         "section_1": "",
         "section_2": "",
-        "irs_ref": "Form 8863, line 13, inline.",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+        "indexed": false,
+        "description": "The maximum expense eligible for lifetime learning credit, per child.",
+        "notes": ""
+    },
+    "ETC_pe_Single": {
         "value": [
             {
                 "year": 2013,
@@ -18144,10 +17228,6 @@
                 "value": 67.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": false
-        },
         "title": "Education tax credit phaseout ends (Single)",
         "type": "float",
         "validators": {
@@ -18155,17 +17235,14 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
-    },
-    "_ETC_pe_Married": {
-        "description": "The education tax credit will be zero for those taxpayers of married filing status with modified AGI level (in thousands) higher than this level.",
+        },
         "section_1": "",
         "section_2": "",
-        "irs_ref": "Form 8863, line 13, inline.",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+        "indexed": true,
+        "description": "The education tax credit will be zero for those taxpayers of single filing status with modified AGI (in thousands) higher than this level.",
+        "notes": ""
+    },
+    "ETC_pe_Married": {
         "value": [
             {
                 "year": 2013,
@@ -18192,10 +17269,6 @@
                 "value": 134.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": false
-        },
         "title": "Education tax credit phaseout ends (Married)",
         "type": "float",
         "validators": {
@@ -18203,27 +17276,20 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
+        },
+        "section_1": "",
+        "section_2": "",
+        "indexed": true,
+        "description": "The education tax credit will be zero for those taxpayers of married filing status with modified AGI level (in thousands) higher than this level.",
+        "notes": ""
     },
-    "_ACTC_rt": {
-        "description": "This is the fraction of earnings used in calculating the ACTC, which is a partially refundable credit that supplements the CTC for some taxpayers.",
-        "section_1": "Child/Dependent Credits",
-        "section_2": "Additional Child Tax Credit",
-        "irs_ref": "Form 8812, line 8, inline.",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+    "ACTC_rt": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.15
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Additional Child Tax Credit rate",
         "type": "float",
         "validators": {
@@ -18231,27 +17297,20 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_ACTC_rt_bonus_under5family": {
-        "description": "For families with qualifying children under 5 years old, this bonus rate is added to the fraction of earnings (additional child tax credit rate) used in calculating the ACTC.",
+        },
         "section_1": "Child/Dependent Credits",
         "section_2": "Additional Child Tax Credit",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "This is the fraction of earnings used in calculating the ACTC, which is a partially refundable credit that supplements the CTC for some taxpayers.",
+        "notes": ""
+    },
+    "ACTC_rt_bonus_under5family": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Bonus additional child tax credit rate for families with qualifying children under 5",
         "type": "float",
         "validators": {
@@ -18259,17 +17318,14 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_ACTC_Income_thd": {
-        "description": "The portion of earned income below this threshold does not count as base for the Additional Child Tax Credit.",
+        },
         "section_1": "Child/Dependent Credits",
         "section_2": "Additional Child Tax Credit",
-        "irs_ref": "Form 8812, line 7, in-line.",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "For families with qualifying children under 5 years old, this bonus rate is added to the fraction of earnings (additional child tax credit rate) used in calculating the ACTC.",
+        "notes": ""
+    },
+    "ACTC_Income_thd": {
         "value": [
             {
                 "year": 2013,
@@ -18328,10 +17384,6 @@
                 "value": 3000.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Additional Child Tax Credit income threshold",
         "type": "float",
         "validators": {
@@ -18339,27 +17391,20 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
-    },
-    "_ACTC_ChildNum": {
-        "description": "Families with this number of qualified children or more may qualify for a different formula to calculate the Additional Child Tax Credit, which is a partially refundable credit that supplements the Child Tax Credit for some taxpayers.",
+        },
         "section_1": "Child/Dependent Credits",
         "section_2": "Additional Child Tax Credit",
-        "irs_ref": "Form 8812, Part II. ",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "The portion of earned income below this threshold does not count as base for the Additional Child Tax Credit.",
+        "notes": ""
+    },
+    "ACTC_ChildNum": {
         "value": [
             {
                 "year": 2013,
                 "value": 3
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Additional Child Tax Credit minimum number of qualified children for different formula",
         "type": "int",
         "validators": {
@@ -18367,27 +17412,20 @@
                 "min": 0,
                 "max": 99
             }
-        }
+        },
+        "section_1": "Child/Dependent Credits",
+        "section_2": "Additional Child Tax Credit",
+        "indexed": false,
+        "description": "Families with this number of qualified children or more may qualify for a different formula to calculate the Additional Child Tax Credit, which is a partially refundable credit that supplements the Child Tax Credit for some taxpayers.",
+        "notes": ""
     },
-    "_CTC_new_c": {
-        "description": "In addition to all credits currently available for dependents, this parameter gives each qualifying child a new refundable credit with this maximum amount.",
-        "section_1": "Refundable Credits",
-        "section_2": "New Refundable Child Tax Credit",
-        "irs_ref": "",
-        "notes": "Child age qualification for the new child tax credit is the same as under current-law Child Tax Credit.",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": false,
+    "CTC_new_c": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "New refundable child tax credit maximum amount per child",
         "type": "float",
         "validators": {
@@ -18395,27 +17433,20 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
-    },
-    "_CTC_new_c_under5_bonus": {
-        "description": "The maximum amount of the new refundable child tax credit allowed for each child is increased by this amount for qualifying children under 5 years old.",
+        },
         "section_1": "Refundable Credits",
         "section_2": "New Refundable Child Tax Credit",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "In addition to all credits currently available for dependents, this parameter gives each qualifying child a new refundable credit with this maximum amount.",
+        "notes": "Child age qualification for the new child tax credit is the same as under current-law Child Tax Credit."
+    },
+    "CTC_new_c_under5_bonus": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Bonus new refundable child tax credit maximum for qualifying children under five",
         "type": "float",
         "validators": {
@@ -18423,27 +17454,20 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
-    },
-    "_CTC_new_for_all": {
-        "description": "The maximum amount of the new refundable child tax credit does not depend on AGI when true; otherwise, see _CTC_new_rt.",
+        },
         "section_1": "Refundable Credits",
         "section_2": "New Refundable Child Tax Credit",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "The maximum amount of the new refundable child tax credit allowed for each child is increased by this amount for qualifying children under 5 years old.",
+        "notes": ""
+    },
+    "CTC_new_for_all": {
         "value": [
             {
                 "year": 2013,
                 "value": false
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Whether or not maximum amount of the new refundable child tax credit is available to all",
         "type": "bool",
         "validators": {
@@ -18451,27 +17475,20 @@
                 "min": false,
                 "max": true
             }
-        }
-    },
-    "_CTC_new_rt": {
-        "description": "The maximum amount of the new child tax credit is increased at this rate per dollar of positive AGI until _CTC_new_c times the number of qualified children is reached if CTC_new_for_all is false; if CTC_new_for_all is true, there is no AGI limitation to the maximum amount.",
+        },
         "section_1": "Refundable Credits",
         "section_2": "New Refundable Child Tax Credit",
-        "irs_ref": "",
-        "notes": "Child age qualification for the new child tax credit is the same as under current-law Child Tax Credit.",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "The maximum amount of the new refundable child tax credit does not depend on AGI when true; otherwise, see CTC_new_rt.",
+        "notes": ""
+    },
+    "CTC_new_rt": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "New refundable child tax credit amount phasein rate",
         "type": "float",
         "validators": {
@@ -18479,173 +17496,166 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
-    },
-    "_CTC_new_ps": {
-        "description": "The total amount of new child tax credit is reduced for taxpayers with AGI higher than this level.",
+        },
         "section_1": "Refundable Credits",
         "section_2": "New Refundable Child Tax Credit",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+        "indexed": false,
+        "description": "The maximum amount of the new child tax credit is increased at this rate per dollar of positive AGI until CTC_new_c times the number of qualified children is reached if CTC_new_for_all is false; if CTC_new_for_all is true, there is no AGI limitation to the maximum amount.",
+        "notes": "Child age qualification for the new child tax credit is the same as under current-law Child Tax Credit."
+    },
+    "CTC_new_ps": {
         "value": [
             {
                 "year": 2013,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 0.0
             },
             {
                 "year": 2013,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 0.0
             },
             {
                 "year": 2013,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 0.0
             },
             {
                 "year": 2013,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 0.0
             },
             {
                 "year": 2013,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 0.0
             },
             {
                 "year": 2014,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 0.0
             },
             {
                 "year": 2014,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 0.0
             },
             {
                 "year": 2014,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 0.0
             },
             {
                 "year": 2014,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 0.0
             },
             {
                 "year": 2014,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 0.0
             },
             {
                 "year": 2015,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 0.0
             },
             {
                 "year": 2015,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 0.0
             },
             {
                 "year": 2015,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 0.0
             },
             {
                 "year": 2015,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 0.0
             },
             {
                 "year": 2015,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 0.0
             },
             {
                 "year": 2016,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 0.0
             },
             {
                 "year": 2016,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 0.0
             },
             {
                 "year": 2016,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 0.0
             },
             {
                 "year": 2016,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 0.0
             },
             {
                 "year": 2016,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 0.0
             },
             {
                 "year": 2017,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 0.0
             },
             {
                 "year": 2017,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 0.0
             },
             {
                 "year": 2017,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 0.0
             },
             {
                 "year": 2017,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 0.0
             },
             {
                 "year": 2017,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 0.0
             },
             {
                 "year": 2018,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 0.0
             },
             {
                 "year": 2018,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 0.0
             },
             {
                 "year": 2018,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 0.0
             },
             {
                 "year": 2018,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 0.0
             },
             {
                 "year": 2018,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "New refundable child tax credit phaseout starting AGI",
         "type": "float",
         "validators": {
@@ -18653,27 +17663,20 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
-    },
-    "_CTC_new_prt": {
-        "description": "The total amount of the new child tax credit is reduced at this rate per dollar exceeding the phaseout starting AGI, _CTC_new_ps.",
+        },
         "section_1": "Refundable Credits",
         "section_2": "New Refundable Child Tax Credit",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": true,
+        "description": "The total amount of new child tax credit is reduced for taxpayers with AGI higher than this level.",
+        "notes": ""
+    },
+    "CTC_new_prt": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "New refundable child tax credit amount phaseout rate",
         "type": "float",
         "validators": {
@@ -18681,27 +17684,20 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
-    },
-    "_CTC_new_refund_limited": {
-        "description": "Specifies whether the new child tax credit refund is limited by the new child tax credit refund limit rate (_CTC_new_refund_limit_payroll_rt).",
+        },
         "section_1": "Refundable Credits",
         "section_2": "New Refundable Child Tax Credit",
-        "irs_ref": "",
-        "notes": "Set this parameter to true to limit the refundability or false to allow full refundability for all taxpayers.",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "The total amount of the new child tax credit is reduced at this rate per dollar exceeding the phaseout starting AGI, CTC_new_ps.",
+        "notes": ""
+    },
+    "CTC_new_refund_limited": {
         "value": [
             {
                 "year": 2013,
                 "value": false
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "New child tax credit refund limited to a decimal fraction of payroll taxes",
         "type": "bool",
         "validators": {
@@ -18709,27 +17705,20 @@
                 "min": false,
                 "max": true
             }
-        }
-    },
-    "_CTC_new_refund_limit_payroll_rt": {
-        "description": "The fraction of payroll taxes (employee plus employer shares, but excluding all Medicare payroll taxes) that serves as a limit to the amount of new child tax credit that can be refunded.",
+        },
         "section_1": "Refundable Credits",
         "section_2": "New Refundable Child Tax Credit",
-        "irs_ref": "",
-        "notes": "Set this parameter to zero for no refundability; set it to 9e99 for unlimited refundability for taxpayers with payroll tax liabilities.",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "Specifies whether the new child tax credit refund is limited by the new child tax credit refund limit rate (_CTC_new_refund_limit_payroll_rt).",
+        "notes": "Set this parameter to true to limit the refundability or false to allow full refundability for all taxpayers."
+    },
+    "CTC_new_refund_limit_payroll_rt": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "New child tax credit refund limit rate (decimal fraction of payroll taxes)",
         "type": "float",
         "validators": {
@@ -18737,27 +17726,20 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
-    },
-    "_CTC_new_refund_limited_all_payroll": {
-        "description": "Specifies whether the new child tax credit refund limit rate (_CTC_new_refund_limit_payroll_rt) applies to all FICA taxes (true) or just OASDI taxes (false).",
+        },
         "section_1": "Refundable Credits",
         "section_2": "New Refundable Child Tax Credit",
-        "irs_ref": "",
-        "notes": "If the new CTC is limited, set this parameter to true to limit the refundability to all FICA taxes or false to limit refundabiity to OASDI taxes.",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "The fraction of payroll taxes (employee plus employer shares, but excluding all Medicare payroll taxes) that serves as a limit to the amount of new child tax credit that can be refunded.",
+        "notes": "Set this parameter to zero for no refundability; set it to 9e99 for unlimited refundability for taxpayers with payroll tax liabilities."
+    },
+    "CTC_new_refund_limited_all_payroll": {
         "value": [
             {
                 "year": 2013,
                 "value": false
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "New child tax credit refund limit applies to all FICA taxes, not just OASDI",
         "type": "bool",
         "validators": {
@@ -18765,27 +17747,20 @@
                 "min": false,
                 "max": true
             }
-        }
+        },
+        "section_1": "Refundable Credits",
+        "section_2": "New Refundable Child Tax Credit",
+        "indexed": false,
+        "description": "Specifies whether the new child tax credit refund limit rate (_CTC_new_refund_limit_payroll_rt) applies to all FICA taxes (true) or just OASDI taxes (false).",
+        "notes": "If the new CTC is limited, set this parameter to true to limit the refundability to all FICA taxes or false to limit refundabiity to OASDI taxes."
     },
-    "_FST_AGI_trt": {
-        "description": "Individual income taxes and the employee share of payroll taxes are credited against this minimum tax, so the surtax is the difference between the tax rate times AGI and the credited taxes. The new minimum tax is similar to the Fair Share Tax, except that no credits are exempted from the base.",
-        "section_1": "Surtaxes",
-        "section_2": "New Minimum Tax",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+    "FST_AGI_trt": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "New minimum tax; rate as a decimal fraction of AGI",
         "type": "float",
         "validators": {
@@ -18793,375 +17768,354 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_FST_AGI_thd_lo": {
-        "description": "A taxpayer is only subject to the new minimum tax if they exceed this level of AGI.",
+        },
         "section_1": "Surtaxes",
         "section_2": "New Minimum Tax",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+        "indexed": false,
+        "description": "Individual income taxes and the employee share of payroll taxes are credited against this minimum tax, so the surtax is the difference between the tax rate times AGI and the credited taxes. The new minimum tax is similar to the Fair Share Tax, except that no credits are exempted from the base.",
+        "notes": ""
+    },
+    "FST_AGI_thd_lo": {
         "value": [
             {
                 "year": 2013,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 1000000.0
             },
             {
                 "year": 2013,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 1000000.0
             },
             {
                 "year": 2013,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 500000.0
             },
             {
                 "year": 2013,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 1000000.0
             },
             {
                 "year": 2013,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 1000000.0
             },
             {
                 "year": 2014,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 1000000.0
             },
             {
                 "year": 2014,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 1000000.0
             },
             {
                 "year": 2014,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 500000.0
             },
             {
                 "year": 2014,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 1000000.0
             },
             {
                 "year": 2014,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 1000000.0
             },
             {
                 "year": 2015,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 1000000.0
             },
             {
                 "year": 2015,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 1000000.0
             },
             {
                 "year": 2015,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 500000.0
             },
             {
                 "year": 2015,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 1000000.0
             },
             {
                 "year": 2015,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 1000000.0
             },
             {
                 "year": 2016,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 1000000.0
             },
             {
                 "year": 2016,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 1000000.0
             },
             {
                 "year": 2016,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 500000.0
             },
             {
                 "year": 2016,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 1000000.0
             },
             {
                 "year": 2016,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 1000000.0
             },
             {
                 "year": 2017,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 1000000.0
             },
             {
                 "year": 2017,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 1000000.0
             },
             {
                 "year": 2017,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 500000.0
             },
             {
                 "year": 2017,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 1000000.0
             },
             {
                 "year": 2017,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 1000000.0
             },
             {
                 "year": 2018,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 1000000.0
             },
             {
                 "year": 2018,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 1000000.0
             },
             {
                 "year": 2018,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 500000.0
             },
             {
                 "year": 2018,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 1000000.0
             },
             {
                 "year": 2018,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 1000000.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Minimum AGI needed to be subject to the new minimum tax",
         "type": "float",
         "validators": {
             "range": {
                 "min": 0,
-                "max": "_FST_AGI_thd_hi"
+                "max": "FST_AGI_thd_hi"
             }
-        }
-    },
-    "_FST_AGI_thd_hi": {
-        "description": "The new minimum tax will be fully phased in at this level of AGI. If there is no phase-in, this upper threshold should be set equal to the lower AGI threshold.",
+        },
         "section_1": "Surtaxes",
         "section_2": "New Minimum Tax",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+        "indexed": true,
+        "description": "A taxpayer is only subject to the new minimum tax if they exceed this level of AGI.",
+        "notes": ""
+    },
+    "FST_AGI_thd_hi": {
         "value": [
             {
                 "year": 2013,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 2000000.0
             },
             {
                 "year": 2013,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 2000000.0
             },
             {
                 "year": 2013,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 1000000.0
             },
             {
                 "year": 2013,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 2000000.0
             },
             {
                 "year": 2013,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 2000000.0
             },
             {
                 "year": 2014,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 2000000.0
             },
             {
                 "year": 2014,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 2000000.0
             },
             {
                 "year": 2014,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 1000000.0
             },
             {
                 "year": 2014,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 2000000.0
             },
             {
                 "year": 2014,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 2000000.0
             },
             {
                 "year": 2015,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 2000000.0
             },
             {
                 "year": 2015,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 2000000.0
             },
             {
                 "year": 2015,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 1000000.0
             },
             {
                 "year": 2015,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 2000000.0
             },
             {
                 "year": 2015,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 2000000.0
             },
             {
                 "year": 2016,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 2000000.0
             },
             {
                 "year": 2016,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 2000000.0
             },
             {
                 "year": 2016,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 1000000.0
             },
             {
                 "year": 2016,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 2000000.0
             },
             {
                 "year": 2016,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 2000000.0
             },
             {
                 "year": 2017,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 2000000.0
             },
             {
                 "year": 2017,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 2000000.0
             },
             {
                 "year": 2017,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 1000000.0
             },
             {
                 "year": 2017,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 2000000.0
             },
             {
                 "year": 2017,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 2000000.0
             },
             {
                 "year": 2018,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 2000000.0
             },
             {
                 "year": 2018,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 2000000.0
             },
             {
                 "year": 2018,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 1000000.0
             },
             {
                 "year": 2018,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 2000000.0
             },
             {
                 "year": 2018,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 2000000.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "AGI level at which the New Minimum Tax is fully phased in",
         "type": "float",
         "validators": {
             "range": {
-                "min": "_FST_AGI_thd_lo",
+                "min": "FST_AGI_thd_lo",
                 "max": 9e+99
             }
-        }
-    },
-    "_AGI_surtax_trt": {
-        "description": "The surtax rate is applied to the portion of Adjusted Gross Income above the AGI surtax threshold.",
+        },
         "section_1": "Surtaxes",
-        "section_2": "New AGI Surtax",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "section_2": "New Minimum Tax",
+        "indexed": true,
+        "description": "The new minimum tax will be fully phased in at this level of AGI. If there is no phase-in, this upper threshold should be set equal to the lower AGI threshold.",
+        "notes": ""
+    },
+    "AGI_surtax_trt": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "New AGI surtax rate",
         "type": "float",
         "validators": {
@@ -19169,173 +18123,166 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_AGI_surtax_thd": {
-        "description": "The aggregate gross income above this AGI surtax threshold is taxed at surtax rate on AGI.",
+        },
         "section_1": "Surtaxes",
         "section_2": "New AGI Surtax",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+        "indexed": false,
+        "description": "The surtax rate is applied to the portion of Adjusted Gross Income above the AGI surtax threshold.",
+        "notes": ""
+    },
+    "AGI_surtax_thd": {
         "value": [
             {
                 "year": 2013,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2013,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2013,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2013,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2013,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2014,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2015,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2016,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2017,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 9e+99
             },
             {
                 "year": 2018,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 9e+99
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Threshold for the new AGI surtax",
         "type": "float",
         "validators": {
@@ -19343,27 +18290,20 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
-    },
-    "_LST": {
-        "description": "The lump-sum tax is levied on every member of a tax filing unit. The lump-sum tax is included only in combined taxes; it is not included in income or payroll taxes.",
+        },
         "section_1": "Surtaxes",
-        "section_2": "Lump-Sum Tax",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "section_2": "New AGI Surtax",
+        "indexed": true,
+        "description": "The aggregate gross income above this AGI surtax threshold is taxed at surtax rate on AGI.",
+        "notes": ""
+    },
+    "LST": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Dollar amount of lump-sum tax",
         "type": "float",
         "validators": {
@@ -19371,17 +18311,14 @@
                 "min": -9e+99,
                 "max": 9e+99
             }
-        }
+        },
+        "section_1": "Surtaxes",
+        "section_2": "Lump-Sum Tax",
+        "indexed": false,
+        "description": "The lump-sum tax is levied on every member of a tax filing unit. The lump-sum tax is included only in combined taxes; it is not included in income or payroll taxes.",
+        "notes": ""
     },
-    "_UBI_u18": {
-        "description": "UBI benefit provided to people under 18.",
-        "section_1": "Universal Basic Income",
-        "section_2": "UBI Benefits",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+    "UBI_u18": {
         "value": [
             {
                 "year": 2013,
@@ -19408,10 +18345,6 @@
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "UBI benefit for those under 18",
         "type": "float",
         "validators": {
@@ -19419,17 +18352,14 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
-    },
-    "_UBI_1820": {
-        "description": "UBI benefit provided to people 18-20 years of age.",
+        },
         "section_1": "Universal Basic Income",
         "section_2": "UBI Benefits",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+        "indexed": true,
+        "description": "UBI benefit provided to people under 18.",
+        "notes": ""
+    },
+    "UBI_1820": {
         "value": [
             {
                 "year": 2013,
@@ -19456,10 +18386,6 @@
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "UBI benefit for those 18 through 20",
         "type": "float",
         "validators": {
@@ -19467,17 +18393,14 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
-    },
-    "_UBI_21": {
-        "description": "UBI benefit provided to people 21 and over.",
+        },
         "section_1": "Universal Basic Income",
         "section_2": "UBI Benefits",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": true,
-        "cpi_inflated": true,
+        "indexed": true,
+        "description": "UBI benefit provided to people 18-20 years of age.",
+        "notes": ""
+    },
+    "UBI_21": {
         "value": [
             {
                 "year": 2013,
@@ -19504,10 +18427,6 @@
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "UBI benefit for those 21 and over",
         "type": "float",
         "validators": {
@@ -19515,27 +18434,20 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
-    },
-    "_UBI_ecrt": {
-        "description": "One minus this fraction of UBI benefits are taxable and will be added to AGI.",
+        },
         "section_1": "Universal Basic Income",
-        "section_2": "UBI Taxability",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "section_2": "UBI Benefits",
+        "indexed": true,
+        "description": "UBI benefit provided to people 21 and over.",
+        "notes": ""
+    },
+    "UBI_ecrt": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Fraction of UBI benefits excluded from AGI",
         "type": "float",
         "validators": {
@@ -19543,27 +18455,20 @@
                 "min": 0,
                 "max": 1
             }
-        }
+        },
+        "section_1": "Universal Basic Income",
+        "section_2": "UBI Taxability",
+        "indexed": false,
+        "description": "One minus this fraction of UBI benefits are taxable and will be added to AGI.",
+        "notes": ""
     },
-    "_CR_RetirementSavings_hc": {
-        "description": "If greater than zero, this decimal fraction reduces the portion of the retirement savings credit that can be claimed.",
-        "section_1": "Nonrefundable Credits",
-        "section_2": "Misc. Credit Limits",
-        "irs_ref": "",
-        "notes": "Credit claimed will be (1-Haircut)*RetirementSavingsCredit.",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+    "CR_RetirementSavings_hc": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": false
-        },
         "title": "Credit for retirement savings haircut",
         "type": "float",
         "validators": {
@@ -19571,27 +18476,20 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_CR_ForeignTax_hc": {
-        "description": "If greater than zero, this decimal fraction reduces the portion of the foreign tax credit that can be claimed.",
+        },
         "section_1": "Nonrefundable Credits",
         "section_2": "Misc. Credit Limits",
-        "irs_ref": "",
-        "notes": "Credit claimed will be (1-Haircut)*ForeignTaxCredit.",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "If greater than zero, this decimal fraction reduces the portion of the retirement savings credit that can be claimed.",
+        "notes": "Credit claimed will be (1-Haircut)*RetirementSavingsCredit."
+    },
+    "CR_ForeignTax_hc": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": false
-        },
         "title": "Credit for foreign tax haircut",
         "type": "float",
         "validators": {
@@ -19599,27 +18497,20 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_CR_ResidentialEnergy_hc": {
-        "description": "If greater than zero, this decimal fraction reduces the portion of the residential energy credit that can be claimed.",
+        },
         "section_1": "Nonrefundable Credits",
         "section_2": "Misc. Credit Limits",
-        "irs_ref": "",
-        "notes": "Credit claimed will be (1-Haircut)*ResidentialEnergyCredit.",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "If greater than zero, this decimal fraction reduces the portion of the foreign tax credit that can be claimed.",
+        "notes": "Credit claimed will be (1-Haircut)*ForeignTaxCredit."
+    },
+    "CR_ResidentialEnergy_hc": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": false
-        },
         "title": "Credit for residential energy haircut",
         "type": "float",
         "validators": {
@@ -19627,27 +18518,20 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_CR_GeneralBusiness_hc": {
-        "description": "If greater than zero, this decimal fraction reduces the portion of the general business credit that can be claimed.",
+        },
         "section_1": "Nonrefundable Credits",
         "section_2": "Misc. Credit Limits",
-        "irs_ref": "",
-        "notes": "Credit claimed will be (1-Haircut)*GeneralBusinessCredit.",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "If greater than zero, this decimal fraction reduces the portion of the residential energy credit that can be claimed.",
+        "notes": "Credit claimed will be (1-Haircut)*ResidentialEnergyCredit."
+    },
+    "CR_GeneralBusiness_hc": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": false
-        },
         "title": "Credit for general business haircut",
         "type": "float",
         "validators": {
@@ -19655,27 +18539,20 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_CR_MinimumTax_hc": {
-        "description": "If greater than zero, this decimal fraction reduces the portion of the previous year minimum tax credit that can be claimed.",
+        },
         "section_1": "Nonrefundable Credits",
         "section_2": "Misc. Credit Limits",
-        "irs_ref": "",
-        "notes": "Credit claimed will be (1-Haircut)*PreviousYearMinimumTaxCredit.",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "If greater than zero, this decimal fraction reduces the portion of the general business credit that can be claimed.",
+        "notes": "Credit claimed will be (1-Haircut)*GeneralBusinessCredit."
+    },
+    "CR_MinimumTax_hc": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": false
-        },
         "title": "Credit for previous year minimum tax credit haircut",
         "type": "float",
         "validators": {
@@ -19683,27 +18560,20 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_CR_AmOppRefundable_hc": {
-        "description": "If greater than zero, this decimal fraction reduces the portion of the refundable American Opportunity credit that can be claimed.",
+        },
         "section_1": "Nonrefundable Credits",
         "section_2": "Misc. Credit Limits",
-        "irs_ref": "",
-        "notes": "Credit claimed will be (1-Haircut)*RefundablePortionOfAmericanOpportunityCredit.",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "If greater than zero, this decimal fraction reduces the portion of the previous year minimum tax credit that can be claimed.",
+        "notes": "Credit claimed will be (1-Haircut)*PreviousYearMinimumTaxCredit."
+    },
+    "CR_AmOppRefundable_hc": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": false
-        },
         "title": "Refundable portion of the American Opportunity Credit haircut",
         "type": "float",
         "validators": {
@@ -19711,27 +18581,20 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_CR_AmOppNonRefundable_hc": {
-        "description": "If greater than zero, this decimal fraction reduces the portion of the nonrefundable American Opportunity credit that can be claimed.",
+        },
         "section_1": "Nonrefundable Credits",
         "section_2": "Misc. Credit Limits",
-        "irs_ref": "",
-        "notes": "Credit claimed will be (1-Haircut)*NonRefundablePortionOfAmericanOpportunityCredit.",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "If greater than zero, this decimal fraction reduces the portion of the refundable American Opportunity credit that can be claimed.",
+        "notes": "Credit claimed will be (1-Haircut)*RefundablePortionOfAmericanOpportunityCredit."
+    },
+    "CR_AmOppNonRefundable_hc": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": false
-        },
         "title": "Nonrefundable portion of the American Opportunity Credit haircut",
         "type": "float",
         "validators": {
@@ -19739,27 +18602,20 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_CR_SchR_hc": {
-        "description": "If greater than zero, this decimal fraction reduces the portion of Schedule R credit that can be claimed.",
+        },
         "section_1": "Nonrefundable Credits",
         "section_2": "Misc. Credit Limits",
-        "irs_ref": "",
-        "notes": "Credit claimed will be (1-Haircut)*ScheduleRCredit",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "If greater than zero, this decimal fraction reduces the portion of the nonrefundable American Opportunity credit that can be claimed.",
+        "notes": "Credit claimed will be (1-Haircut)*NonRefundablePortionOfAmericanOpportunityCredit."
+    },
+    "CR_SchR_hc": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": false
-        },
         "title": "Schedule R Credit haircut",
         "type": "float",
         "validators": {
@@ -19767,27 +18623,20 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_CR_OtherCredits_hc": {
-        "description": "If greater than zero, this decimal fraction reduces the portion of other credit that can be claimed.",
+        },
         "section_1": "Nonrefundable Credits",
         "section_2": "Misc. Credit Limits",
-        "irs_ref": "",
-        "notes": "Credit claimed will be (1-Haircut)*OtherCredits.",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "If greater than zero, this decimal fraction reduces the portion of Schedule R credit that can be claimed.",
+        "notes": "Credit claimed will be (1-Haircut)*ScheduleRCredit"
+    },
+    "CR_OtherCredits_hc": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": false
-        },
         "title": "Other Credits haircut",
         "type": "float",
         "validators": {
@@ -19795,27 +18644,20 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_CR_Education_hc": {
-        "description": "If greater than zero, this decimal fraction reduces the portion of education credits that can be claimed.",
+        },
         "section_1": "Nonrefundable Credits",
         "section_2": "Misc. Credit Limits",
-        "irs_ref": "",
-        "notes": "Credit claimed will be (1-Haircut)*EducationCredits.",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "If greater than zero, this decimal fraction reduces the portion of other credit that can be claimed.",
+        "notes": "Credit claimed will be (1-Haircut)*OtherCredits."
+    },
+    "CR_Education_hc": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": false
-        },
         "title": "Education Credits haircut",
         "type": "float",
         "validators": {
@@ -19823,27 +18665,20 @@
                 "min": 0,
                 "max": 1
             }
-        }
+        },
+        "section_1": "Nonrefundable Credits",
+        "section_2": "Misc. Credit Limits",
+        "indexed": false,
+        "description": "If greater than zero, this decimal fraction reduces the portion of education credits that can be claimed.",
+        "notes": "Credit claimed will be (1-Haircut)*EducationCredits."
     },
-    "_CR_Charity_rt": {
-        "description": "If greater than zero, this decimal fraction represents the portion of total charitable contributions provided as a nonrefundable tax credit.",
-        "section_1": "",
-        "section_2": "",
-        "irs_ref": "",
-        "notes": "Credit claimed will be (rt) * (e19800 + e20100)",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+    "CR_Charity_rt": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Charity Credit rate",
         "type": "float",
         "validators": {
@@ -19851,48 +18686,41 @@
                 "min": 0,
                 "max": 1
             }
-        }
-    },
-    "_CR_Charity_f": {
-        "description": "Only charitable giving in excess of this dollar amount is eligible for the charity credit.",
+        },
         "section_1": "",
         "section_2": "",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "If greater than zero, this decimal fraction represents the portion of total charitable contributions provided as a nonrefundable tax credit.",
+        "notes": "Credit claimed will be (rt) * (e19800 + e20100)"
+    },
+    "CR_Charity_f": {
         "value": [
             {
                 "year": 2013,
-                "marital_status": "single",
+                "MARS": "single",
                 "value": 0.0
             },
             {
                 "year": 2013,
-                "marital_status": "joint",
+                "MARS": "mjoint",
                 "value": 0.0
             },
             {
                 "year": 2013,
-                "marital_status": "separate",
+                "MARS": "mseparate",
                 "value": 0.0
             },
             {
                 "year": 2013,
-                "marital_status": "headhousehold",
+                "MARS": "headhh",
                 "value": 0.0
             },
             {
                 "year": 2013,
-                "marital_status": "widow",
+                "MARS": "widow",
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Charity Credit Floor",
         "type": "float",
         "validators": {
@@ -19900,27 +18728,20 @@
                 "min": 0,
                 "max": 9e+99
             }
-        }
-    },
-    "_CR_Charity_frt": {
-        "description": "Only charitable giving in excess of this decimal fraction of AGI is eligible for the charity credit.",
+        },
         "section_1": "",
         "section_2": "",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "Only charitable giving in excess of this dollar amount is eligible for the charity credit.",
+        "notes": ""
+    },
+    "CR_Charity_frt": {
         "value": [
             {
                 "year": 2013,
                 "value": 0.0
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Charity Credit Floor Rate",
         "type": "float",
         "validators": {
@@ -19928,27 +18749,20 @@
                 "min": 0,
                 "max": 1
             }
-        }
+        },
+        "section_1": "",
+        "section_2": "",
+        "indexed": false,
+        "description": "Only charitable giving in excess of this decimal fraction of AGI is eligible for the charity credit.",
+        "notes": ""
     },
-    "_BEN_ssi_repeal": {
-        "description": "SSI benefits can be repealed by switching this parameter to true.",
-        "section_1": "Benefits",
-        "section_2": "Benefit Repeal",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+    "BEN_ssi_repeal": {
         "value": [
             {
                 "year": 2013,
                 "value": false
             }
         ],
-        "compatible_data": {
-            "puf": false,
-            "cps": true
-        },
         "title": "SSI benefit repeal switch",
         "type": "bool",
         "validators": {
@@ -19956,27 +18770,20 @@
                 "min": false,
                 "max": true
             }
-        }
-    },
-    "_BEN_housing_repeal": {
-        "description": "Housing benefits can be repealed by switching this parameter to true.",
+        },
         "section_1": "Benefits",
         "section_2": "Benefit Repeal",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "SSI benefits can be repealed by switching this parameter to true.",
+        "notes": ""
+    },
+    "BEN_housing_repeal": {
         "value": [
             {
                 "year": 2013,
                 "value": false
             }
         ],
-        "compatible_data": {
-            "puf": false,
-            "cps": true
-        },
         "title": "Housing benefit repeal switch",
         "type": "bool",
         "validators": {
@@ -19984,27 +18791,20 @@
                 "min": false,
                 "max": true
             }
-        }
-    },
-    "_BEN_snap_repeal": {
-        "description": "SNAP benefits can be repealed by switching this parameter to true.",
+        },
         "section_1": "Benefits",
         "section_2": "Benefit Repeal",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "Housing benefits can be repealed by switching this parameter to true.",
+        "notes": ""
+    },
+    "BEN_snap_repeal": {
         "value": [
             {
                 "year": 2013,
                 "value": false
             }
         ],
-        "compatible_data": {
-            "puf": false,
-            "cps": true
-        },
         "title": "SNAP benefit repeal switch",
         "type": "bool",
         "validators": {
@@ -20012,27 +18812,20 @@
                 "min": false,
                 "max": true
             }
-        }
-    },
-    "_BEN_tanf_repeal": {
-        "description": "TANF benefits can be repealed by switching this parameter to true.",
+        },
         "section_1": "Benefits",
         "section_2": "Benefit Repeal",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "SNAP benefits can be repealed by switching this parameter to true.",
+        "notes": ""
+    },
+    "BEN_tanf_repeal": {
         "value": [
             {
                 "year": 2013,
                 "value": false
             }
         ],
-        "compatible_data": {
-            "puf": false,
-            "cps": true
-        },
         "title": "TANF benefit repeal switch",
         "type": "bool",
         "validators": {
@@ -20040,27 +18833,20 @@
                 "min": false,
                 "max": true
             }
-        }
-    },
-    "_BEN_vet_repeal": {
-        "description": "Veterans benefits can be repealed by switching this parameter to true.",
+        },
         "section_1": "Benefits",
         "section_2": "Benefit Repeal",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "TANF benefits can be repealed by switching this parameter to true.",
+        "notes": ""
+    },
+    "BEN_vet_repeal": {
         "value": [
             {
                 "year": 2013,
                 "value": false
             }
         ],
-        "compatible_data": {
-            "puf": false,
-            "cps": true
-        },
         "title": "Veterans benefit repeal switch",
         "type": "bool",
         "validators": {
@@ -20068,27 +18854,20 @@
                 "min": false,
                 "max": true
             }
-        }
-    },
-    "_BEN_wic_repeal": {
-        "description": "WIC benefits can be repealed by switching this parameter to true.",
+        },
         "section_1": "Benefits",
         "section_2": "Benefit Repeal",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "Veterans benefits can be repealed by switching this parameter to true.",
+        "notes": ""
+    },
+    "BEN_wic_repeal": {
         "value": [
             {
                 "year": 2013,
                 "value": false
             }
         ],
-        "compatible_data": {
-            "puf": false,
-            "cps": true
-        },
         "title": "WIC benefit repeal switch",
         "type": "bool",
         "validators": {
@@ -20096,27 +18875,20 @@
                 "min": false,
                 "max": true
             }
-        }
-    },
-    "_BEN_mcare_repeal": {
-        "description": "Medicare benefits can be repealed by switching this parameter to true.",
+        },
         "section_1": "Benefits",
         "section_2": "Benefit Repeal",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "WIC benefits can be repealed by switching this parameter to true.",
+        "notes": ""
+    },
+    "BEN_mcare_repeal": {
         "value": [
             {
                 "year": 2013,
                 "value": false
             }
         ],
-        "compatible_data": {
-            "puf": false,
-            "cps": true
-        },
         "title": "Medicare benefit repeal switch",
         "type": "bool",
         "validators": {
@@ -20124,27 +18896,20 @@
                 "min": false,
                 "max": true
             }
-        }
-    },
-    "_BEN_mcaid_repeal": {
-        "description": "Medicaid benefits can be repealed by switching this parameter to true.",
+        },
         "section_1": "Benefits",
         "section_2": "Benefit Repeal",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "Medicare benefits can be repealed by switching this parameter to true.",
+        "notes": ""
+    },
+    "BEN_mcaid_repeal": {
         "value": [
             {
                 "year": 2013,
                 "value": false
             }
         ],
-        "compatible_data": {
-            "puf": false,
-            "cps": true
-        },
         "title": "Medicaid benefit repeal switch",
         "type": "bool",
         "validators": {
@@ -20152,27 +18917,20 @@
                 "min": false,
                 "max": true
             }
-        }
-    },
-    "_BEN_oasdi_repeal": {
-        "description": "Social Security benefits (e02400) can be repealed by switching this parameter to true.",
+        },
         "section_1": "Benefits",
         "section_2": "Benefit Repeal",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "Medicaid benefits can be repealed by switching this parameter to true.",
+        "notes": ""
+    },
+    "BEN_oasdi_repeal": {
         "value": [
             {
                 "year": 2013,
                 "value": false
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Social Security benefit repeal switch",
         "type": "bool",
         "validators": {
@@ -20180,27 +18938,20 @@
                 "min": false,
                 "max": true
             }
-        }
-    },
-    "_BEN_ui_repeal": {
-        "description": "Unemployment insurance benefits (e02300) can be repealed by switching this parameter to true.",
+        },
         "section_1": "Benefits",
         "section_2": "Benefit Repeal",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "Social Security benefits (e02400) can be repealed by switching this parameter to true.",
+        "notes": ""
+    },
+    "BEN_ui_repeal": {
         "value": [
             {
                 "year": 2013,
                 "value": false
             }
         ],
-        "compatible_data": {
-            "puf": true,
-            "cps": true
-        },
         "title": "Unemployment insurance benefit repeal switch",
         "type": "bool",
         "validators": {
@@ -20208,27 +18959,20 @@
                 "min": false,
                 "max": true
             }
-        }
-    },
-    "_BEN_other_repeal": {
-        "description": "Other benefits can be repealed by switching this parameter to true.",
+        },
         "section_1": "Benefits",
         "section_2": "Benefit Repeal",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
+        "indexed": false,
+        "description": "Unemployment insurance benefits (e02300) can be repealed by switching this parameter to true.",
+        "notes": ""
+    },
+    "BEN_other_repeal": {
         "value": [
             {
                 "year": 2013,
                 "value": false
             }
         ],
-        "compatible_data": {
-            "puf": false,
-            "cps": true
-        },
         "title": "Other benefit repeal switch",
         "type": "bool",
         "validators": {
@@ -20236,6 +18980,11 @@
                 "min": false,
                 "max": true
             }
-        }
+        },
+        "section_1": "Benefits",
+        "section_2": "Benefit Repeal",
+        "indexed": false,
+        "description": "Other benefits can be repealed by switching this parameter to true.",
+        "notes": ""
     }
 }

--- a/paramtools/exceptions.py
+++ b/paramtools/exceptions.py
@@ -62,7 +62,8 @@ collision_list = [
     "extend",
     "extend_func",
     "label_to_extend",
-    "indexing_rates",
+    "indexing_rate",
+    "indexed",
 ]
 
 

--- a/paramtools/exceptions.py
+++ b/paramtools/exceptions.py
@@ -62,7 +62,8 @@ collision_list = [
     "extend",
     "extend_func",
     "label_to_extend",
-    "indexing_rate",
+    "get_index_rate",
+    "index_rates",
     "indexed",
 ]
 

--- a/paramtools/exceptions.py
+++ b/paramtools/exceptions.py
@@ -60,7 +60,9 @@ collision_list = [
     "validation_error",
     "view_state",
     "extend",
+    "extend_func",
     "label_to_extend",
+    "indexing_rates",
 ]
 
 

--- a/paramtools/exceptions.py
+++ b/paramtools/exceptions.py
@@ -61,10 +61,10 @@ collision_list = [
     "view_state",
     "extend",
     "extend_func",
+    "uses_extend_func",
     "label_to_extend",
     "get_index_rate",
     "index_rates",
-    "indexed",
 ]
 
 

--- a/paramtools/parameters.py
+++ b/paramtools/parameters.py
@@ -28,7 +28,7 @@ class Parameters:
     field_map: Dict = {}
     array_first: bool = False
     label_to_extend: str = None
-    indexed: bool = False
+    uses_extend_func: bool = False
     index_rates: Dict = {}
 
     def __init__(
@@ -468,7 +468,9 @@ class Parameters:
 
         returns: extended_vo
         """
-        if not self.indexed or not self._data[param].get("indexed", False):
+        if not self.uses_extend_func or not self._data[param].get(
+            "indexed", False
+        ):
             return extend_vo
 
         known_val = known_vo[self.label_to_extend]

--- a/paramtools/parameters.py
+++ b/paramtools/parameters.py
@@ -457,8 +457,17 @@ class Parameters:
         known_vo: ValueObject,
         extend_grid: List,
     ):
+        """
+        Function for applying indexing rates to parameter values as they
+        are extended. Projects may implement their own extend_func by
+        overriding this one. Projects need to write their own indexing_rate
+        method for returning the correct indexing rate for a given parameter
+        and value of label_to_extend (abbreviated to lte_val).
+
+        returns: extended_vo
+        """
         # case 1: extend_vo is the next item in extend_grid
-        # TOOD:
+        # TODO:
         # case 2: extend_vo is the first value in the array and
         #         known_vo is n values ahead.
 
@@ -466,12 +475,17 @@ class Parameters:
             return extend_vo
 
         lte_val = known_vo[self.label_to_extend]
-        v = extend_vo["value"] * (1 + self.indexing_rates(param, lte_val))
+        v = extend_vo["value"] * (1 + self.indexing_rate(param, lte_val))
         extend_vo["value"] = np.round(v, 2) if v < 9e99 else 9e99
         return extend_vo
 
-    def indexing_rates(self, param, lte_val):
-        return 0.0
+    def indexing_rate(self, param, lte_val):
+        """
+        Projects should override this method with their own `indexing_rate`
+        method. This method receives a parameter name and lte_val, the value of
+        label_to_extend. It should return the corresponding indexing_rate.
+        """
+        raise NotImplementedError()
 
     def _set_state(self, params=None, **labels):
         """

--- a/paramtools/schema.py
+++ b/paramtools/schema.py
@@ -76,6 +76,7 @@ class BaseParamSchema(Schema):
     validators = fields.Nested(
         ValueValidatorSchema(), required=False, missing={}
     )
+    indexed = fields.Boolean(required=False)
 
 
 class EmptySchema(Schema):

--- a/paramtools/tests/extend_ex.json
+++ b/paramtools/tests/extend_ex.json
@@ -33,8 +33,29 @@
             }
         }
     },
+    "indexed_param": {
+        "title": "indexed param",
+        "description": ".",
+        "type": "float",
+        "indexed": true,
+        "value": [
+            {"d0": 2, "d1": "c1", "value": 1},
+            {"d0": 2, "d1": "c2", "value": 2},
+            {"d0": 3, "d1": "c1", "value": 3},
+            {"d0": 3, "d1": "c2", "value": 4},
+            {"d0": 5, "d1": "c1", "value": 5},
+            {"d0": 5, "d1": "c2", "value": 6},
+            {"d0": 7, "d1": "c1", "value": 7},
+            {"d0": 7, "d1": "c2", "value": 8}
+        ],
+        "validators": {
+            "range": {
+                "min": -100, "max": "related_param"
+            }
+        }
+    },
     "related_param": {
-        "title": "extend param",
+        "title": "related param",
         "description": "Test error on adjustment extension.",
         "type": "int",
         "value": [

--- a/paramtools/tests/test_parameters.py
+++ b/paramtools/tests/test_parameters.py
@@ -1150,7 +1150,7 @@ class TestIndex:
             defaults = extend_ex_path
             label_to_extend = "d0"
             array_first = True
-            indexed = True
+            uses_extend_func = True
             index_rates = {lte: 0 for lte in range(10)}
 
         params = IndexParams1()
@@ -1174,7 +1174,7 @@ class TestIndex:
             defaults = extend_ex_path
             label_to_extend = "d0"
             array_first = True
-            indexed = True
+            uses_extend_func = True
             index_rates = {lte: 0.02 for lte in range(10)}
 
         params = IndexParams2()

--- a/paramtools/tests/test_parameters.py
+++ b/paramtools/tests/test_parameters.py
@@ -1135,3 +1135,65 @@ class TestExtend:
             [-1, -1],
             [-1, -1],
         ]
+
+
+def grow(n, r, t):
+    while t > 0:
+        n = round(n * (1 + r), 2)
+        t -= 1
+    return n
+
+
+class TestIndex:
+    def test_index_simple(self, extend_ex_path):
+        class IndexParams1(Parameters):
+            defaults = extend_ex_path
+            label_to_extend = "d0"
+            array_first = True
+            indexed = True
+
+            def indexing_rate(self, param, lte_val):
+                return 0
+
+        params = IndexParams1()
+        params.adjust({"indexed_param": [{"d0": 3, "value": 3}]})
+
+        assert params.indexed_param.tolist() == [
+            [1, 2],
+            [1, 2],
+            [1, 2],
+            [3, 3],
+            [3, 3],
+            [3, 3],
+            [3, 3],
+            [3, 3],
+            [3, 3],
+            [3, 3],
+            [3, 3],
+        ]
+
+        class IndexParams2(Parameters):
+            defaults = extend_ex_path
+            label_to_extend = "d0"
+            array_first = True
+            indexed = True
+
+            def indexing_rate(self, param, lte_val):
+                return 0.02
+
+        params = IndexParams2()
+        params.adjust({"indexed_param": [{"d0": 3, "value": 3}]})
+        exp = [
+            [grow(1, 0.02, 1), grow(2, 0.02, 1)],
+            [grow(1, 0.02, 2), grow(2, 0.02, 2)],
+            [grow(1, 0.02, 0), grow(2, 0.02, 0)],
+            [grow(3, 0.02, 0)] * 2,
+            [grow(3, 0.02, 1)] * 2,
+            [grow(3, 0.02, 2)] * 2,
+            [grow(3, 0.02, 3)] * 2,
+            [grow(3, 0.02, 4)] * 2,
+            [grow(3, 0.02, 5)] * 2,
+            [grow(3, 0.02, 6)] * 2,
+            [grow(3, 0.02, 7)] * 2,
+        ]
+        np.testing.assert_allclose(params.indexed_param.tolist(), exp)

--- a/paramtools/tests/test_parameters.py
+++ b/paramtools/tests/test_parameters.py
@@ -1138,9 +1138,9 @@ class TestExtend:
 
 
 def grow(n, r, t):
-    while t > 0:
-        n = round(n * (1 + r), 2)
-        t -= 1
+    mult = 1 if t >= 0 else -1
+    for _ in range(0, abs(t)):
+        n = round(n * (1 + r) ** mult, 2)
     return n
 
 
@@ -1151,9 +1151,7 @@ class TestIndex:
             label_to_extend = "d0"
             array_first = True
             indexed = True
-
-            def indexing_rate(self, param, lte_val):
-                return 0
+            index_rates = {lte: 0 for lte in range(10)}
 
         params = IndexParams1()
         params.adjust({"indexed_param": [{"d0": 3, "value": 3}]})
@@ -1177,15 +1175,13 @@ class TestIndex:
             label_to_extend = "d0"
             array_first = True
             indexed = True
-
-            def indexing_rate(self, param, lte_val):
-                return 0.02
+            index_rates = {lte: 0.02 for lte in range(10)}
 
         params = IndexParams2()
         params.adjust({"indexed_param": [{"d0": 3, "value": 3}]})
         exp = [
-            [grow(1, 0.02, 1), grow(2, 0.02, 1)],
-            [grow(1, 0.02, 2), grow(2, 0.02, 2)],
+            [grow(1, 0.02, -2), grow(2, 0.02, -2)],
+            [grow(1, 0.02, -1), grow(2, 0.02, -1)],
             [grow(1, 0.02, 0), grow(2, 0.02, 0)],
             [grow(3, 0.02, 0)] * 2,
             [grow(3, 0.02, 1)] * 2,


### PR DESCRIPTION
This PR adds parameter indexing. This is turned on by setting the class attribute `indexed` to `True` and  by implementing an `indexing_rate` method. Here's an example that indexes Tax-Calculator's parameters:

```python
import paramtools

class TaxParams(paramtools.Parameters):
    defaults = {
        "schema": {
            "labels": {
                "year": {
                    "type": "int",
                    "validators": {"range": {"min": 2013, "max": 2027}}
                },
                "marital_status": {
                    "type": "str",
                    "validators": {"choice": {"choices": ["single", "joint"]}}
                },
            }
        },
        "standard_deduction": {
            "title": "Standard deduction amount",
            "description": "Amount filing unit can use as a standard deduction.",
            "type": "float",

            # Set indexed to True to extend standard_deduction with the built-in
            # extension logic.
            "indexed": True,

            "value": [
                {"year": 2017, "marital_status": "single", "value": 6350},
                {"year": 2017, "marital_status": "joint", "value": 12700},
                {"year": 2018, "marital_status": "single", "value": 12000},
                {"year": 2018, "marital_status": "joint", "value": 24000},
                {"year": 2026, "marital_status": "single", "value": 7685},
                {"year": 2026, "marital_status": "joint", "value": 15369}],
            "validators": {
                "range": {
                    "min": 0,
                    "max": 9e+99
                }
            }
        },
    }
    array_first = True
    label_to_extend = "year"
    # Activate use of extend_func method.
    uses_extend_func = True
    # inflation rates from Tax-Calculator v2.5.0
    index_rates = {
        2013: 0.0148,
        2014: 0.0159,
        2015: 0.0012,
        2016: 0.0127,
        2017: 0.0187,
        2018: 0.0224,
        2019: 0.0186,
        2020: 0.0233,
        2021: 0.0229,
        2022: 0.0228,
        2023: 0.0221,
        2024: 0.0211,
        2025: 0.0209,
        2026: 0.0211,
        2027: 0.0208,
        2028: 0.021,
        2029: 0.021
    }


params = TaxParams()
params.standard_deduction

# output:
# array([[ 6074.92, 12149.84],
#        [ 6164.83, 12329.66],
#        [ 6262.85, 12525.7 ],
#        [ 6270.37, 12540.73],
#        [ 6350.  , 12700.  ],
#        [12000.  , 24000.  ],
#        [12268.8 , 24537.6 ],
#        [12497.  , 24994.  ],
#        [12788.18, 25576.36],
#        [13081.03, 26162.06],
#        [13379.28, 26758.55],
#        [13674.96, 27349.91],
#        [13963.5 , 27926.99],
#        [ 7685.  , 15369.  ],
#        [ 7847.15, 15693.29]])

```

TODO:

- [ ] Implement way for indexing to be turned on and off for specific parameters.
- [x] Add tests.
- [x] Add docs.

Note: ParamTools will not support updating index rates after the class has been initialized. That is, any updates to the indexing rates should be applied to the rates before this class is initialized.
