### PR TITLE
Alias adjust method to make it easy to write custom adjust methods

### DIFF
--- a/docs/customadjust.py
+++ b/docs/customadjust.py
@@ -1,0 +1,66 @@
+import io
+import os
+
+import pandas as pd
+
+import paramtools
+
+
+class CSVParams(paramtools.Parameters):
+    defaults = {
+        "schema": {
+            "labels": {
+                "year": {
+                    "type": "int",
+                    "validators": {"range": {"min": 2000, "max": 2005}},
+                }
+            }
+        },
+        "a": {
+            "title": "A",
+            "description": "a param",
+            "type": "int",
+            "value": [{"year": 2000, "value": 1}, {"year": 2001, "value": 2}],
+        },
+        "b": {
+            "title": "B",
+            "description": "b param",
+            "type": "int",
+            "value": [{"year": 2000, "value": 3}, {"year": 2001, "value": 4}],
+        },
+    }
+
+    def adjust(self, params_or_path, **kwargs):
+        """
+        A custom adjust method that converts CSV files to
+        ParamTools compliant Python dictionaries.
+        """
+        if os.path.exists(params_or_path):
+            paramsdf = pd.read_csv(params_or_path, index_col="year")
+        else:
+            paramsdf = pd.read_csv(
+                io.StringIO(params_or_path), index_col="year"
+            )
+
+        dfdict = paramsdf.to_dict()
+        params = {"a": [], "b": []}
+        for label in params:
+            for year, value in dfdict[label].items():
+                params[label] += [{"year": year, "value": value}]
+        breakpoint()
+        # call adjust method on paramtools.Parameters which will
+        # call _adjust to actually do the update.
+        return super().adjust(params, **kwargs)
+
+
+csv_string = """
+year,a,b
+2000,5,6\n
+2001,6,7\n
+"""
+
+params = CSVParams()
+print(params.adjust(csv_string))
+
+print(params.a)
+print(params.b)

--- a/docs/docs/api/custom-adjust.md
+++ b/docs/docs/api/custom-adjust.md
@@ -1,0 +1,114 @@
+# Custom Adjustments
+
+The ParamTools adjustment format and logic can be augmented significantly. This is helpful for projects that need to support a pre-existing data format or require custom adjustment logic. Projects should customize their adjustments by writing their own `adjust` method and then calling the default `adjust` method from there:
+
+
+```python
+
+class Params(paramtools.Parameters):
+    def adjust(self, params_or_path, **kwargs):
+        params = self.read_params(params_or_path)
+
+        # ... custom logic here
+
+        # call default adjust method.
+        return super().adjust(params, **kwargs)
+
+```
+
+
+## Example
+
+Some projects may find it convenient to use CSVs for their adjustment format. That's no problem for ParamTools as long as the CSV is converted to a JSON file or Python dictionary that meets the ParamTools criteria.
+
+```python
+import io
+import os
+
+import pandas as pd
+
+import paramtools
+
+
+class CSVParams(paramtools.Parameters):
+    defaults = {
+        "schema": {
+            "labels": {
+                "year": {
+                    "type": "int",
+                    "validators": {"range": {"min": 2000, "max": 2005}}
+                }
+            }
+        },
+        "a": {
+            "title": "A",
+            "description": "a param",
+            "type": "int",
+            "value": [
+                {"year": 2000, "value": 1},
+                {"year": 2001, "value": 2},
+            ]
+        },
+        "b": {
+            "title": "B",
+            "description": "b param",
+            "type": "int",
+            "value": [
+                {"year": 2000, "value": 3},
+                {"year": 2001, "value": 4},
+            ]
+        }
+    }
+
+    def adjust(self, params_or_path, **kwargs):
+        """
+        A custom adjust method that converts CSV files to
+        ParamTools compliant Python dictionaries.
+        """
+        if os.path.exists(params_or_path):
+            paramsdf = pd.read_csv(params_or_path, index_col="year")
+        else:
+            paramsdf = pd.read_csv(io.StringIO(params_or_path), index_col="year")
+
+        dfdict = paramsdf.to_dict()
+        params = {"a": [], "b": []}
+        for label in params:
+            for year, value in dfdict[label].items():
+                params[label] += [{"year": year, "value": value}]
+
+        # call adjust method on paramtools.Parameters which will
+        # call _adjust to actually do the update.
+        return super().adjust(params, **kwargs)
+
+```
+
+Now we create an example CSV file. To keep the example self-contained, the CSV is just a string, but this example works with CSV files, too. The values of "A" are updated to 5 in 2000 and 6 in 2001, and the values of "B" are updated to 6 in 2000 and 7 in 2001.
+
+
+```python
+
+# this could also be a path to a CSV file.
+csv_string = """
+year,a,b
+2000,5,6\n
+2001,6,7\n
+"""
+
+params = CSVParams()
+params.adjust(csv_string)
+
+# output
+# OrderedDict([('a', [{'year': 2000, 'value': 5}, {'year': 2001, 'value': 6}]),
+#              ('b', [{'year': 2000, 'value': 6}, {'year': 2001, 'value': 7}])])
+
+params.a
+
+# output:
+# [{'year': 2000, 'value': 5}, {'year': 2001, 'value': 6}]
+
+params.b
+
+# output
+# [{'year': 2000, 'value': 6}, {'year': 2001, 'value': 7}]
+
+```

