### PR TITLE
actions -> operators

### DIFF
--- a/docs/docs/parameters.md
+++ b/docs/docs/parameters.md
@@ -22,7 +22,7 @@ The ParamTools JSON file is split into two components: a component that defines 
             "cpi_inflatable": {"type": "bool"},
             "cpi_inflated": {"type": "bool"}
         },
-        "actions": {
+        "operators": {
             "array_first": true,
             "label_to_extend": "year",
             "uses_extend_func": true
@@ -88,7 +88,7 @@ The ParamTools JSON file is split into two components: a component that defines 
             "cpi_inflated": {"type": "bool"}
         }
     },
-    "actions": {
+    "operators": {
         "array_first": true,
         "label_to_extend": true,
         "uses_extend_func": true
@@ -100,7 +100,7 @@ The ParamTools JSON file is split into two components: a component that defines 
 
 - `additional_members`: Additional Members are parameter level members that are specific to your model. For example, "title" is a parameter level member that is required by ParamTools, but "cpi_inflated" is not. Therefore, "cpi_inflated" needs to be defined in `additional_members`.
 
-- `actions`: Actions affect how the data is read into and handled by the `Parameters` class:
+- `operators`: Operators affect how the data is read into and handled by the `Parameters` class:
 
     - `array_first`: If value is `true`, parameters' values will be accessed as arrays by default.
 

--- a/paramtools/exceptions.py
+++ b/paramtools/exceptions.py
@@ -46,7 +46,7 @@ collision_list = [
     "_update_param",
     "_validator_schema",
     "_defaults_schema",
-    "actions",
+    "operators",
     "adjust",
     "array_first",
     "clear_state",

--- a/paramtools/parameters.py
+++ b/paramtools/parameters.py
@@ -57,23 +57,19 @@ class Parameters:
         self._state = initial_state or {}
         self.index_rates = index_rates or self.index_rates
 
-        # set actions in order of importance:
+        # set operators in order of importance:
         # __init__ arg: most important
         # class attribute: middle importance
         # schema action: least important
         # default value if three above are not specified.
-        actions = [
+        ops = [
             ("array_first", array_first, False),
             ("label_to_extend", label_to_extend, None),
             ("uses_extend_func", uses_extend_func, False),
         ]
-        schema_actions = self._schema.get("actions", {})
-        for name, init_value, default in actions:
-            user_vals = [
-                init_value,
-                getattr(self, name),
-                schema_actions.get(name),
-            ]
+        schema_ops = self._schema.get("operators", {})
+        for name, init_value, default in ops:
+            user_vals = [init_value, getattr(self, name), schema_ops.get(name)]
             for value in user_vals:
                 if value != default and value is not None:
                     setattr(self, name, value)
@@ -90,9 +86,9 @@ class Parameters:
         else:
             self.set_state()
 
-        if "actions" not in self._schema:
-            self._schema["actions"] = {}
-        self._schema["actions"].update(self.actions)
+        if "operators" not in self._schema:
+            self._schema["operators"] = {}
+        self._schema["operators"].update(self.operators)
 
     def set_state(self, **labels):
         """
@@ -259,7 +255,7 @@ class Parameters:
         )
 
     @property
-    def actions(self):
+    def operators(self):
         return {
             "array_first": self.array_first,
             "label_to_extend": self.label_to_extend,

--- a/paramtools/schema.py
+++ b/paramtools/schema.py
@@ -330,7 +330,7 @@ class AdditionalMembersSchema(Schema):
     number_dims = fields.Integer(required=False, missing=0)
 
 
-class ActionsSchema(Schema):
+class OperatorsSchema(Schema):
     array_first = fields.Bool(required=False)
     label_to_extend = fields.Str(required=False, allow_none=True)
     uses_extend_func = fields.Bool(required=False)
@@ -349,7 +349,7 @@ class ParamToolsSchema(Schema):
         required=False,
         missing={},
     )
-    actions = fields.Nested(ActionsSchema, required=False)
+    operators = fields.Nested(OperatorsSchema, required=False)
 
 
 # A few fields that have not been instantiated yet

--- a/paramtools/tests/test_parameters.py
+++ b/paramtools/tests/test_parameters.py
@@ -164,7 +164,7 @@ class TestSchema:
         with pytest.raises(ma.ValidationError):
             Params2()
 
-    def test_actions_spec(self):
+    def test_operators_spec(self):
         class Params1(Parameters):
             array_first = False
             defaults = {
@@ -179,7 +179,7 @@ class TestSchema:
                             "validators": {"range": {"min": 0, "max": 10}},
                         },
                     },
-                    "actions": {
+                    "operators": {
                         "array_first": False,
                         "label_to_extend": "somelabel",
                     },
@@ -189,7 +189,7 @@ class TestSchema:
         params = Params1(array_first=True, label_to_extend="mylabel")
         assert params.array_first
         assert params.label_to_extend == "mylabel"
-        assert params.actions == {
+        assert params.operators == {
             "array_first": True,
             "label_to_extend": "mylabel",
             "uses_extend_func": False,
@@ -199,19 +199,19 @@ class TestSchema:
         params = Params1()
         assert params.array_first
         assert params.label_to_extend == "somelabel"
-        assert params.actions == {
+        assert params.operators == {
             "array_first": True,
             "label_to_extend": "somelabel",
             "uses_extend_func": False,
         }
 
         class Params2(Parameters):
-            defaults = {"schema": {"actions": {"array_first": True}}}
+            defaults = {"schema": {"operators": {"array_first": True}}}
 
         params = Params2()
         assert params.array_first
         assert params.label_to_extend is None
-        assert params.actions == {
+        assert params.operators == {
             "array_first": True,
             "label_to_extend": None,
             "uses_extend_func": False,


### PR DESCRIPTION
Rename "actions" to "operators" in "schema" object. I meant to do this in PR #73 (and indeed [thought that I did](https://github.com/PSLmodels/ParamTools/pull/73#issuecomment-529965975)), but I somehow forgot to push the final commit that did the update.