### PR TITLE
Add warnings

### DIFF
--- a/docs/docs/parameters.md
+++ b/docs/docs/parameters.md
@@ -61,7 +61,7 @@ The ParamTools JSON file is split into two components: a component that defines 
         "validators": {
             "range": {
                 "min": 0,
-                "max": 9e+99
+                "level": "warn",
             }
         }
     },
@@ -160,17 +160,17 @@ The ParamTools JSON file is split into two components: a component that defines 
     - if labels are not used: `{"value": "my value"}`
 
 - `validators`: Key-value pairs of the validator objects (*the ranges are inclusive*):
+    - `level`: All validators take a `level` argument which is either "error" or "warn". By default it is set to "error".
 
 ```json
 {
     "validators": {
-        "range": {"min": "min value", "max": "max value"},
+        "range": {"min": "min value", "max": "max value", "level": "warn"},
         "choice": {"choices": ["list", "of", "allowed", "values"]},
         "date_range": {"min": "2018-01-01", "max": "2018-06-01"}
     }
 }
 ```
-
 
 
 [1]: https://docs.scipy.org/doc/numpy/reference/generated/numpy.ndarray.ndim.html

--- a/paramtools/exceptions.py
+++ b/paramtools/exceptions.py
@@ -1,4 +1,5 @@
 import json
+from collections import defaultdict
 
 from paramtools import utils
 
@@ -19,10 +20,11 @@ class ValidationError(ParamToolsError):
     def __init__(self, messages, labels):
         self.messages = messages
         self.labels = labels
-        raveled_messages = {
-            param: utils.ravel(msgs) for param, msgs in self.messages.items()
-        }
-        super().__init__(json.dumps(raveled_messages, indent=4))
+        error_msg = defaultdict(dict)
+        for error_type, msgs in self.messages.items():
+            for param, msg in msgs.items():
+                error_msg[error_type][param] = utils.ravel(msg)
+        super().__init__(json.dumps(error_msg, indent=4))
 
 
 class InconsistentLabelsException(ParamToolsError):
