### PR TITLE
Add method for sorting values according to label order

### DIFF
--- a/paramtools/exceptions.py
+++ b/paramtools/exceptions.py
@@ -62,6 +62,7 @@ collision_list = [
     "read_params",
     "set_state",
     "specification",
+    "sort_values",
     "to_array",
     "validation_error",
     "view_state",

--- a/paramtools/parameters.py
+++ b/paramtools/parameters.py
@@ -4,7 +4,7 @@ import json
 import itertools
 import warnings
 from collections import OrderedDict, defaultdict
-from functools import reduce
+from functools import partial, reduce
 from typing import Optional, Dict, List, Any
 
 import numpy as np
@@ -828,3 +828,29 @@ class Parameters:
         Return instance as python dictionary.
         """
         return dict(self.items())
+
+    def sort_values(self):
+        """
+        Sort value objects for all parameters according
+        to the order specified in schema.
+        """
+
+        def keyfunc(vo, label, label_values):
+            if label in vo:
+                return label_values.index(vo[label])
+            else:
+                return -1
+
+        # iterate over labels so that the first label's order
+        # takes precedence.
+        label_grid = self._stateless_label_grid
+        order = list(reversed(label_grid))
+
+        for param, data in self._data.items():
+            for label in order:
+                label_values = label_grid[label]
+                data["value"].sort(
+                    key=partial(
+                        keyfunc, label=label, label_values=label_values
+                    )
+                )

--- a/paramtools/parameters.py
+++ b/paramtools/parameters.py
@@ -856,3 +856,7 @@ class Parameters:
                         keyfunc, label=label, label_values=label_values
                     )
                 )
+            # Only update attributes when array first is off, since
+            # value order will not affect how arrays are constructed.
+            if not self.array_first:
+                setattr(self, param, data["value"])

--- a/paramtools/parameters.py
+++ b/paramtools/parameters.py
@@ -266,13 +266,15 @@ class Parameters:
             "uses_extend_func": self.uses_extend_func,
         }
 
-    def dump(self):
+    def dump(self, sort_values=False):
         """
         Dump a representation of this instance to JSON. This makes it
         possible to load this instance's data after sending the data
         across the wire or from another programming language. The
         dumped values will be queried using this instance's state.
         """
+        if sort_values:
+            self.sort_values()
         spec = self.specification(
             meta_data=True, include_empty=True, serializable=True
         )

--- a/paramtools/tests/test_parameters.py
+++ b/paramtools/tests/test_parameters.py
@@ -398,7 +398,6 @@ class TestAccess:
     def test_dump_sort_values(self, TestParams):
         """Test sort_values keyword in dump()"""
         tp = TestParams()
-        tp = TestParams()
         for param in tp:
             shuffle(tp._data[param]["value"])
 
@@ -422,9 +421,9 @@ class TestAccess:
         # Test that param attributes are not updated when
         # array first is True
         params = ExtParams()
-        params.extend_param = 2
+        params.extend_param = "don't update me"
         params.sort_values()
-        assert params.extend_param == 2
+        assert params.extend_param == "don't update me"
 
 
 class TestAdjust:

--- a/paramtools/tests/test_parameters.py
+++ b/paramtools/tests/test_parameters.py
@@ -334,7 +334,7 @@ class TestAccess:
             np.testing.assert_equal(data, getattr(params, param))
 
     def test_sort_values(self, TestParams):
-        """Ensure sort works and is stable"""
+        """Ensure sort runs and is stable"""
         sorted_tp = TestParams()
         sorted_tp.sort_values()
         assert sorted_tp.dump() == TestParams().dump()
@@ -343,10 +343,13 @@ class TestAccess:
         for param in shuffled_tp:
             shuffle(shuffled_tp._data[param]["value"])
 
-        assert sorted_tp != shuffled_tp.dump()
+        assert sorted_tp.dump() != shuffled_tp.dump()
 
         shuffled_tp.sort_values()
         assert sorted_tp.dump() == shuffled_tp.dump()
+        # Test attribute is updated, too.
+        for param in sorted_tp:
+            assert getattr(sorted_tp, param) == getattr(shuffled_tp, param)
 
     def test_sort_values_correctness(self):
         """Ensure sort is correct"""
@@ -390,7 +393,6 @@ class TestAccess:
         assert params.param != exp and params.param == shuffled
 
         params.sort_values()
-        params.set_state()
         assert params.param == exp
 
     def test_dump_sort_values(self, TestParams):
@@ -405,9 +407,24 @@ class TestAccess:
 
         assert sorted_dump != shuffled_dump
 
-        sortedtp = TestParams()
-        sortedtp.sort_values()
-        assert sortedtp.dump() == sorted_dump
+        sorted_tp = TestParams()
+        sorted_tp.sort_values()
+        assert sorted_tp.dump() == sorted_dump
+
+    def test_sort_values_w_array(self, extend_ex_path):
+        """Test sort values with array first config"""
+
+        class ExtParams(Parameters):
+            defaults = extend_ex_path
+            label_to_extend = "d0"
+            array_first = True
+
+        # Test that param attributes are not updated when
+        # array first is True
+        params = ExtParams()
+        params.extend_param = 2
+        params.sort_values()
+        assert params.extend_param == 2
 
 
 class TestAdjust:

--- a/paramtools/tests/test_parameters.py
+++ b/paramtools/tests/test_parameters.py
@@ -393,6 +393,22 @@ class TestAccess:
         params.set_state()
         assert params.param == exp
 
+    def test_dump_sort_values(self, TestParams):
+        """Test sort_values keyword in dump()"""
+        tp = TestParams()
+        tp = TestParams()
+        for param in tp:
+            shuffle(tp._data[param]["value"])
+
+        shuffled_dump = tp.dump()
+        sorted_dump = tp.dump(sort_values=True)
+
+        assert sorted_dump != shuffled_dump
+
+        sortedtp = TestParams()
+        sortedtp.sort_values()
+        assert sortedtp.dump() == sorted_dump
+
 
 class TestAdjust:
     def test_adjust_int_param(self, TestParams):


### PR DESCRIPTION
This PR adds a method for sorting values according to label order as defined in the schema object. Values objects that are added as part of the "extend" process are added randomly and thus, do not appear to have a sensible order. This feature helps applications like Compute Studio that use the order of the value objects for display purposes.