--- a/docs/docs/api/guide.md
+++ b/docs/docs/api/guide.md
@@ -14,6 +14,8 @@ API
 
 [**Extend with Indexing:**](/api/index/) Index parameter values.
 
+[**Custom Adjustment Formats and Logic**](/api/custom-adjust/) Customize the adjustment format and logic to meet your project's needs.
+
 *Documentation on these parts of the API coming soon:*
 
 **Array access:** Access parameter values as NumPy arrays.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -6,5 +6,6 @@ nav:
         - Guide: 'api/guide.md'
         - Extend: 'api/extend.md'
         - Extend with Indexing: 'api/indexing.md'
+        - Custom Adjustments: 'api/custom-adjust.md'
 
 theme: mkdocs

--- a/paramtools/exceptions.py
+++ b/paramtools/exceptions.py
@@ -35,6 +35,7 @@ collision_list = [
     "select_eq",
     "select_ne",
     "select_gt",
+    "_adjust",
     "_numpy_type",
     "_parse_errors",
     "_resolve_order",

--- a/paramtools/parameters.py
+++ b/paramtools/parameters.py
@@ -109,7 +109,10 @@ class Parameters:
         Deserialize and validate parameter adjustments. `params_or_path`
         can be a file path or a `dict` that has not been fully deserialized.
         The adjusted values replace the current values stored in the
-        corresponding parameter attributes.
+        corresponding parameter attributes. This simply calls a private
+        method `_adjust` to do the upate. Creating this layer on top of
+        `_adjust` makes it easy to subclass Parameters and implement custom
+        `adjust` methods.
 
         Returns: parsed, validated parameters.
 
@@ -118,6 +121,14 @@ class Parameters:
 
             ParameterUpdateException if label values do not match at
                 least one existing value item's corresponding label values.
+        """
+        return self._adjust(
+            params_or_path, raise_errors=raise_errors, extend_adj=extend_adj
+        )
+
+    def _adjust(self, params_or_path, raise_errors=True, extend_adj=True):
+        """
+        Internal method for performing adjustments.
         """
         params = self.read_params(params_or_path)
 
@@ -176,13 +187,13 @@ class Parameters:
                         array_first = self.array_first
                         self.array_first = False
                         # delete params that will be overwritten out by extend.
-                        self.adjust(
+                        self._adjust(
                             {param: to_delete},
                             extend_adj=False,
                             raise_errors=True,
                         )
                         # set user adjustments.
-                        self.adjust(
+                        self._adjust(
                             {param: vos}, extend_adj=False, raise_errors=True
                         )
                         self.array_first = array_first
@@ -448,9 +459,7 @@ class Parameters:
                         adjustment[param].append(ext)
         # Ensure that the adjust method of paramtools.Parameter is used
         # in case the child class also implements adjust.
-        Parameters.adjust(
-            self, adjustment, extend_adj=False, raise_errors=raise_errors
-        )
+        self._adjust(adjustment, extend_adj=False, raise_errors=raise_errors)
 
     def extend_func(
         self,


### PR DESCRIPTION
This moves the adjustment logic to a private `_adjust` method, and the `adjust` method simply calls this private method. This makes it easier to write custom `adjust` methods on top of ParamTools which is helpful if a project wants to define its own custom adjustment data format or if it needs to apply custom logic to its adjust method. Without this alias approach, ParamTools's internal methods may accidentally call your wrapper method instead of the core adjust method. The convention for doing this is something like:

```python
import io
import os

import pandas as pd

import paramtools


class CSVParams(paramtools.Parameters):
    defaults = {
        "schema": {
            "labels": {
                "year": {
                    "type": "int", 
                    "validators": {"range": {"min": 2000, "max": 2005}}
                }
            }
        },
        "a": {
            "title": "A",
            "description": "a param",
            "type": "int",
            "value": [
                {"year": 2000, "value": 1},
                {"year": 2001, "value": 2},
            ]
        },
        "b": {
            "title": "B",
            "description": "b param",
            "type": "int",
            "value": [
                {"year": 2000, "value": 3},
                {"year": 2001, "value": 4},
            ]
        }
    }
    
    def adjust(self, params_or_path, **kwargs):
        if os.path.exists(params_or_path):
            paramsdf = pd.read_csv(params_or_path)
        else:
            paramsdf = pd.read_csv(io.StringIO(params_or_path))
            
        dfdict = paramsdf.to_dict()
        params = {"a": [], "b": []}
        for label in params:
            for year, value in d[label].items():
                params[label] += [{"year": year, "value": value}]
        
        # call adjust method on paramtools.Parameters which will
        # call _adjust to actually do the update. 
        return super().adjust(params, **kwargs)
```


```python
params = CSVParams()
params.adjust("""
year,a,b
2000,5,6\n
2001,6,7\n
""")

# output
# OrderedDict([('a', [{'value': 5, 'year': 2000}, {'value': 6, 'year': 2001}]),
#             ('b', [{'value': 6, 'year': 2000}, {'value': 7, 'year': 2001}])])
```

```python
params.a

# output:
# [{'value': 5, 'year': 2000}, {'value': 6, 'year': 2001}]
```

```python
params.b

# output
# [{'value': 6, 'year': 2000}, {'value': 7, 'year': 2001}]

```