@@ -32,6 +34,7 @@ class InconsistentLabelsException(ParamToolsError):
 collision_list = [
     "_data",
     "_errors",
+    "_warnings",
     "select_eq",
     "select_gt",
     "_adjust",
@@ -57,6 +60,7 @@ collision_list = [
     "label_grid",
     "label_validators",
     "errors",
+    "warnings",
     "field_map",
     "from_array",
     "read_params",
@@ -73,6 +77,7 @@ collision_list = [
     "get_index_rate",
     "index_rates",
     "to_dict",
+    "_parse_validation_messages",
 ]
 
 

--- a/paramtools/schema.py
+++ b/paramtools/schema.py
@@ -8,10 +8,7 @@ from marshmallow import (
     ValidationError as MarshmallowValidationError,
 )
 
-from paramtools.contrib import (
-    validate as contrib_validate,
-    fields as contrib_fields,
-)
+from paramtools import contrib
 from paramtools import utils
 
 
@@ -25,10 +22,12 @@ class RangeSchema(Schema):
 
     _min = fields.Field(attribute="min", data_key="min")
     _max = fields.Field(attribute="max", data_key="max")
+    level = fields.String(validate=[validate.OneOf(["warn", "error"])])
 
 
 class ChoiceSchema(Schema):
     choices = fields.List(fields.Field)
+    level = fields.String(validate=[validate.OneOf(["warn", "error"])])
 
 
 class ValueValidatorSchema(Schema):
@@ -144,6 +143,13 @@ class BaseValidatorSchema(Schema):
         "choice": "_get_choice_validator",
     }
 
+    def load(self, data, ignore_warnings):
+        self.ignore_warnings = ignore_warnings
+        try:
+            return super().load(data)
+        finally:
+            self.ignore_warnings = False
+
     @validates_schema
     def validate_params(self, data, **kwargs):
         """
@@ -152,16 +158,20 @@ class BaseValidatorSchema(Schema):
         parameters have been validated. Note that all data has been
         type-validated. These methods only do range validation.
         """
+        warnings = defaultdict(dict)
         errors = defaultdict(dict)
-        errors_exist = False
         for name, specs in data.items():
             for i, spec in enumerate(specs):
-                iserrors = self.validate_param(name, spec, data)
-                if iserrors:
-                    errors_exist = True
-                    errors[name][i] = {"value": iserrors}
-        if errors_exist:
-            raise MarshmallowValidationError(dict(errors))
+                _warnings, _errors = self.validate_param(name, spec, data)
+                if _warnings:
+                    warnings[name][i] = {"value": _warnings}
+                if _errors:
+                    errors[name][i] = {"value": _errors}
+        if warnings and not self.ignore_warnings:
+            errors["warnings"] = warnings
+        if errors:
+            ve = MarshmallowValidationError(dict(errors))
+            raise ve
 
     def validate_param(self, param_name, param_spec, raw_data):
         """
@@ -181,22 +191,26 @@ class BaseValidatorSchema(Schema):
             )
             validators.append(validator)
 
+        warnings = []
         errors = []
         for validator in validators:
             try:
                 validator(param_spec, is_value_object=True)
-            except MarshmallowValidationError as ve:
-                errors += ve.messages
+            except contrib.validate.ValidationError as ve:
+                if ve.level == "warn":
+                    warnings += ve.messages
+                else:
+                    errors += ve.messages
 
-        return errors
+        return warnings, errors
 
     def _get_range_validator(
         self, vname, range_dict, param_name, param_spec, raw_data
     ):
         if vname == "range":
-            range_class = contrib_validate.Range
+            range_class = contrib.validate.Range
         elif vname == "date_range":
-            range_class = contrib_validate.DateRange
+            range_class = contrib.validate.DateRange
         else:
             raise MarshmallowValidationError(
                 f"{vname} is not an allowed validator."
@@ -220,6 +234,7 @@ class BaseValidatorSchema(Schema):
             max_vo=max_vos,
             error_min=error_min,
             error_max=error_max,
+            level=range_dict.get("level"),
         )
 
     def _sort_by_label_to_extend(self, vos):
@@ -259,7 +274,9 @@ class BaseValidatorSchema(Schema):
             choices="{choices}",
             label_suffix=label_suffix,
         )
-        return contrib_validate.OneOf(choices, error=error)
+        return contrib.validate.OneOf(
+            choices, error=error, level=choice_dict.get("level")
+        )
 
     def _resolve_op_value(self, op_value, param_name, param_spec, raw_data):
         """
@@ -358,11 +375,11 @@ class ParamToolsSchema(Schema):
 
 # A few fields that have not been instantiated yet
 CLASS_FIELD_MAP = {
-    "str": contrib_fields.Str,
-    "int": contrib_fields.Integer,
-    "float": contrib_fields.Float,
-    "bool": contrib_fields.Boolean,
-    "date": contrib_fields.Date,
+    "str": contrib.fields.Str,
+    "int": contrib.fields.Integer,
+    "float": contrib.fields.Float,
+    "bool": contrib.fields.Boolean,
+    "date": contrib.fields.Date,
 }
 
 
@@ -372,35 +389,35 @@ INVALID_DATE = {"invalid": "Not a valid date: {input}."}
 
 # A few fields that have been instantiated
 FIELD_MAP = {
-    "str": contrib_fields.Str(allow_none=True),
-    "int": contrib_fields.Integer(
+    "str": contrib.fields.Str(allow_none=True),
+    "int": contrib.fields.Integer(
         allow_none=True, error_messages=INVALID_NUMBER
     ),
-    "float": contrib_fields.Float(
+    "float": contrib.fields.Float(
         allow_none=True, error_messages=INVALID_NUMBER
     ),
-    "bool": contrib_fields.Boolean(
+    "bool": contrib.fields.Boolean(
         allow_none=True, error_messages=INVALID_BOOLEAN
     ),
-    "date": contrib_fields.Date(allow_none=True, error_messages=INVALID_DATE),
+    "date": contrib.fields.Date(allow_none=True, error_messages=INVALID_DATE),
 }
 
 VALIDATOR_MAP = {
-    "range": contrib_validate.Range,
-    "date_range": contrib_validate.DateRange,
-    "choice": contrib_validate.OneOf,
+    "range": contrib.validate.Range,
+    "date_range": contrib.validate.DateRange,
+    "choice": contrib.validate.OneOf,
 }
 
 
 def get_type(data):
     numeric_types = {
-        "int": contrib_fields.Int64(
+        "int": contrib.fields.Int64(
             allow_none=True, error_messages=INVALID_NUMBER
         ),
-        "bool": contrib_fields.Bool_(
+        "bool": contrib.fields.Bool_(
             allow_none=True, error_messages=INVALID_BOOLEAN
         ),
-        "float": contrib_fields.Float64(
+        "float": contrib.fields.Float64(
             allow_none=True, error_messages=INVALID_NUMBER
         ),
     }

--- a/paramtools/tests/defaults.json
+++ b/paramtools/tests/defaults.json
@@ -1,161 +1,173 @@
 {
-    "schema": {
-        "labels": {
-            "label0": {
-                "type": "str",
-                "validators": {"choice": {"choices": ["zero",
-                                                      "one"]}}
-            },
-            "label1": {
-                "type": "int",
-                "validators": {"range": {"min": 0, "max": 5}}
-            },
-            "label2": {
-                "type": "int",
-                "validators": {"range": {"min": 0, "max": 2}}
-            }
-        },
-        "additional_members": {
-            "opt0": {"type": "str"}
-        }
-    },
-    "min_int_param": {
-        "title": "min integer parameter",
-        "description": "Serves as minimum reference variable.",
-        "notes": "See max_int_param",
-        "opt0": "an option",
-        "type": "int",
-        "value": [
-            {"label0": "zero", "label1": 1, "value": 1},
-            {"label0": "one", "label1": 2, "value": 2}
-        ],
-        "validators": {"range": {"min": 0, "max": "max_int_param"}}
-    },
-    "max_int_param": {
-        "title": "max integer parameter",
-        "description": "Serves as maximum reference variable.",
-        "notes": "See min_int_param",
-        "opt0": "an option",
-        "type": "int",
-        "value": [
-            {"label0": "zero", "label1": 1, "value": 3},
-            {"label0": "one", "label1": 2, "value": 4}
-        ],
-        "validators": {"range": {"min": "min_int_param", "max": 10}}
-    },
-    "str_choice_param": {
-        "title": "String Choice Param",
-        "description": "Example for string type params using a choice validator",
-        "opt0": "another option",
+  "schema": {
+    "labels": {
+      "label0": {
         "type": "str",
-        "value": "value0",
-        "validators": {"choice": {"choices": ["value0", "value1"]}}
-    },
-    "date_param": {
-        "title": "Date parameter",
-        "description": "Example for a date parameter",
-        "opt0": "another option",
-        "type": "date",
-        "value": [
-            {"label0": "zero", "label1": 1, "value": "2018-01-15"}
-        ],
-        "validators": {"date_range": {"min": "2018-01-01", "max": "2018-12-31"}}
-    },
-    "date_min_param": {
-        "title": "Date Min Param",
-        "description": "Serves as minimum reference variable.",
-        "notes": "See date_max_param.",
-        "opt0": "an option",
-        "type": "date",
-        "value": [
-            {"label0": "zero", "label1": 1, "value": "2018-01-15"}
-        ],
-        "validators": {"date_range": {"min": "2018-01-01", "max": "date_max_param"}}
-    },
-    "date_max_param": {
-        "title": "Date max parameter",
-        "description": "Serves as maximum reference variable.",
-        "notes": "See date_min_param.",
-        "opt0": "an option",
-        "type": "date",
-        "value": [
-            {"label0": "zero", "label1": 1, "value": "2018-01-15"}
-        ],
-        "validators": {"date_range": {"min": "date_min_param", "max": "2018-12-31"}}
-    },
-    "float_list_param": {
-        "title": "Float List Param",
-        "description": "Example for a float, list param.",
-        "opt0": "an option",
-        "type": "float",
-        "number_dims": 1,
-        "value": [
-            {"label0": "zero", "label1": 1, "value": [1, 2.0, 3.5, 4.6]}
-        ],
-        "validators": {"range": {"min": 0, "max": 10}}
-    },
-    "simple_int_list_param": {
-        "title": "Simple Int List Param",
-        "description": "Test case where param is simple and a list.",
-        "opt0": "an option",
+        "validators": { "choice": { "choices": ["zero", "one"] } }
+      },
+      "label1": {
         "type": "int",
-        "number_dims": 1,
-        "value": [1, 2, 3, 4],
-        "validators": {"range": {"min": 0, "max": 10}}
-    },
-    "int_default_param": {
-        "title": "Integer Default Reference Param",
-        "description": "Example for a int param using a default reference value",
-        "opt0": "an option",
+        "validators": { "range": { "min": 0, "max": 5 } }
+      },
+      "label2": {
         "type": "int",
-        "value": 2,
-        "validators": {"range": {"min": "default", "max": 10}}
+        "validators": { "range": { "min": 0, "max": 2 } }
+      }
     },
-    "int_dense_array_param": {
-        "title": "Integer Dense Array Param",
-        "description": "Example of using an int type param that supports to/from_array.",
-        "opt0": "an option",
-        "type": "int",
-        "value": [
-            {"label0": "zero", "label1": 0, "label2": 0, "value": 1},
-            {"label0": "zero", "label1": 0, "label2": 1, "value": 2},
-            {"label0": "zero", "label1": 0, "label2": 2, "value": 3},
-            {"label0": "zero", "label1": 1, "label2": 0, "value": 4},
-            {"label0": "zero", "label1": 1, "label2": 1, "value": 5},
-            {"label0": "zero", "label1": 1, "label2": 2, "value": 6},
-            {"label0": "zero", "label1": 2, "label2": 0, "value": 7},
-            {"label0": "zero", "label1": 2, "label2": 1, "value": 8},
-            {"label0": "zero", "label1": 2, "label2": 2, "value": 9},
-            {"label0": "zero", "label1": 3, "label2": 0, "value": 10},
-            {"label0": "zero", "label1": 3, "label2": 1, "value": 11},
-            {"label0": "zero", "label1": 3, "label2": 2, "value": 12},
-            {"label0": "zero", "label1": 4, "label2": 0, "value": 13},
-            {"label0": "zero", "label1": 4, "label2": 1, "value": 14},
-            {"label0": "zero", "label1": 4, "label2": 2, "value": 15},
-            {"label0": "zero", "label1": 5, "label2": 0, "value": 16},
-            {"label0": "zero", "label1": 5, "label2": 1, "value": 17},
-            {"label0": "zero", "label1": 5, "label2": 2, "value": 18},
-
-            {"label0": "one", "label1": 0, "label2": 0, "value": 19},
-            {"label0": "one", "label1": 0, "label2": 1, "value": 20},
-            {"label0": "one", "label1": 0, "label2": 2, "value": 21},
-            {"label0": "one", "label1": 1, "label2": 0, "value": 22},
-            {"label0": "one", "label1": 1, "label2": 1, "value": 23},
-            {"label0": "one", "label1": 1, "label2": 2, "value": 24},
-            {"label0": "one", "label1": 2, "label2": 0, "value": 25},
-            {"label0": "one", "label1": 2, "label2": 1, "value": 26},
-            {"label0": "one", "label1": 2, "label2": 2, "value": 27},
-            {"label0": "one", "label1": 3, "label2": 0, "value": 28},
-            {"label0": "one", "label1": 3, "label2": 1, "value": 29},
-            {"label0": "one", "label1": 3, "label2": 2, "value": 30},
-            {"label0": "one", "label1": 4, "label2": 0, "value": 31},
-            {"label0": "one", "label1": 4, "label2": 1, "value": 32},
-            {"label0": "one", "label1": 4, "label2": 2, "value": 33},
-            {"label0": "one", "label1": 5, "label2": 0, "value": 34},
-            {"label0": "one", "label1": 5, "label2": 1, "value": 35},
-            {"label0": "one", "label1": 5, "label2": 2, "value": 36}
-
-        ],
-        "validators": {"range": {"min": 1, "max": 36}}
+    "additional_members": {
+      "opt0": { "type": "str" }
     }
+  },
+  "min_int_param": {
+    "title": "min integer parameter",
+    "description": "Serves as minimum reference variable.",
+    "notes": "See max_int_param",
+    "opt0": "an option",
+    "type": "int",
+    "value": [
+      { "label0": "zero", "label1": 1, "value": 1 },
+      { "label0": "one", "label1": 2, "value": 2 }
+    ],
+    "validators": { "range": { "min": 0, "max": "max_int_param" } }
+  },
+  "max_int_param": {
+    "title": "max integer parameter",
+    "description": "Serves as maximum reference variable.",
+    "notes": "See min_int_param",
+    "opt0": "an option",
+    "type": "int",
+    "value": [
+      { "label0": "zero", "label1": 1, "value": 3 },
+      { "label0": "one", "label1": 2, "value": 4 }
+    ],
+    "validators": { "range": { "min": "min_int_param", "max": 10 } }
+  },
+  "str_choice_param": {
+    "title": "String Choice Param",
+    "description": "Example for string type params using a choice validator",
+    "opt0": "another option",
+    "type": "str",
+    "value": "value0",
+    "validators": { "choice": { "choices": ["value0", "value1"] } }
+  },
+  "date_param": {
+    "title": "Date parameter",
+    "description": "Example for a date parameter",
+    "opt0": "another option",
+    "type": "date",
+    "value": [{ "label0": "zero", "label1": 1, "value": "2018-01-15" }],
+    "validators": { "date_range": { "min": "2018-01-01", "max": "2018-12-31" } }
+  },
+  "date_min_param": {
+    "title": "Date Min Param",
+    "description": "Serves as minimum reference variable.",
+    "notes": "See date_max_param.",
+    "opt0": "an option",
+    "type": "date",
+    "value": [{ "label0": "zero", "label1": 1, "value": "2018-01-15" }],
+    "validators": {
+      "date_range": { "min": "2018-01-01", "max": "date_max_param" }
+    }
+  },
+  "date_max_param": {
+    "title": "Date max parameter",
+    "description": "Serves as maximum reference variable.",
+    "notes": "See date_min_param.",
+    "opt0": "an option",
+    "type": "date",
+    "value": [{ "label0": "zero", "label1": 1, "value": "2018-01-15" }],
+    "validators": {
+      "date_range": { "min": "date_min_param", "max": "2018-12-31" }
+    }
+  },
+  "float_list_param": {
+    "title": "Float List Param",
+    "description": "Example for a float, list param.",
+    "opt0": "an option",
+    "type": "float",
+    "number_dims": 1,
+    "value": [{ "label0": "zero", "label1": 1, "value": [1, 2.0, 3.5, 4.6] }],
+    "validators": { "range": { "min": 0, "max": 10 } }
+  },
+  "simple_int_list_param": {
+    "title": "Simple Int List Param",
+    "description": "Test case where param is simple and a list.",
+    "opt0": "an option",
+    "type": "int",
+    "number_dims": 1,
+    "value": [1, 2, 3, 4],
+    "validators": { "range": { "min": 0, "max": 10 } }
+  },
+  "int_default_param": {
+    "title": "Integer Default Reference Param",
+    "description": "Example for a int param using a default reference value",
+    "opt0": "an option",
+    "type": "int",
+    "value": 2,
+    "validators": { "range": { "min": "default", "max": 10 } }
+  },
+  "int_dense_array_param": {
+    "title": "Integer Dense Array Param",
+    "description": "Example of using an int type param that supports to/from_array.",
+    "opt0": "an option",
+    "type": "int",
+    "value": [
+      { "label0": "zero", "label1": 0, "label2": 0, "value": 1 },
+      { "label0": "zero", "label1": 0, "label2": 1, "value": 2 },
+      { "label0": "zero", "label1": 0, "label2": 2, "value": 3 },
+      { "label0": "zero", "label1": 1, "label2": 0, "value": 4 },
+      { "label0": "zero", "label1": 1, "label2": 1, "value": 5 },
+      { "label0": "zero", "label1": 1, "label2": 2, "value": 6 },
+      { "label0": "zero", "label1": 2, "label2": 0, "value": 7 },
+      { "label0": "zero", "label1": 2, "label2": 1, "value": 8 },
+      { "label0": "zero", "label1": 2, "label2": 2, "value": 9 },
+      { "label0": "zero", "label1": 3, "label2": 0, "value": 10 },
+      { "label0": "zero", "label1": 3, "label2": 1, "value": 11 },
+      { "label0": "zero", "label1": 3, "label2": 2, "value": 12 },
+      { "label0": "zero", "label1": 4, "label2": 0, "value": 13 },
+      { "label0": "zero", "label1": 4, "label2": 1, "value": 14 },
+      { "label0": "zero", "label1": 4, "label2": 2, "value": 15 },
+      { "label0": "zero", "label1": 5, "label2": 0, "value": 16 },
+      { "label0": "zero", "label1": 5, "label2": 1, "value": 17 },
+      { "label0": "zero", "label1": 5, "label2": 2, "value": 18 },
+
+      { "label0": "one", "label1": 0, "label2": 0, "value": 19 },
+      { "label0": "one", "label1": 0, "label2": 1, "value": 20 },
+      { "label0": "one", "label1": 0, "label2": 2, "value": 21 },
+      { "label0": "one", "label1": 1, "label2": 0, "value": 22 },
+      { "label0": "one", "label1": 1, "label2": 1, "value": 23 },
+      { "label0": "one", "label1": 1, "label2": 2, "value": 24 },
+      { "label0": "one", "label1": 2, "label2": 0, "value": 25 },
+      { "label0": "one", "label1": 2, "label2": 1, "value": 26 },
+      { "label0": "one", "label1": 2, "label2": 2, "value": 27 },
+      { "label0": "one", "label1": 3, "label2": 0, "value": 28 },
+      { "label0": "one", "label1": 3, "label2": 1, "value": 29 },
+      { "label0": "one", "label1": 3, "label2": 2, "value": 30 },
+      { "label0": "one", "label1": 4, "label2": 0, "value": 31 },
+      { "label0": "one", "label1": 4, "label2": 1, "value": 32 },
+      { "label0": "one", "label1": 4, "label2": 2, "value": 33 },
+      { "label0": "one", "label1": 5, "label2": 0, "value": 34 },
+      { "label0": "one", "label1": 5, "label2": 1, "value": 35 },
+      { "label0": "one", "label1": 5, "label2": 2, "value": 36 }
+    ],
+    "validators": { "range": { "min": 1, "max": 36 } }
+  },
+  "str_choice_warn_param": {
+    "title": "String Choice Warnings Param",
+    "description": "Example for string type params using a choice validator with warnings",
+    "opt0": "another option",
+    "type": "str",
+    "value": "value0",
+    "validators": {
+      "choice": { "choices": ["value0", "value1"], "level": "warn" }
+    }
+  },
+  "int_warn_param": {
+    "title": "Integer Parameter that uses warnings",
+    "description": "Example for a int param using warnings with a range validator",
+    "opt0": "an option",
+    "type": "int",
+    "value": 2,
+    "validators": { "range": { "min": 0, "max": 10, "level": "warn" } }
+  }
 }

--- a/paramtools/tests/test_validate.py
+++ b/paramtools/tests/test_validate.py
@@ -110,3 +110,17 @@ def test_DateRange():
 
         with pytest.raises(ValidationError):
             drange({"value": datetime.date(2020, 1, 2)}, is_value_object=True)
+
+
+def test_level():
+    oneof = OneOf(choices=["allowed1", "allowed2"], level="warn")
+    assert oneof.level == "warn"
+    with pytest.raises(ValidationError) as excinfo:
+        oneof("notachoice")
+    assert excinfo.value.level == "warn"
+
+    range_ = Range(0, 10, level="warn")
+    assert range_.level == "warn"
+    with pytest.raises(ValidationError) as excinfo:
+        range_(11)
+    assert excinfo.value.level == "warn"


### PR DESCRIPTION
Adds a "level" argument to the validators object that allows the user to specify whether it should throw a warning or not if the value is not valid. If level is set to "warning" then a warning is thrown. By default, "level" is set to "error," and does not need to explicitly be specified. Users can control whether warnings are ignored or raised by setting `ignore_warnings` to `True` in the `Parameters.adjust(...)` method. Note that `ignore_warnings` is `False` by default.

```python
import paramtools

class Params(paramtools.Parameters):
    defaults = {
        "myparam": {
            "title": "a param",
            "description": "",
            "type": "int",
            "value": 2,
            "validators": {
                "range": {"min": 0, "max": 2, "level": "warn"} # <--- level set to warn
            }
        }
    }
```

Throws error when `ignore_warnings` is `False`:
```python
params = Params()
params.adjust({"myparam": -1})

# output
# ---------------------------------------------------------------------------
# ValidationError                           Traceback (most recent call last)
# <ipython-input-2-db7b27f0ae3f> in <module>
#       1 params = Params()
# ----> 2 params.adjust({"myparam": -1})

# ~/Documents/ParamTools/paramtools/parameters.py in adjust(self, params_or_path, ignore_warnings, raise_errors, extend_adj)
#     161             ignore_warnings=ignore_warnings,
#     162             raise_errors=raise_errors,
# --> 163             extend_adj=extend_adj,
#     164         )
#     165 

# ~/Documents/ParamTools/paramtools/parameters.py in _adjust(self, params_or_path, ignore_warnings, raise_errors, extend_adj)
#     271             not ignore_warnings and has_warnings
#     272         ):
# --> 273             raise self.validation_error
#     274 
#     275         # Update attrs for params that were adjusted.

# ValidationError: {
#     "warnings": {
#         "myparam": [
#             "myparam -1 < min 0 "
#         ]
#     }
# }

```

Ignores warning validator when `ignore_warnings` is `True`
```python
params = Params()
params.adjust({"myparam": -1}, ignore_warnings=True)
params.myparam

# output
# [{'value': -1}]

```

Note this PR also fixes syntax around imports and my editor reformatted the `defaults.json` test file.