### PR TITLE
Make Parameters class iterable

### DIFF
--- a/paramtools/exceptions.py
+++ b/paramtools/exceptions.py
@@ -52,6 +52,8 @@ collision_list = [
     "clear_state",
     "defaults",
     "dump",
+    "items",
+    "keys",
     "label_grid",
     "label_validators",
     "errors",

--- a/paramtools/parameters.py
+++ b/paramtools/parameters.py
@@ -796,3 +796,14 @@ class Parameters:
             error_info["labels"][pname] = error_labels
 
         self._errors.update(dict(error_info))
+
+    def __iter__(self):
+        return iter(self._data)
+
+    def keys(self):
+        return self._data.keys()
+
+    def items(self):
+        for param in self:
+            yield param, getattr(self, param)
+        return

--- a/paramtools/tests/test_parameters.py
+++ b/paramtools/tests/test_parameters.py
@@ -318,6 +318,19 @@ class TestAccess:
         params2.set_state(label0="one")
         assert params2.dump() == dumped
 
+    def test_iterable(self, TestParams):
+        params = TestParams()
+
+        act = set([])
+        for param in params:
+            act.add(param)
+
+        assert set(params._data.keys()) == act
+        assert set(params._data.keys()) == set(params.keys())
+
+        for param, data in params.items():
+            np.testing.assert_equal(data, getattr(params, param))
+
 
 class TestAdjust:
     def test_adjust_int_param(self, TestParams):


### PR DESCRIPTION
This makes the `Parameters` class iterable. Now, it can be looped over like a dictionary:

```python
import paramtools

class MyParams(paramtools.Parameters):
    defaults = {
        "one_param": {
            "title": "one param",
            "description": "",
            "type": "str",
            "value": "hello"
        },
        "two_param": {
            "title": "two param",
            "description": "",
            "type": "str",
            "value": "world"
        }
    }
    
params = MyParams()


for param in params:
    print(param)

# one_param
# two_param

for param, value in params.items():
    print(param, value)

# one_param [{'value': 'hello'}]
# two_param [{'value': 'world'}]

params.keys()

# odict_keys(['one_param', 'two_param'])