### PR TITLE
Add ability to register custom fields

### DIFF
--- a/docs/docs/api/custom-types.md
+++ b/docs/docs/api/custom-types.md
@@ -1,0 +1,220 @@
+# Custom Types
+
+Often, the behavior for a field needs to be customized to support a particular shape or validation method that ParamTools does not support out of the box. In this case, you may use the `register_custom_type` function to add your new `type` to the ParamTools type registry. Each `type` has a corresponding `field` that is used for serialization and deserialization. ParamTools will then use this `field` any time it is handling a `value`, `label`, or `member` that is of this `type`.
+
+ParamTools is built on top of [`marshmallow`](https://github.com/marshmallow-code/marshmallow), a general purpose validation library. This means that you must implement a custom `marshmallow` field to go along with your new type. Please refer to the `marshmallow` [docs](https://marshmallow.readthedocs.io/en/stable/) if you have questions about the use of `marshmallow` in the examples below.
+
+
+## 32 Bit Integer Example
+
+ParamTools's default integer field uses NumPy's `int64` type. This example shows you how to define an `int32` type and reference it in your `defaults`.
+
+First, let's define the Marshmallow class:
+
+```python
+import marshmallow as ma
+import numpy as np
+
+class Int32(ma.fields.Field):
+    """
+    A custom type for np.int32.
+    https://numpy.org/devdocs/reference/arrays.dtypes.html
+    """
+    # minor detail that makes this play nice with array_first
+    np_type = np.int32
+
+    def _serialize(self, value, *args, **kwargs):
+        """Convert np.int32 to basic, serializable Python int."""
+        return value.tolist()
+
+    def _deserialize(self, value, *args, **kwargs):
+        """Cast value from JSON to NumPy Int32."""
+        converted = np.int32(value)
+        return converted
+
+```
+
+
+Now, reference it in our defaults JSON/dict object:
+
+```python
+import paramtools as pt
+
+
+# add int32 type to the paramtools type registry
+pt.register_custom_type("int32", Int32())
+
+
+class Params(pt.Parameters):
+    defaults = {
+        "small_int": {
+            "title": "Small integer",
+            "description": "Demonstrate how to define a custom type",
+            "type": "int32",
+            "value": 2
+        }
+    }
+
+
+params = Params(array_first=True)
+
+
+print(f"value: {params.small_int}, type: {type(params.small_int)}")
+
+# value: 2, type: <class 'numpy.int32'>
+
+```
+
+One problem with this is that we could run into some deserialization issues. Due to integer overflow, our deserialized result is not the number that we passed in--it's negative!
+
+```python
+params.adjust(dict(
+    # this number wasn't chosen randomly.
+    small_int=2147483647 + 1
+))
+
+# OrderedDict([('small_int', [{'value': -2147483648}])])
+```
+
+### Marshmallow Validator
+
+Fortunately, you can specify a custom validator with `marshmallow` or ParamTools. Making this works requires modifying the `_deserialize` method to check for overflow like this:
+
+```python
+    # check out the full example at the bottom of this page.
+    def _deserialize(self, value, *args, **kwargs):
+        """Cast value from JSON to NumPy Int32."""
+        converted = np.int32(value)
+
+        # check for overflow and let range validator
+        # display the error message.
+        if converted != int(value):
+            return int(value)
+
+        return converted
+```
+
+ Now, let's see how to use `marshmallow` to fix this problem:
+
+```python
+import marshmallow as ma
+import paramtools as pt
+
+
+# get the minimum and maxium values for 32 bit integers.
+min_int32 = -2147483648  # = np.iinfo(np.int32).min
+max_int32 = 2147483647  # = np.iinfo(np.int32).max
+
+# add int32 type to the paramtools type registry
+pt.register_custom_type(
+    "int32",
+    Int32(validate=[
+        ma.validate.Range(min=min_int32, max=max_int32)
+    ])
+)
+
+
+class Params(pt.Parameters):
+    defaults = {
+        "small_int": {
+            "title": "Small integer",
+            "description": "Demonstrate how to define a custom type",
+            "type": "int32",
+            "value": 2
+        }
+    }
+
+
+params = Params(array_first=True)
+
+params.adjust(dict(
+    small_int=np.int64(max_int32) + 1
+))
+
+# ValidationError: {
+#     "errors": {
+#         "small_int": [
+#             "Must be greater than or equal to -2147483648 and less than or equal to 2147483647."
+#         ]
+#     }
+# }
+
+```
+
+### ParamTools Validator
+
+Finally, we will use ParamTools to solve this problem. We need to modify how we create our custom `marshmallow` field so that it's wrapped by ParamTools's `PartialField`. This makes it clear that your field still needs to be initialized, and that your custom field is able to receive validation information from the `defaults` configuration:
+
+
+```python
+import paramtools as pt
+
+
+# add int32 type to the paramtools type registry
+pt.register_custom_type(
+    "int32",
+    pt.PartialField(Int32)
+)
+
+
+class Params(pt.Parameters):
+    defaults = {
+        "small_int": {
+            "title": "Small integer",
+            "description": "Demonstrate how to define a custom type",
+            "type": "int32",
+            "value": 2,
+            "validators": {
+                "range": {"min": -2147483648, "max": 2147483647}
+            }
+        }
+    }
+
+
+params = Params(array_first=True)
+
+params.adjust(dict(
+    small_int=2147483647 + 1
+))
+
+# ValidationError: {
+#     "errors": {
+#         "small_int": [
+#             "small_int 2147483648 > max 2147483647 "
+#         ]
+#     }
+# }
+
+```
+
+
+### Complete Int32 field
+
+```python
+import marshmallow as ma
+import numpy as np
+
+class Int32(ma.fields.Field):
+    """
+    A custom type for np.int32.
+    https://numpy.org/devdocs/reference/arrays.dtypes.html
+    """
+    # minor detail that makes this play nice with array_first
+    np_type = np.int32
+
+    def _serialize(self, value, *args, **kwargs):
+        """Convert np.int32 to basic Python int."""
+        return value.tolist()
+
+    def _deserialize(self, value, *args, **kwargs):
+        """Cast value from JSON to NumPy Int32."""
+        converted = np.int32(value)
+
+        # check for overflow and let range validator
+        # display the error message.
+        if converted != int(value):
+            return int(value)
+
+        return converted
+
+```

--- a/docs/docs/api/guide.md
+++ b/docs/docs/api/guide.md
@@ -16,6 +16,8 @@ API
 
 [**Custom Adjustment Formats and Logic**](/api/custom-adjust/) Customize the adjustment format and logic to meet your project's needs.
 
+[**Custom types**](/api/custom-types/) Add custom types for your parameters' values, labels, and members.
+
 *Documentation on these parts of the API coming soon:*
 
 **Array access:** Access parameter values as NumPy arrays.

--- a/paramtools/__init__.py
+++ b/paramtools/__init__.py
@@ -7,6 +7,7 @@ from paramtools.exceptions import (
     InconsistentLabelsException,
     collision_list,
     ParameterNameCollisionException,
+    UnknownTypeException,
 )
 from paramtools.parameters import Parameters
 from paramtools.schema import (
@@ -16,12 +17,13 @@ from paramtools.schema import (
     BaseParamSchema,
     EmptySchema,
     BaseValidatorSchema,
-    CLASS_FIELD_MAP,
+    ALLOWED_TYPES,
     FIELD_MAP,
     VALIDATOR_MAP,
     get_type,
     get_param_schema,
     register_custom_type,
+    PartialField,
 )
 from paramtools.select import select, select_eq, select_gt, select_gt_ix
 from paramtools.typing import ValueObject
@@ -51,6 +53,7 @@ __all__ = [
     "InconsistentLabelsException",
     "collision_list",
     "ParameterNameCollisionException",
+    "UnknownTypeException",
     "Parameters",
     "RangeSchema",
     "ChoiceSchema",
@@ -58,12 +61,13 @@ __all__ = [
     "BaseParamSchema",
     "EmptySchema",
     "BaseValidatorSchema",
-    "CLASS_FIELD_MAP",
+    "ALLOWED_TYPES",
     "FIELD_MAP",
     "VALIDATOR_MAP",
     "get_type",
     "get_param_schema",
     "register_custom_type",
+    "PartialField",
     "select",
     "select_eq",
     "select_gt",

--- a/paramtools/__init__.py
+++ b/paramtools/__init__.py
@@ -21,6 +21,7 @@ from paramtools.schema import (
     VALIDATOR_MAP,
     get_type,
     get_param_schema,
+    register_custom_type,
 )
 from paramtools.select import select, select_eq, select_gt, select_gt_ix
 from paramtools.typing import ValueObject
@@ -62,6 +63,7 @@ __all__ = [
     "VALIDATOR_MAP",
     "get_type",
     "get_param_schema",
+    "register_custom_type",
     "select",
     "select_eq",
     "select_gt",

--- a/paramtools/exceptions.py
+++ b/paramtools/exceptions.py
@@ -16,6 +16,10 @@ class SparseValueObjectsException(ParamToolsError):
     pass
 
 
+class UnknownTypeException(ParamToolsError):
+    pass
+
+
 class ValidationError(ParamToolsError):
     def __init__(self, messages, labels):
         self.messages = messages
@@ -61,7 +65,6 @@ collision_list = [
     "label_validators",
     "errors",
     "warnings",
-    "field_map",
     "from_array",
     "read_params",
     "set_state",

--- a/paramtools/parameters.py
+++ b/paramtools/parameters.py
@@ -28,7 +28,6 @@ from paramtools.exceptions import (
 
 class Parameters:
     defaults = None
-    field_map: Dict = {}
     array_first: bool = False
     label_to_extend: str = None
     uses_extend_func: bool = False
@@ -42,7 +41,7 @@ class Parameters:
         uses_extend_func: bool = False,
         index_rates: Optional[dict] = None,
     ):
-        schemafactory = SchemaFactory(self.defaults, self.field_map)
+        schemafactory = SchemaFactory(self.defaults)
         (
             self._defaults_schema,
             self._validator_schema,
@@ -50,9 +49,12 @@ class Parameters:
             self._data,
         ) = schemafactory.schemas()
         self.label_validators = schemafactory.label_validators
-        self._stateless_label_grid = OrderedDict(
-            [(name, v.grid()) for name, v in self.label_validators.items()]
-        )
+        self._stateless_label_grid = OrderedDict()
+        for name, v in self.label_validators.items():
+            if hasattr(v, "grid"):
+                self._stateless_label_grid[name] = v.grid()
+            else:
+                self._stateless_label_grid[name] = []
         self.label_grid = copy.deepcopy(self._stateless_label_grid)
         self._validator_schema.context["spec"] = self
         self._warnings = {}

--- a/paramtools/schema.py
+++ b/paramtools/schema.py
@@ -8,16 +8,12 @@ from marshmallow import (
     ValidationError as MarshmallowValidationError,
 )
 
+from paramtools.exceptions import UnknownTypeException, ParamToolsError
 from paramtools import contrib
 from paramtools import utils
 
 
 ALLOWED_TYPES = ["str", "float", "int", "bool", "date"]
-
-
-def register_custom_type(name: str, field: fields.Field):
-    ALLOWED_TYPES.append(name)
-    FIELD_MAP.update({name: field})
 
 
 class RangeSchema(Schema):
@@ -524,36 +520,72 @@ def make_schema(allowed_types):
     return ParamToolsSchema
 
 
+def is_field_class_like(field):
+    if isinstance(field, type) and issubclass(field, fields.FieldABC):
+        return True
+    elif isinstance(field, PartialField):
+        return True
+    else:
+        return False
+
+
+def is_field_instance_like(field):
+    if not isinstance(field, type) and isinstance(field, fields.Field):
+        return True
+    else:
+        return False
+
+
+def register_custom_type(name: str, field: fields.Field):
+    if isinstance(field, type):
+        raise TypeError(
+            f"Custom fields must be instances. {field} is a class."
+        )
+    elif not isinstance(field, PartialField) and not is_field_instance_like(
+        field
+    ):
+        raise TypeError(
+            "Custom fields must either be instances of PartialField or a marshmallow field."
+        )
+    ALLOWED_TYPES.append(name)
+    FIELD_MAP.update({name: field})
+
+
 ParamToolsSchema = make_schema(allowed_types=ALLOWED_TYPES)
-
-
-# A few fields that have not been instantiated yet
-CLASS_FIELD_MAP = {
-    "str": contrib.fields.Str,
-    "int": contrib.fields.Integer,
-    "float": contrib.fields.Float,
-    "bool": contrib.fields.Boolean,
-    "date": contrib.fields.Date,
-}
 
 
 INVALID_NUMBER = {"invalid": "Not a valid number: {input}."}
 INVALID_BOOLEAN = {"invalid": "Not a valid boolean: {input}."}
 INVALID_DATE = {"invalid": "Not a valid date: {input}."}
 
+
+class PartialField:
+    def __init__(self, field, default_kwargs):
+        self.field = field
+        self.default_kwargs = default_kwargs
+
+    def __call__(self, **kwargs):
+        return self.field(**dict(self.default_kwargs, **kwargs))
+
+
 # A few fields that have been instantiated
 FIELD_MAP = {
-    "str": contrib.fields.Str(allow_none=True),
-    "int": contrib.fields.Integer(
-        allow_none=True, error_messages=INVALID_NUMBER
+    "str": PartialField(contrib.fields.Str, dict(allow_none=True)),
+    "int": PartialField(
+        contrib.fields.Integer,
+        dict(allow_none=True, error_messages=INVALID_NUMBER),
     ),
-    "float": contrib.fields.Float(
-        allow_none=True, error_messages=INVALID_NUMBER
+    "float": PartialField(
+        contrib.fields.Float,
+        dict(allow_none=True, error_messages=INVALID_NUMBER),
     ),
-    "bool": contrib.fields.Boolean(
-        allow_none=True, error_messages=INVALID_BOOLEAN
+    "bool": PartialField(
+        contrib.fields.Boolean,
+        dict(allow_none=True, error_messages=INVALID_BOOLEAN),
     ),
-    "date": contrib.fields.Date(allow_none=True, error_messages=INVALID_DATE),
+    "date": PartialField(
+        contrib.fields.Date, dict(allow_none=True, error_messages=INVALID_DATE)
+    ),
 }
 
 VALIDATOR_MAP = {
@@ -576,7 +608,18 @@ def get_type(data):
         ),
     }
     types = dict(FIELD_MAP, **numeric_types)
-    fieldtype = types[data["type"]]
+    try:
+        _fieldtype = types[data["type"]]
+        if is_field_class_like(_fieldtype):
+            fieldtype = _fieldtype()
+        elif is_field_instance_like(_fieldtype):
+            fieldtype = _fieldtype
+        else:
+            raise TypeError("Field is invalid.")
+    except KeyError:
+        raise UnknownTypeException(
+            f"Received unknown type: {data['type']}. Expected one of {', '.join(ALLOWED_TYPES)}."
+        )
     dim = data.get("number_dims", 0)
     while dim > 0:
         np_type = getattr(fieldtype, "np_type", object)
@@ -586,20 +629,29 @@ def get_type(data):
     return fieldtype
 
 
-def get_param_schema(base_spec, field_map=None):
+def get_param_schema(base_spec):
     """
     Read in data from the initializing schema. This will be used to fill in the
     optional properties on classes derived from the `BaseParamSchema` class.
     This data is also used to build validators for schema for each parameter
     that will be set on the `BaseValidatorSchema` class
     """
-    if field_map is not None:
-        field_map = dict(FIELD_MAP, **field_map)
-    else:
-        field_map = FIELD_MAP.copy()
+    field_map = FIELD_MAP
     optional_fields = {}
     for k, v in base_spec["additional_members"].items():
-        fieldtype = field_map[v["type"]]
+        try:
+            # in the future, we may want to allow validators.
+            _fieldtype = field_map[v["type"]]
+            if is_field_class_like(_fieldtype):
+                fieldtype = _fieldtype()
+            elif is_field_instance_like(_fieldtype):
+                fieldtype = _fieldtype
+            else:
+                raise TypeError("Field is invalid.")
+        except KeyError:
+            raise UnknownTypeException(
+                f"Received unknown type: {v['type']}. Expected one of {', '.join(ALLOWED_TYPES)}."
+            )
         if v.get("number_dims", 0) > 0:
             d = v["number_dims"]
             while d > 0:
@@ -615,9 +667,30 @@ def get_param_schema(base_spec, field_map=None):
     label_validators = {}
     for name, label in base_spec["labels"].items():
         validators = []
-        for vname, kwargs in label["validators"].items():
+        for vname, kwargs in label.get("validators", {}).items():
             validator_class = VALIDATOR_MAP[vname]
             validators.append(validator_class(**kwargs))
-        fieldtype = CLASS_FIELD_MAP[label["type"]]
-        label_validators[name] = fieldtype(validate=validators)
+        try:
+            _fieldtype = field_map[label["type"]]
+            if is_field_class_like(_fieldtype):
+                fieldtype = _fieldtype(validate=validators)
+            elif validators:
+                raise ParamToolsError(
+                    "If a field is already initialized, then it cannot define "
+                    "its validators via JSON configuration. You should use "
+                    "PartialField if you want to define validators via JSON."
+                )
+            elif is_field_instance_like(_fieldtype):
+                fieldtype = _fieldtype
+            else:
+                raise TypeError("Field is invalid.")
+
+            label_validators[name] = fieldtype
+
+        except KeyError:
+            raise UnknownTypeException(
+                f"Received unknown type: {label['type']}. Expected one of "
+                f"{', '.join(ALLOWED_TYPES)}."
+            )
+
     return ParamSchema, label_validators

--- a/paramtools/schema.py
+++ b/paramtools/schema.py
@@ -15,6 +15,11 @@ from paramtools import utils
 ALLOWED_TYPES = ["str", "float", "int", "bool", "date"]
 
 
+def register_custom_type(name: str, field: fields.Field):
+    ALLOWED_TYPES.append(name)
+    FIELD_MAP.update({name: field})
+
+
 class RangeSchema(Schema):
     """
     Schema for range object

--- a/paramtools/schema.py
+++ b/paramtools/schema.py
@@ -560,9 +560,9 @@ INVALID_DATE = {"invalid": "Not a valid date: {input}."}
 
 
 class PartialField:
-    def __init__(self, field, default_kwargs):
+    def __init__(self, field, default_kwargs=None):
         self.field = field
-        self.default_kwargs = default_kwargs
+        self.default_kwargs = default_kwargs or {}
 
     def __call__(self, **kwargs):
         return self.field(**dict(self.default_kwargs, **kwargs))

--- a/paramtools/schema_factory.py
+++ b/paramtools/schema_factory.py
@@ -7,8 +7,7 @@ from paramtools.schema import (
     ValueObject,
     get_type,
     get_param_schema,
-    make_schema,
-    ALLOWED_TYPES,
+    ParamToolsSchema,
 )
 from paramtools import utils
 
@@ -27,17 +26,12 @@ class SchemaFactory:
     deserialize and validate parameter data.
     """
 
-    def __init__(self, defaults, field_map=None):
+    def __init__(self, defaults):
         defaults = utils.read_json(defaults)
         self.defaults = {k: v for k, v in defaults.items() if k != "schema"}
-        # Make shallow copy to prevent modifications to the original.
-        allowed_types = list(ALLOWED_TYPES)
-        if field_map:
-            allowed_types += field_map.keys()
-        ParamToolsSchema = make_schema(allowed_types)
         self.schema = ParamToolsSchema().load(defaults.get("schema", {}))
         (self.BaseParamSchema, self.label_validators) = get_param_schema(
-            self.schema, field_map=field_map
+            self.schema
         )
 
     def schemas(self):

--- a/paramtools/tests/test_examples/test_tc_ex.py
+++ b/paramtools/tests/test_examples/test_tc_ex.py
@@ -4,7 +4,7 @@ import pytest
 
 from marshmallow import fields, Schema
 
-from paramtools import Parameters
+from paramtools import Parameters, register_custom_type
 
 
 CURRENT_PATH = os.path.abspath(os.path.dirname(__file__))
@@ -23,8 +23,10 @@ class CompatibleDataSchema(Schema):
 
 
 @pytest.fixture
-def field_map():
-    return {"compatible_data": fields.Nested(CompatibleDataSchema())}
+def register_compatible_data():
+    register_custom_type(
+        "compatible_data", fields.Nested(CompatibleDataSchema())
+    )
 
 
 @pytest.fixture
@@ -33,10 +35,9 @@ def defaults_spec_path():
 
 
 @pytest.fixture
-def TaxcalcParams(defaults_spec_path, field_map):
+def TaxcalcParams(defaults_spec_path, register_compatible_data):
     class _TaxcalcParams(Parameters):
         defaults = defaults_spec_path
-        field_map = {"compatible_data": fields.Nested(CompatibleDataSchema())}
 
     return _TaxcalcParams
 

--- a/paramtools/tests/test_parameters.py
+++ b/paramtools/tests/test_parameters.py
@@ -16,9 +16,9 @@ from paramtools import (
     InconsistentLabelsException,
     collision_list,
     ParameterNameCollisionException,
+    register_custom_type,
+    Parameters,
 )
-
-from paramtools import Parameters
 
 CURRENT_PATH = os.path.abspath(os.path.dirname(__file__))
 
@@ -247,17 +247,19 @@ class TestSchema:
             hello = ma.fields.Boolean()
             world = ma.fields.Boolean()
 
+        register_custom_type("custom_type", ma.fields.Nested(Custom()))
+
         class Params(Parameters):
-            field_map = {"custom_type": ma.fields.Nested(Custom)}
             defaults = {
                 "schema": {
-                    "additional_members": {"custom": {"type": "custom_type"}}
+                    "labels": {"custom_label": {"type": "custom_type"}},
+                    "additional_members": {"custom": {"type": "custom_type"}},
                 },
                 "param": {
                     "title": "",
                     "description": "",
                     "type": "int",
-                    "value": 0,
+                    "value": [{"custom_label": {"hello": True}, "value": 0}],
                     "custom": {"hello": True, "world": True},
                 },
             }

--- a/paramtools/tests/test_schema.py
+++ b/paramtools/tests/test_schema.py
@@ -1,4 +1,17 @@
-from paramtools import get_type
+import copy
+
+import pytest
+import marshmallow as ma
+
+from paramtools import (
+    get_type,
+    get_param_schema,
+    register_custom_type,
+    ALLOWED_TYPES,
+    UnknownTypeException,
+    PartialField,
+    ParamToolsError,
+)
 
 
 def test_get_type_with_list():
@@ -9,3 +22,70 @@ def test_get_type_with_list():
 
     list_int_field = get_type({"type": "int", "number_dims": 2})
     assert list_int_field.np_type == int_field.np_type
+
+
+def test_register_custom_type():
+    """
+    Test allowed to register marshmallow field and PartialField instances and
+    test that uninitialized fields and random classes throw type errors.
+    """
+    custom_type = "custom"
+    assert custom_type not in ALLOWED_TYPES
+    register_custom_type(custom_type, ma.fields.String())
+    assert custom_type in ALLOWED_TYPES
+
+    register_custom_type("partial-test", PartialField(ma.fields.Str(), {}))
+    assert "partial-test" in ALLOWED_TYPES
+
+    with pytest.raises(TypeError):
+        register_custom_type("custom", ma.fields.Str)
+
+    class Whatever:
+        pass
+
+    with pytest.raises(TypeError):
+        register_custom_type("whatever", Whatever())
+
+
+def test_get_type():
+    custom_type = "custom"
+    register_custom_type(custom_type, ma.fields.String())
+
+    assert isinstance(get_type({"type": custom_type}), ma.fields.String)
+
+    with pytest.raises(UnknownTypeException):
+        get_type({"type": "unknown"})
+
+
+def test_make_schema():
+    custom_type = "custom"
+    register_custom_type(custom_type, ma.fields.String())
+
+    schema = {
+        "labels": {"lab": {"type": custom_type, "validators": {}}},
+        "additional_members": {"custom": {"type": custom_type}},
+    }
+
+    assert get_param_schema(schema)
+
+    bad_schema = copy.deepcopy(schema)
+    bad_schema["labels"]["lab"]["type"] = "unknown"
+    with pytest.raises(UnknownTypeException):
+        get_param_schema(bad_schema)
+
+    bad_schema = copy.deepcopy(schema)
+    bad_schema["additional_members"]["custom"]["type"] = "unknown"
+    with pytest.raises(UnknownTypeException):
+        get_param_schema(bad_schema)
+
+    schema = {
+        "labels": {
+            "lab": {
+                "type": custom_type,
+                "validators": {"choice": {"choices": ["hello"]}},
+            }
+        },
+        "additional_members": {"custom": {"type": custom_type}},
+    }
+    with pytest.raises(ParamToolsError):
+        get_param_schema(schema)


### PR DESCRIPTION
Prompted by the issue that @jdebacker opened, this PR adds the ability to register custom fields like this:

```python
import paramtools as pt
import marshmallow as ma

class DepreciationRules(ma.Schema):
    life = ma.fields.Integer(validate=ma.validate.Range(min=0))
    method = ma.fields.String(
        validate=ma.validate.OneOf(choices=["SL", "Expensing"])
    )

pt.register_custom_type("depreciation_rules", ma.fields.Nested(DepreciationRules()))

class AssetsParams(pt.Parameters):
    defaults = "assets.json"
```

Using this code, we can load defaults that look like this:

```json
{
    "asset": {
        "title": "CCC Assets",
        "description": "assets param",
        "type": "depreciation_rules",
        "value": [
            {
                "value": {
                    "life": 5,
                    "method": "SL"
                }
            },
            {
                "value": {
                    "life": 5,
                    "method": "SL"
                }
            }
        ]
    }
}
```