### PR TITLE
Fix bug where errors weren't raised on non-list params

### DIFF
--- a/paramtools/contrib/fields.py
+++ b/paramtools/contrib/fields.py
@@ -8,6 +8,12 @@ class NumPySerializeMixin:
     def _serialize(self, value, attr, obj, **kwargs):
         return value.tolist()
 
+    def _validated(self, value):
+        value = super()._validated(value)
+        if value.shape != tuple():
+            raise self.make_error("invalid", input=value)
+        return value
+
 
 class Float64(NumPySerializeMixin, marshmallow_fields.Number):
     """

--- a/paramtools/tests/defaults.json
+++ b/paramtools/tests/defaults.json
@@ -99,6 +99,22 @@
       }
     }
   },
+  "float_param": {
+    "title": "Float Reference Param",
+    "description": "Example for a float param.",
+    "opt0": "an option",
+    "type": "float",
+    "value": 2.0,
+    "validators": {}
+  },
+  "bool_param": {
+    "title": "Boolean Reference Param",
+    "description": "Example for a bool param.",
+    "opt0": "an option",
+    "type": "bool",
+    "value": true,
+    "validators": {}
+  },
   "min_int_param": {
     "title": "min integer parameter",
     "description": "Serves as minimum reference variable.",

--- a/paramtools/tests/test_parameters.py
+++ b/paramtools/tests/test_parameters.py
@@ -856,6 +856,20 @@ class TestValidationMessages:
         }
         assert excinfo.value.labels["errors"] == exp_labels
 
+        params = TestParams()
+        adjustment = {"float_param": [2.5]}
+
+        params.adjust(adjustment, raise_errors=False)
+        exp = {"float_param": ["Not a valid number: [2.5]."]}
+        assert params.errors == exp
+
+        params = TestParams()
+        adjustment = {"bool_param": [False]}
+
+        params.adjust(adjustment, raise_errors=False)
+        exp = {"bool_param": ["Not a valid boolean: [False]."]}
+        assert params.errors == exp
+
     def test_range_validation_on_list_param(self, TestParams):
         params = TestParams()
         adj = {


### PR DESCRIPTION
Resolves bug found by @Peter-Metz: https://github.com/PSLmodels/Tax-Calculator/pull/2401#discussion_r409622984