### PR TITLE
Update int field so that floats are invalid

### DIFF
--- a/paramtools/contrib/fields.py
+++ b/paramtools/contrib/fields.py
@@ -19,7 +19,7 @@ class Float64(NumPySerializeMixin, marshmallow_fields.Number):
     num_type = np_type = np.float64
 
 
-class Int64(NumPySerializeMixin, marshmallow_fields.Number):
+class Int64(NumPySerializeMixin, marshmallow_fields.Integer):
     """
     Implements "int" :ref:`spec:Type property` for parameter values.
     Defined as `numpy.int64 <https://docs.scipy.org/doc/numpy-1.15.0/user/basics.types.html>`__ type

--- a/paramtools/schema.py
+++ b/paramtools/schema.py
@@ -562,6 +562,7 @@ ParamToolsSchema = make_schema(allowed_types=ALLOWED_TYPES)
 
 
 INVALID_NUMBER = {"invalid": "Not a valid number: {input}."}
+INVALID_INTEGER = {"invalid": "Not a valid integer: {input}."}
 INVALID_BOOLEAN = {"invalid": "Not a valid boolean: {input}."}
 INVALID_DATE = {"invalid": "Not a valid date: {input}."}
 
@@ -580,7 +581,7 @@ FIELD_MAP = {
     "str": PartialField(contrib.fields.Str, dict(allow_none=True)),
     "int": PartialField(
         contrib.fields.Integer,
-        dict(allow_none=True, error_messages=INVALID_NUMBER),
+        dict(allow_none=True, error_messages=INVALID_INTEGER),
     ),
     "float": PartialField(
         contrib.fields.Float,
@@ -605,7 +606,7 @@ VALIDATOR_MAP = {
 def get_type(data):
     numeric_types = {
         "int": contrib.fields.Int64(
-            allow_none=True, error_messages=INVALID_NUMBER
+            allow_none=True, error_messages=INVALID_INTEGER, strict=True
         ),
         "bool": contrib.fields.Bool_(
             allow_none=True, error_messages=INVALID_BOOLEAN

--- a/paramtools/tests/test_parameters.py
+++ b/paramtools/tests/test_parameters.py
@@ -715,13 +715,13 @@ class TestValidationMessages:
         with pytest.raises(ValidationError) as excinfo:
             params.adjust(adj)
 
-        exp_user_message = {"min_int_param": ["Not a valid number: abc."]}
+        exp_user_message = {"min_int_param": ["Not a valid integer: abc."]}
         assert json.loads(excinfo.value.args[0]) == {
             "errors": exp_user_message
         }
 
         exp_internal_message = {
-            "min_int_param": [["Not a valid number: abc."]]
+            "min_int_param": [["Not a valid integer: abc."]]
         }
         assert excinfo.value.messages["errors"] == exp_internal_message
 
@@ -789,13 +789,11 @@ class TestValidationMessages:
     def test_errors_int_param(self, TestParams):
         params = TestParams()
         adjustment = {
-            "min_int_param": [
-                {"label0": "zero", "label1": 1, "value": "not a number"}
-            ]
+            "min_int_param": [{"label0": "zero", "label1": 1, "value": 2.5}]
         }
 
         params.adjust(adjustment, raise_errors=False)
-        exp = {"min_int_param": ["Not a valid number: not a number."]}
+        exp = {"min_int_param": ["Not a valid integer: 2.5."]}
         assert params.errors == exp
 
     def test_errors_multiple_params(self, TestParams):
@@ -813,8 +811,8 @@ class TestValidationMessages:
         params.adjust(adjustment, raise_errors=False)
         exp = {
             "min_int_param": [
-                "Not a valid number: not a number.",
-                "Not a valid number: still not a number.",
+                "Not a valid integer: not a number.",
+                "Not a valid integer: still not a number.",
             ],
             "date_param": ["Not a valid date: not a date."],
         }


### PR DESCRIPTION
This PR makes it so that floats are not casted to integers. For example, if a parameter's value indicates an age cut-off, then a user attempting to set the value to a float is probably confused about the meaning of the parameter. So, raising an error here could be helpful for the user.

cc @Peter-Metz 