### PR TITLE
Drop warnings for adjusting non-active values.

### DIFF
--- a/paramtools/parameters.py
+++ b/paramtools/parameters.py
@@ -2,7 +2,6 @@ import copy
 import os
 import json
 import itertools
-import warnings
 from collections import OrderedDict, defaultdict
 from functools import partial, reduce
 from typing import Optional, Dict, List, Any
@@ -194,17 +193,6 @@ class Parameters:
                         vos, self.label_to_extend, extend_grid
                     ):
                         if self.label_to_extend in vo:
-                            if (
-                                vo[self.label_to_extend]
-                                not in self.label_grid[self.label_to_extend]
-                            ):
-                                msg = (
-                                    f"{param}[{self.label_to_extend}={vo[self.label_to_extend]}] "
-                                    f"is not active in the current state: "
-                                    f"{self.label_to_extend}= "
-                                    f"{self.label_grid[self.label_to_extend]}."
-                                )
-                                warnings.warn(msg)
                             gt = select_gt_ix(
                                 self._data[param]["value"],
                                 True,

--- a/paramtools/tests/test_parameters.py
+++ b/paramtools/tests/test_parameters.py
@@ -1777,8 +1777,7 @@ class TestExtend:
 
         params = ExtParams()
         params.set_state(d0=list(range(2, 11)))
-        with pytest.warns(UserWarning):
-            params.adjust({"extend_param": [{"d0": 1, "value": -1}]})
+        params.adjust({"extend_param": [{"d0": 1, "value": -1}]})
         assert params.extend_param.tolist() == []
         params.array_first = False
         params.clear_state()


### PR DESCRIPTION
ParamTools emits warnings if you adjust a parameter's value that is not active. That is, the value's label value is not in the set of values in the active `state`. This PR removes those warnings since this case is more normal than I thought:

```python
In [1]: import taxcalc                                                                                                                                                                        

In [2]: pol = taxcalc.Policy()                                                                                                                                                                

In [3]: pol.adjust({"II_em": [{"year": 2017, "value": 2000}]})                                                                                                                                
/home/hankdoupe/miniconda3/envs/taxcalc-dev/lib/python3.8/site-packages/paramtools/parameters.py:207: UserWarning: II_em[year=2017] is not active in the current state: year= [2013].
  warnings.warn(msg)
Out[3]: OrderedDict([('II_em', [{'year': 2017, 'value': 2000.0}])])

In [4]:                                                                                                                                                                                       
```
