### PR TITLE
Add select less than function

### DIFF
--- a/paramtools/exceptions.py
+++ b/paramtools/exceptions.py
@@ -37,6 +37,7 @@ collision_list = [
     "_warnings",
     "select_eq",
     "select_gt",
+    "select_lt",
     "_adjust",
     "_numpy_type",
     "_parse_errors",

--- a/paramtools/parameters.py
+++ b/paramtools/parameters.py
@@ -13,7 +13,7 @@ from marshmallow import ValidationError as MarshmallowValidationError
 from paramtools import utils
 from paramtools.schema import ParamToolsSchema
 from paramtools.schema_factory import SchemaFactory
-from paramtools.select import select_eq, select_gt_ix, select_gt
+from paramtools.select import select_eq, select_gt_ix, select_gt, select_lt
 from paramtools.tree import Tree
 from paramtools.typing import ValueObject
 from paramtools.exceptions import (
@@ -749,6 +749,14 @@ class Parameters:
 
     def select_gt(self, param, exact_match, **labels):
         return select_gt(
+            self._data[param]["value"],
+            exact_match,
+            labels,
+            tree=self._search_trees.get(param),
+        )
+
+    def select_lt(self, param, exact_match, **labels):
+        return select_lt(
             self._data[param]["value"],
             exact_match,
             labels,

--- a/paramtools/select.py
+++ b/paramtools/select.py
@@ -45,6 +45,10 @@ def gt_ix_func(cmp_list: list, x: Any, y: Iterable) -> bool:
     return all(x_val > cmp_list.index(item) for item in y)
 
 
+def lt_func(x, y) -> bool:
+    return all(x < item for item in y)
+
+
 def select_eq(
     value_objects: List[ValueObject],
     exact_match: bool,
@@ -77,3 +81,12 @@ def select_gt_ix(
         labels,
         tree,
     )
+
+
+def select_lt(
+    value_objects: List[ValueObject],
+    exact_match: bool,
+    labels: dict,
+    tree: Tree = None,
+) -> List[ValueObject]:
+    return select(value_objects, exact_match, lt_func, labels, tree)

--- a/paramtools/tests/test_parameters.py
+++ b/paramtools/tests/test_parameters.py
@@ -1905,3 +1905,39 @@ class TestIndex:
                     "indexed_param": [{"d0": 3, "value": 8}],
                 }
             )
+
+
+class TestSelect:
+    def test_select_lt(self):
+        class Params(Parameters):
+            defaults = {
+                "schema": {
+                    "labels": {
+                        "d0": {"type": "int"},
+                        "d1": {
+                            "type": "str",
+                            "validators": {
+                                "choice": {"choices": ["hello", "world"]}
+                            },
+                        },
+                    }
+                },
+                "param": {
+                    "title": "",
+                    "description": "",
+                    "type": "int",
+                    "value": [
+                        {"d0": 1, "d1": "hello", "value": 1},
+                        {"d0": 1, "d1": "world", "value": 1},
+                        {"d0": 2, "d1": "hello", "value": 1},
+                        {"d0": 3, "d1": "world", "value": 1},
+                    ],
+                },
+            }
+
+        params = Params()
+        assert list(params.select_lt("param", False, d0=3)) == [
+            {"d0": 1, "d1": "hello", "value": 1},
+            {"d0": 1, "d1": "world", "value": 1},
+            {"d0": 2, "d1": "hello", "value": 1},
+        ]

--- a/paramtools/tests/test_select.py
+++ b/paramtools/tests/test_select.py
@@ -1,6 +1,6 @@
 import pytest
 
-from paramtools.select import select_eq, select_gt
+from paramtools.select import select_eq, select_gt, select_lt
 
 
 @pytest.fixture
@@ -30,4 +30,12 @@ def test_select_gt(vos):
     assert list(select_gt(vos, True, labels={"d0": 1})) == [
         {"d0": 2, "d1": "hello", "value": 1},
         {"d0": 3, "d1": "world", "value": 1},
+    ]
+
+
+def test_select_lt(vos):
+    assert list(select_lt(vos, True, labels={"d0": 3})) == [
+        {"d0": 1, "d1": "hello", "value": 1},
+        {"d0": 1, "d1": "world", "value": 1},
+        {"d0": 2, "d1": "hello", "value": 1},
     ]


### PR DESCRIPTION
This PR adds a function for selecting parameter values based on a label value being less than some other value:

```python
In [1]: from paramtools import Parameters                                                                                                                                                     

In [2]: class Params(Parameters): 
   ...:     defaults = { 
   ...:         "schema": { 
   ...:             "labels": { 
   ...:                 "d0": {"type": "int"}, 
   ...:                 "d1": { 
   ...:                     "type": "str", 
   ...:                     "validators": { 
   ...:                         "choice": {"choices": ["hello", "world"]} 
   ...:                     }, 
   ...:                 }, 
   ...:             } 
   ...:         }, 
   ...:         "param": { 
   ...:             "title": "", 
   ...:             "description": "", 
   ...:             "type": "int", 
   ...:             "value": [ 
   ...:                 {"d0": 1, "d1": "hello", "value": 1}, 
   ...:                 {"d0": 1, "d1": "world", "value": 1}, 
   ...:                 {"d0": 2, "d1": "hello", "value": 1}, 
   ...:                 {"d0": 3, "d1": "world", "value": 1}, 
   ...:             ], 
   ...:         }, 
   ...:     } 
   ...:  
   ...:                                                                                                                                                                                       

In [3]: params = Params()                                                                                                                                                                     

In [4]: params.select_lt("param", exact_match=False, d0=2)                                                                                                                                    
Out[4]: [{'value': 1, 'd0': 1, 'd1': 'hello'}, {'value': 1, 'd0': 1, 'd1': 'world'}]

In [5]: params.select_lt("param", exact_match=False, d0=2, d1="world")                                                                                                                        
Out[5]: [{'value': 1, 'd0': 1, 'd1': 'hello'}]

In [6]:                                                                                                                                                                                       
```