### PR TITLE
Add 'when' validator

### DIFF
--- a/docs/docs/parameters.md
+++ b/docs/docs/parameters.md
@@ -161,16 +161,35 @@ The ParamTools JSON file is split into two components: a component that defines 
 
 - `validators`: Key-value pairs of the validator objects (*the ranges are inclusive*):
     - `level`: All validators take a `level` argument which is either "error" or "warn". By default it is set to "error".
+    - `when`:
+        - `is` is set to `equal_to` by default but can also be `greater_than` or `less_than`.
+            - e.g: `"is": {"greater_than": 0}`
+
+        - If the sub-validators refer to the value of another parameter, then the other parameter
+        must have `number_dims` equal to 0, i.e. be a scalar value and not an array value.
 
 ```json
 {
     "validators": {
         "range": {"min": "min value", "max": "max value", "level": "warn"},
         "choice": {"choices": ["list", "of", "allowed", "values"]},
-        "date_range": {"min": "2018-01-01", "max": "2018-06-01"}
+        "date_range": {"min": "2018-01-01", "max": "2018-06-01"},
+        "when": {
+            "param": "other parameter",
+            "is": "equal_value",
+            "then": {
+                "range": {
+                    "min": "min value if other parameter is 'equal_value'"
+                }
+            },
+            "otherwise": {
+                "range": {
+                    "min": "min value if other parameter is not 'equal_value'"
+                }
+            }
+        }
     }
 }
 ```
-
 
 [1]: https://docs.scipy.org/doc/numpy/reference/generated/numpy.ndarray.ndim.html

