### PR TITLE
Sort values by default in dump()

### DIFF
--- a/paramtools/parameters.py
+++ b/paramtools/parameters.py
@@ -266,7 +266,7 @@ class Parameters:
             "uses_extend_func": self.uses_extend_func,
         }
 
-    def dump(self, sort_values=False):
+    def dump(self, sort_values=True):
         """
         Dump a representation of this instance to JSON. This makes it
         possible to load this instance's data after sending the data
@@ -842,6 +842,10 @@ class Parameters:
                 return label_values.index(vo[label])
             else:
                 return -1
+
+        # nothing to do if labels aren't specified
+        if not self._stateless_label_grid:
+            return
 
         # iterate over labels so that the first label's order
         # takes precedence.

--- a/paramtools/tests/test_parameters.py
+++ b/paramtools/tests/test_parameters.py
@@ -337,16 +337,22 @@ class TestAccess:
         """Ensure sort runs and is stable"""
         sorted_tp = TestParams()
         sorted_tp.sort_values()
-        assert sorted_tp.dump() == TestParams().dump()
+        assert sorted_tp.dump(sort_values=False) == TestParams().dump(
+            sort_values=False
+        )
 
         shuffled_tp = TestParams()
         for param in shuffled_tp:
             shuffle(shuffled_tp._data[param]["value"])
 
-        assert sorted_tp.dump() != shuffled_tp.dump()
+        assert sorted_tp.dump(sort_values=False) != shuffled_tp.dump(
+            sort_values=False
+        )
 
         shuffled_tp.sort_values()
-        assert sorted_tp.dump() == shuffled_tp.dump()
+        assert sorted_tp.dump(sort_values=False) == shuffled_tp.dump(
+            sort_values=False
+        )
         # Test attribute is updated, too.
         for param in sorted_tp:
             assert getattr(sorted_tp, param) == getattr(shuffled_tp, param)
@@ -401,14 +407,14 @@ class TestAccess:
         for param in tp:
             shuffle(tp._data[param]["value"])
 
-        shuffled_dump = tp.dump()
+        shuffled_dump = tp.dump(sort_values=False)
         sorted_dump = tp.dump(sort_values=True)
 
         assert sorted_dump != shuffled_dump
 
         sorted_tp = TestParams()
         sorted_tp.sort_values()
-        assert sorted_tp.dump() == sorted_dump
+        assert sorted_tp.dump(sort_values=False) == sorted_dump
 
     def test_sort_values_w_array(self, extend_ex_path):
         """Test sort values with array first config"""


### PR DESCRIPTION
This PR makes `dump` sort the value objects by default. Initially, this was not the default because there is a small performance hit on `dump` when the values are sorted (about 10ms on a large configuration). However, I think the result will be less confusing to users who expect the value objects to have a certain order. Users with performance concerns can simply set `sort_values` to `False`.