### PR TITLE
Enhancements and bug fixes for extend method

### DIFF
--- a/paramtools/parameters.py
+++ b/paramtools/parameters.py
@@ -367,7 +367,13 @@ class Parameters:
             value_items.append(vi)
         return value_items
 
-    def extend(self, label_to_extend=None, params=None, raise_errors=True):
+    def extend(
+        self,
+        label_to_extend=None,
+        label_to_extend_values=None,
+        params=None,
+        raise_errors=True,
+    ):
         """
         Extend parameters along label_to_extend.
 
@@ -385,7 +391,10 @@ class Parameters:
                 for param, data in spec.items()
                 if param in params
             }
-        extend_grid = self._stateless_label_grid[label_to_extend]
+        extend_grid = (
+            label_to_extend_values
+            or self._stateless_label_grid[label_to_extend]
+        )
         adjustment = defaultdict(list)
         for param, data in spec.items():
             if not any(label_to_extend in vo for vo in data["value"]):
@@ -450,7 +459,11 @@ class Parameters:
                     for value_object in value_objects:
                         ext = dict(value_object, **{label_to_extend: val})
                         ext = self.extend_func(
-                            param, ext, value_object, extend_grid
+                            param,
+                            ext,
+                            value_object,
+                            extend_grid,
+                            label_to_extend,
                         )
                         extended_vos.add(
                             utils.hashable_value_object(value_object)
@@ -467,6 +480,7 @@ class Parameters:
         extend_vo: ValueObject,
         known_vo: ValueObject,
         extend_grid: List,
+        label_to_extend: str,
     ):
         """
         Function for applying indexing rates to parameter values as they
@@ -482,10 +496,10 @@ class Parameters:
         ):
             return extend_vo
 
-        known_val = known_vo[self.label_to_extend]
+        known_val = known_vo[label_to_extend]
         known_ix = extend_grid.index(known_val)
 
-        toext_val = extend_vo[self.label_to_extend]
+        toext_val = extend_vo[label_to_extend]
         toext_ix = extend_grid.index(toext_val)
 
         if toext_ix > known_ix:

--- a/paramtools/tests/test_parameters.py
+++ b/paramtools/tests/test_parameters.py
@@ -1193,3 +1193,21 @@ class TestIndex:
             [grow(3, 0.02, 7)] * 2,
         ]
         np.testing.assert_allclose(params.indexed_param.tolist(), exp)
+
+    def test_related_param_errors(self, extend_ex_path):
+        class IndexParams2(Parameters):
+            defaults = extend_ex_path
+            label_to_extend = "d0"
+            array_first = True
+            uses_extend_func = True
+            index_rates = {lte: 0.02 for lte in range(10)}
+
+        params = IndexParams2()
+
+        with pytest.raises(ValidationError):
+            params.adjust(
+                {
+                    "related_param": [{"value": 8.1, "d0": 4}],
+                    "indexed_param": [{"d0": 3, "value": 8}],
+                }
+            )

--- a/paramtools/tests/test_parameters.py
+++ b/paramtools/tests/test_parameters.py
@@ -1136,6 +1136,37 @@ class TestExtend:
             [-1, -1],
         ]
 
+    def test_custom_extend(self, extend_ex_path):
+        class ExtParams(Parameters):
+            defaults = extend_ex_path
+            # label_to_extend = "d0"
+            array_first = False
+
+        params = ExtParams()
+        params.adjust({"extend_param": [{"value": None}]})
+        params.adjust(
+            {
+                "extend_param": [
+                    {"d0": 2, "d1": "c1", "value": 1},
+                    {"d0": 2, "d1": "c2", "value": 2},
+                ]
+            }
+        )
+        params.extend(
+            label_to_extend="d0",
+            label_to_extend_values=[2, 4, 7],
+            params="extend_param",
+        )
+
+        assert sorted(params.extend_param, key=lambda vo: vo["d0"]) == [
+            {"d0": 2, "d1": "c1", "value": 1},
+            {"d0": 2, "d1": "c2", "value": 2},
+            {"d0": 4, "d1": "c1", "value": 1},
+            {"d0": 4, "d1": "c2", "value": 2},
+            {"d0": 7, "d1": "c1", "value": 1},
+            {"d0": 7, "d1": "c2", "value": 2},
+        ]
+
 
 def grow(n, r, t):
     mult = 1 if t >= 0 else -1


### PR DESCRIPTION
This PR makes a couple enhancements to the extend method:
- Updates all values at once instead of one at a time. This better respects validation that depends on the values of other parameters.
- `extend` takes a `label_to_extend_values` argument allowing you to specify how a parameter's values are extended on a more granular level.