### PR TITLE
Add api-reference, update docs theme and style

### DIFF
--- a/docs/docs/CNAME
+++ b/docs/docs/CNAME
@@ -1,1 +1,1 @@
-paramtools.org
+paramtools.dev

--- a/docs/docs/api/reference.md
+++ b/docs/docs/api/reference.md
@@ -1,0 +1,5 @@
+# API documentation
+
+::: paramtools.Parameters
+    :docstring:
+    :members:

--- a/docs/docs/css/custom.css
+++ b/docs/docs/css/custom.css
@@ -1,0 +1,29 @@
+div.autodoc-docstring {
+  padding-left: 20px;
+  margin-bottom: 30px;
+  border-left: 5px solid rgba(230, 230, 230);
+}
+
+div.autodoc-members {
+  padding-left: 20px;
+  margin-bottom: 15px;
+}
+
+header.md-header, div.md-footer-nav, div.md-footer-meta.md-typeset {
+  background-color: #13274F;
+}
+
+a, a:hover {
+  color: #13274F !important;
+  text-decoration-line: underline;
+}
+
+.md-nav__link--active, .md-nav__link:active, .md-nav__item--nested > .md-nav__link {
+  color: #13274F;
+}
+
+.md-footer-meta.md-typeset a, .md-flex__ellipsis, i.md-icon {
+
+  color: hsla(0,0%,100%,.7) !important;
+
+}

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -7,5 +7,18 @@ nav:
         - Extend: 'api/extend.md'
         - Extend with Indexing: 'api/indexing.md'
         - Custom Adjustments: 'api/custom-adjust.md'
-
-theme: mkdocs
+        - Custom Type: 'api/custom-types.md'
+        - Reference: 'api/reference.md'
+markdown_extensions:
+  - admonition
+  - codehilite
+  - mkautodoc
+extra_css:
+    - css/custom.css
+theme:
+    name: 'material'
+    highlightjs: true
+    hljs_languages:
+        - python
+        - json
+        - bash


### PR DESCRIPTION
The PT docs have needed a little TLC for a bit now. This PR adds:
- API reference docs using [`mkautodoc`](https://github.com/tomchristie/mkautodoc)
- New theme using [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/)
- Updates to the CSS to use Atlanta Braves blue
- New domain at https://paramtools.dev