### PR TITLE
Bug fix: Bring back support for custom fields

### DIFF
--- a/paramtools/schema_factory.py
+++ b/paramtools/schema_factory.py
@@ -5,9 +5,10 @@ from paramtools.schema import (
     OrderedSchema,
     BaseValidatorSchema,
     ValueObject,
-    ParamToolsSchema,
     get_type,
     get_param_schema,
+    make_schema,
+    ALLOWED_TYPES,
 )
 from paramtools import utils
 
@@ -26,9 +27,14 @@ class SchemaFactory:
     deserialize and validate parameter data.
     """
 
-    def __init__(self, defaults, field_map={}):
+    def __init__(self, defaults, field_map=None):
         defaults = utils.read_json(defaults)
         self.defaults = {k: v for k, v in defaults.items() if k != "schema"}
+        # Make shallow copy to prevent modifications to the original.
+        allowed_types = list(ALLOWED_TYPES)
+        if field_map:
+            allowed_types += field_map.keys()
+        ParamToolsSchema = make_schema(allowed_types)
         self.schema = ParamToolsSchema().load(defaults.get("schema", {}))
         (self.BaseParamSchema, self.label_validators) = get_param_schema(
             self.schema, field_map=field_map

--- a/paramtools/tests/test_parameters.py
+++ b/paramtools/tests/test_parameters.py
@@ -242,6 +242,53 @@ class TestSchema:
         with pytest.raises(ma.ValidationError):
             Params()
 
+    def test_custom_fields(self):
+        class Custom(ma.Schema):
+            hello = ma.fields.Boolean()
+            world = ma.fields.Boolean()
+
+        class Params(Parameters):
+            field_map = {"custom_type": ma.fields.Nested(Custom)}
+            defaults = {
+                "schema": {
+                    "additional_members": {"custom": {"type": "custom_type"}}
+                },
+                "param": {
+                    "title": "",
+                    "description": "",
+                    "type": "int",
+                    "value": 0,
+                    "validators": {},
+                    "custom": {"hello": True, "world": True},
+                },
+            }
+
+        params = Params()
+        assert params
+        assert params._data["param"]["custom"] == {
+            "hello": True,
+            "world": True,
+        }
+
+        class BadSpec(Parameters):
+            field_map = {"custom_type": ma.fields.Nested(Custom)}
+            defaults = {
+                "schema": {
+                    "additional_members": {"custom": {"type": "custom_type"}}
+                },
+                "param": {
+                    "title": "",
+                    "description": "",
+                    "type": "int",
+                    "value": 0,
+                    "validators": {},
+                    "custom": {"hello": 123, "world": "whoops"},
+                },
+            }
+
+        with pytest.raises(ma.ValidationError):
+            BadSpec()
+
 
 class TestAccess:
     def test_specification(self, TestParams, defaults_spec_path):

--- a/paramtools/tests/test_parameters.py
+++ b/paramtools/tests/test_parameters.py
@@ -258,7 +258,6 @@ class TestSchema:
                     "description": "",
                     "type": "int",
                     "value": 0,
-                    "validators": {},
                     "custom": {"hello": True, "world": True},
                 },
             }
@@ -281,7 +280,6 @@ class TestSchema:
                     "description": "",
                     "type": "int",
                     "value": 0,
-                    "validators": {},
                     "custom": {"hello": 123, "world": "whoops"},
                 },
             }


### PR DESCRIPTION
PR #72 added strict validation on the "schema" object making it impossible to define custom fields on ParamTools objects. Support for custom fields was added to support fields like Tax-Calculator's `compatible_data`. Since there wasn't a test for this feature, no errors were thrown when it was removed in #72. This PR re-instates this feature and adds a test for custom fields so that this doesn't happen again in the future.

```python
import marshmallow as ma
import paramtools as pt


class CompatibleData(ma.Schema):
    cps = ma.fields.Boolean()
    puf = ma.fields.Boolean()

class Params(pt.Parameters):
    field_map = {"compatible_data_type": ma.fields.Nested(CompatibleData)}
    defaults = {
        "schema": {
            "additional_members": {
                "compatible_data": {"type": "compatible_data_type"}
            }
        },
        "standard_deduction": {
            "title": "",
            "description": "",
            "type": "int",
            "value": 0,
            "compatible_data": {"puf": True, "cps": True},
        },
    }

```