--- a/paramtools/contrib/__init__.py
+++ b/paramtools/contrib/__init__.py
@@ -1,4 +1,4 @@
-from paramtools.contrib.validate import Range, DateRange, OneOf
+from paramtools.contrib.validate import Range, DateRange, OneOf, When
 from paramtools.contrib.fields import (
     Float64,
     Int64,
@@ -16,6 +16,7 @@ __all__ = [
     "Range",
     "DateRange",
     "OneOf",
+    "When",
     "Float64",
     "Int64",
     "Bool_",

--- a/paramtools/contrib/validate.py
+++ b/paramtools/contrib/validate.py
@@ -126,6 +126,13 @@ class When(ma.validate.Validator):
                     )
         return msgs
 
+    def grid(self):
+        """
+        Just return grid of first validator. It's unlikely that
+        there will be multiple.
+        """
+        return self.then_validators[0].grid()
+
 
 class Range(ma.validate.Range):
     """

--- a/paramtools/schema.py
+++ b/paramtools/schema.py
@@ -43,9 +43,30 @@ class ValueValidatorSchema(Schema):
     when = fields.Nested("WhenSchema", required=False)
 
 
+class IsSchema(Schema):
+    equal_to = fields.Field(required=False)
+    greater_than = fields.Field(required=False)
+    less_than = fields.Field(required=False)
+
+    @validates_schema
+    def just_one(self, data, **kwargs):
+        if len(data.keys()) > 1:
+            raise MarshmallowValidationError(
+                f"Only one condition may be specified for the 'is' field. "
+                f"You specified {len(data.keys())}."
+            )
+
+    def _deserialize(self, data, **kwargs):
+        if data is not None and not isinstance(data, dict):
+            data = {"equal_to": data}
+        return super()._deserialize(data, **kwargs)
+
+
 class WhenSchema(Schema):
     param = fields.Str()
-    _is = fields.Field(attribute="is", data_key="is")
+    _is = fields.Nested(
+        IsSchema(), attribute="is", data_key="is", required=False
+    )
     then = fields.Nested(ValueValidatorSchema())
     otherwise = fields.Nested(ValueValidatorSchema())
 
@@ -210,7 +231,13 @@ class BaseValidatorSchema(Schema):
         return warnings, errors
 
     def _get_when_validator(
-        self, vname, when_dict, param_name, param_spec, raw_data
+        self,
+        vname,
+        when_dict,
+        param_name,
+        param_spec,
+        raw_data,
+        ndim_restriction=False,
     ):
         when_param = when_dict["param"]
 
@@ -222,7 +249,6 @@ class BaseValidatorSchema(Schema):
                 f"'{when_param}' is not a specified parameter."
             )
 
-        validators = []
         oth_param, when_vos = self._resolve_op_value(
             when_param, param_name, param_spec, raw_data
         )
@@ -230,23 +256,58 @@ class BaseValidatorSchema(Schema):
         for vname, vdata in when_dict["then"].items():
             then_validators.append(
                 getattr(self, self.WRAPPER_MAP[vname])(
-                    vname, vdata, param_name, param_spec, raw_data
+                    vname,
+                    vdata,
+                    param_name,
+                    param_spec,
+                    raw_data,
+                    ndim_restriction=True,
                 )
             )
         otherwise_validators = []
         for vname, vdata in when_dict["otherwise"].items():
-            validators.append(
+            otherwise_validators.append(
                 getattr(self, self.WRAPPER_MAP[vname])(
-                    vname, vdata, param_name, param_spec, raw_data
+                    vname,
+                    vdata,
+                    param_name,
+                    param_spec,
+                    raw_data,
+                    ndim_restriction=True,
                 )
             )
 
+        _type = self.context["spec"]._data[oth_param]["type"]
+        number_dims = self.context["spec"]._data[oth_param]["number_dims"]
+
+        error_then = (
+            f"When {oth_param}{{when_labels}}{{ix}} is {{is_val}}, "
+            f"{param_name}{{labels}}{{ix}} value is invalid: {{submsg}}"
+        )
+        error_otherwise = (
+            f"When {oth_param}{{when_labels}}{{ix}} is not {{is_val}}, "
+            f"{param_name}{{labels}}{{ix}} value is invalid: {{submsg}}"
+        )
+
         return contrib.validate.When(
-            when_dict["is"], when_vos, then_validators, otherwise_validators
+            when_dict["is"],
+            when_vos,
+            then_validators,
+            otherwise_validators,
+            error_then,
+            error_otherwise,
+            _type,
+            number_dims,
         )
 
     def _get_range_validator(
-        self, vname, range_dict, param_name, param_spec, raw_data
+        self,
+        vname,
+        range_dict,
+        param_name,
+        param_spec,
+        raw_data,
+        ndim_restriction=False,
     ):
         if vname == "range":
             range_class = contrib.validate.Range
@@ -261,11 +322,22 @@ class BaseValidatorSchema(Schema):
             min_oth_param, min_vos = self._resolve_op_value(
                 min_value, param_name, param_spec, raw_data
             )
+        else:
+            min_oth_param, min_vos = None, []
+
         max_value = range_dict.get("max", None)
         if max_value is not None:
             max_oth_param, max_vos = self._resolve_op_value(
                 max_value, param_name, param_spec, raw_data
             )
+        else:
+            max_oth_param, max_vos = None, []
+        self._check_ndim_restriction(
+            param_name,
+            min_oth_param,
+            max_oth_param,
+            ndim_restriction=ndim_restriction,
+        )
         min_vos = self._sort_by_label_to_extend(min_vos)
         max_vos = self._sort_by_label_to_extend(max_vos)
         error_min = f"{param_name}{{labels}} {{input}} < min {{min}} {min_oth_param}{{oth_labels}}"
@@ -296,7 +368,13 @@ class BaseValidatorSchema(Schema):
             return vos
 
     def _get_choice_validator(
-        self, vname, choice_dict, param_name, param_spec, raw_data
+        self,
+        vname,
+        choice_dict,
+        param_name,
+        param_spec,
+        raw_data,
+        ndim_restriction=False,
     ):
         choices = choice_dict["choices"]
         labels = utils.make_label_str(param_spec)
@@ -363,6 +441,30 @@ class BaseValidatorSchema(Schema):
         else:
             res = vals
         return oth_param_name, res
+
+    def _check_ndim_restriction(
+        self, param_name, *other_params, ndim_restriction=False
+    ):
+        """
+        Test restriction on validator's concerning references to other
+        parameters with number of dimensions >= 1.
+        """
+        if ndim_restriction and any(other_params):
+            for other_param in other_params:
+                if other_param is None:
+                    continue
+                if other_param == "default":
+                    ndims = self.context["spec"]._data[param_name][
+                        "number_dims"
+                    ]
+                else:
+                    ndims = self.context["spec"]._data[other_param][
+                        "number_dims"
+                    ]
+                if ndims > 0:
+                    raise contrib.validate.ValidationError(
+                        f"{param_name} is validated against {other_param} in an invalid context."
+                    )
 
 
 class LabelSchema(Schema):

--- a/paramtools/tests/defaults.json
+++ b/paramtools/tests/defaults.json
@@ -111,6 +111,24 @@
         "value": 2,
         "validators": {"range": {"min": "default", "max": 10}}
     },
+    "when_param": {
+        "title": "When validator reference param",
+        "description": "Example for using 'when' validator",
+        "type": "int",
+        "value": 0,
+        "validators": {
+            "when": {
+                "param": "str_choice_param",
+                "is": "value0",
+                "then": {
+                    "range": {"min": 0, "max": 0}
+                },
+                "otherwise": {
+                    "choice": {"choices": [0, 2, 5, 7]}
+                }
+            }
+        }
+    },
     "int_dense_array_param": {
         "title": "Integer Dense Array Param",
         "description": "Example of using an int type param that supports to/from_array.",

--- a/paramtools/tests/defaults.json
+++ b/paramtools/tests/defaults.json
@@ -65,6 +65,40 @@
       }
     }
   },
+  "when_array_param": {
+    "title": "When validator reference array param",
+    "description": "Example for using 'when' validator with an array param",
+    "type": "int",
+    "number_dims": 1,
+    "value": [
+      0,
+      1,
+      2,
+      5
+    ],
+    "validators": {
+      "when": {
+        "param": "simple_int_list_param",
+        "is": 2,
+        "then": {
+          "choice": {
+            "choices": [
+              1
+            ]
+          }
+        },
+        "otherwise": {
+          "choice": {
+            "choices": [
+              0,
+              2,
+              5
+            ]
+          }
+        }
+      }
+    }
+  },
   "min_int_param": {
     "title": "min integer parameter",
     "description": "Serves as minimum reference variable.",
@@ -186,6 +220,42 @@
       "date_range": {
         "min": "date_min_param",
         "max": "2018-12-31"
+      }
+    }
+  },
+  "float_list_when_param": {
+    "title": "Float List When Param",
+    "description": "Reference for a float list param, using a when validator.",
+    "opt0": "an option",
+    "type": "float",
+    "number_dims": 1,
+    "value": [
+      {
+        "label0": "zero",
+        "value": [
+          0,
+          2.0,
+          3.0,
+          4.0
+        ]
+      }
+    ],
+    "validators": {
+      "when": {
+        "param": "float_list_param",
+        "is": {
+          "greater_than": 1
+        },
+        "then": {
+          "range": {
+            "min": 1
+          }
+        },
+        "otherwise": {
+          "range": {
+            "min": 0
+          }
+        }
       }
     }
   },

--- a/paramtools/tests/test_parameters.py
+++ b/paramtools/tests/test_parameters.py
@@ -437,6 +437,17 @@ class TestAdjust:
             == 18
         )
 
+    def test_adjust_when_param(self, TestParams):
+        params = TestParams()
+        params.adjust({"when_param": 2, "str_choice_param": "value1"})
+
+        params = TestParams()
+        with pytest.raises(ValidationError):
+            params.adjust({"when_param": 2})
+
+        params = TestParams()
+        params.adjust({"when_param": 0})
+
 
 class TestErrors:
     def test_errors_attribute(self, TestParams):

--- a/paramtools/tests/test_parameters.py
+++ b/paramtools/tests/test_parameters.py
@@ -220,6 +220,28 @@ class TestSchema:
             "uses_extend_func": False,
         }
 
+    def test_when_schema(self):
+        class Params(Parameters):
+            defaults = {
+                "param": {
+                    "title": "",
+                    "description": "",
+                    "type": "int",
+                    "value": 0,
+                    "validators": {
+                        "when": {
+                            "param": "default",
+                            "is": {"less_than": 0, "greater_than": 1},
+                            "then": {"range": {"min": 0}},
+                            "otherwise": {"range": {"min": "default"}},
+                        }
+                    },
+                }
+            }
+
+        with pytest.raises(ma.ValidationError):
+            Params()
+
 
 class TestAccess:
     def test_specification(self, TestParams, defaults_spec_path):

--- a/paramtools/tests/test_validate.py
+++ b/paramtools/tests/test_validate.py
@@ -117,7 +117,7 @@ def test_When():
     choices = [12, 15]
     oneof = OneOf(choices=choices)
     when = When(
-        "world",
+        {"equal_to": "world"},
         when_vos=[{"value": "hello"}],
         then_validators=[range_],
         otherwise_validators=[oneof],
@@ -129,7 +129,7 @@ def test_When():
         when(3)
 
     when = When(
-        "hello",
+        {"equal_to": "hello"},
         when_vos=[{"value": "hello"}],
         then_validators=[range_],
         otherwise_validators=[oneof],

--- a/paramtools/tests/test_validate.py
+++ b/paramtools/tests/test_validate.py
@@ -3,7 +3,7 @@ import datetime
 import pytest
 from marshmallow import ValidationError
 
-from paramtools.contrib import OneOf, Range, DateRange
+from paramtools.contrib import OneOf, Range, DateRange, When
 
 
 def test_OneOf():
@@ -110,3 +110,34 @@ def test_DateRange():
 
         with pytest.raises(ValidationError):
             drange({"value": datetime.date(2020, 1, 2)}, is_value_object=True)
+
+
+def test_When():
+    range_ = Range(0, 10)
+    choices = [12, 15]
+    oneof = OneOf(choices=choices)
+    when = When(
+        "world",
+        when_vos=[{"value": "hello"}],
+        then_validators=[range_],
+        otherwise_validators=[oneof],
+    )
+
+    when(12)
+
+    with pytest.raises(ValidationError):
+        when(3)
+
+    when = When(
+        "hello",
+        when_vos=[{"value": "hello"}],
+        then_validators=[range_],
+        otherwise_validators=[oneof],
+    )
+
+    when(3)
+
+    with pytest.raises(ValidationError):
+        when(12)
+
+    assert when.grid() == list(range(10 + 1))


### PR DESCRIPTION
Resolves #64. I wound up going with a [style similar to what is used by `yup`](https://github.com/jquense/yup#mixedwhenkeys-string--arraystring-builder-object--value-schema-schema-schema):

```json
"swages": {
    "title": "Wage and salary income of spouse",
    "description": "Include self-employment",
    "type": "float",
    "value": 0,
    "validators": {
        "when": {
            "param": "marital_status",
            "is": "single",
            "then": {
                "range": {"min": 0, "max": 0}
            },
            "otherwise": {
                "range": {"min": 0, "max": 9e+99}
            }
       	}
    }
}
```

@jdebacker @Peter-Metz does this solve your use cases/do you have any feedback on this PR?