### PR TITLE
Use marshmallow validation on the "schema" part of the defaults

### DIFF
--- a/paramtools/schema.py
+++ b/paramtools/schema.py
@@ -330,7 +330,7 @@ class AdditionalMembersSchema(Schema):
     number_dims = fields.Integer(required=False, missing=0)
 
 
-class PTSchema(Schema):
+class ParamToolsSchema(Schema):
     labels = fields.Dict(
         keys=fields.Str(),
         values=fields.Nested(LabelSchema()),
@@ -409,7 +409,7 @@ def get_param_schema(base_spec, field_map=None):
     This data is also used to build validators for schema for each parameter
     that will be set on the `BaseValidatorSchema` class
     """
-    schema = PTSchema()
+    schema = ParamToolsSchema()
     base_spec = schema.load(base_spec)
 
     if field_map is not None:

--- a/paramtools/schema.py
+++ b/paramtools/schema.py
@@ -303,6 +303,48 @@ class BaseValidatorSchema(Schema):
         return oth_param_name, res
 
 
+class LabelSchema(Schema):
+    _type = fields.Str(
+        required=True,
+        validate=validate.OneOf(
+            choices=["str", "float", "int", "bool", "date"]
+        ),
+        attribute="type",
+        data_key="type",
+    )
+    number_dims = fields.Integer(required=False, missing=0)
+    validators = fields.Nested(
+        ValueValidatorSchema(), required=False, missing={}
+    )
+
+
+class AdditionalMembersSchema(Schema):
+    _type = fields.Str(
+        required=True,
+        validate=validate.OneOf(
+            choices=["str", "float", "int", "bool", "date"]
+        ),
+        attribute="type",
+        data_key="type",
+    )
+    number_dims = fields.Integer(required=False, missing=0)
+
+
+class PTSchema(Schema):
+    labels = fields.Dict(
+        keys=fields.Str(),
+        values=fields.Nested(LabelSchema()),
+        required=False,
+        missing={},
+    )
+    additional_members = fields.Dict(
+        keys=fields.Str(),
+        values=fields.Nested(AdditionalMembersSchema()),
+        required=False,
+        missing={},
+    )
+
+
 # A few fields that have not been instantiated yet
 CLASS_FIELD_MAP = {
     "str": contrib_fields.Str,
@@ -367,12 +409,15 @@ def get_param_schema(base_spec, field_map=None):
     This data is also used to build validators for schema for each parameter
     that will be set on the `BaseValidatorSchema` class
     """
+    schema = PTSchema()
+    base_spec = schema.load(base_spec)
+
     if field_map is not None:
         field_map = dict(FIELD_MAP, **field_map)
     else:
         field_map = FIELD_MAP.copy()
     optional_fields = {}
-    for k, v in base_spec.get("additional_members", {}).items():
+    for k, v in base_spec["additional_members"].items():
         fieldtype = field_map[v["type"]]
         if v.get("number_dims", 0) > 0:
             d = v["number_dims"]
@@ -387,7 +432,7 @@ def get_param_schema(base_spec, field_map=None):
         {k: v for k, v in optional_fields.items()},
     )
     label_validators = {}
-    for name, label in base_spec.get("labels", {}).items():
+    for name, label in base_spec["labels"].items():
         validators = []
         for vname, kwargs in label["validators"].items():
             validator_class = VALIDATOR_MAP[vname]

--- a/paramtools/tests/test_parameters.py
+++ b/paramtools/tests/test_parameters.py
@@ -6,6 +6,7 @@ from collections import OrderedDict
 
 import pytest
 import numpy as np
+import marshmallow as ma
 
 from paramtools import (
     ValidationError,
@@ -138,6 +139,29 @@ class TestSchema:
 
         TestParams()
         assert defaults_["schema"]
+
+    def test_schema_with_errors(self):
+        class Params(Parameters):
+            array_first = True
+            defaults = {
+                "schema": {
+                    "additional_members": {"additional": {"type": 1234}}
+                }
+            }
+
+        with pytest.raises(ma.ValidationError):
+            Params()
+
+        class Params(Parameters):
+            array_first = True
+            defaults = {
+                "schema": {
+                    "additional_members_123": {"additional": {"type": "str"}}
+                }
+            }
+
+        with pytest.raises(ma.ValidationError):
+            Params()
 
 
 class TestAccess:


### PR DESCRIPTION
This adds validation for when the "schema" part of the defaults is read in by ParamTools. Hopefully, this will make it easier for users to debug errors when they are first writing `defaults` JSON object.