### PR TITLE
Add internal attribute on all extend values

### DIFF
--- a/docs/Extend example.ipynb
+++ b/docs/Extend example.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -25,7 +25,7 @@
        "       [ 7685., 15369.]])"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -72,7 +72,6 @@
     "    array_first = True\n",
     "\n",
     "params = TaxParams()\n",
-    "\n",
     "params.standard_deduction"
    ]
   },
@@ -122,6 +121,302 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[ 6350., 12700.],\n",
+       "       [ 6350., 12700.],\n",
+       "       [ 6350., 12700.],\n",
+       "       [ 6350., 12700.],\n",
+       "       [10000., 10000.],\n",
+       "       [12000., 24000.],\n",
+       "       [12000., 24000.],\n",
+       "       [15000., 24000.],\n",
+       "       [15000., 20000.],\n",
+       "       [15000., 20000.],\n",
+       "       [15000., 20000.],\n",
+       "       [15000., 20000.],\n",
+       "       [15000., 20000.],\n",
+       "       [ 7685., 15369.],\n",
+       "       [ 7685., 15369.]])"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "params = TaxParams()\n",
+    "params.adjust(\n",
+    "    {\n",
+    "        \"standard_deduction\": [\n",
+    "            {\"year\": 2017, \"value\": 10000},\n",
+    "            {\"year\": 2020, \"marital_status\": \"single\", \"value\": 15000},\n",
+    "            {\"year\": 2021, \"marital_status\": \"joint\", \"value\": 20000}\n",
+    "        ]\n",
+    "    },\n",
+    "    clobber=False,\n",
+    ")\n",
+    "\n",
+    "params.standard_deduction"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[ 6074.92, 12149.84],\n",
+       "       [ 6164.83, 12329.66],\n",
+       "       [ 6262.85, 12525.7 ],\n",
+       "       [ 6270.37, 12540.73],\n",
+       "       [ 6350.  , 12700.  ],\n",
+       "       [12000.  , 24000.  ],\n",
+       "       [12268.8 , 24537.6 ],\n",
+       "       [12497.  , 24994.  ],\n",
+       "       [12788.18, 25576.36],\n",
+       "       [13081.03, 26162.06],\n",
+       "       [13379.28, 26758.55],\n",
+       "       [13674.96, 27349.91],\n",
+       "       [13963.5 , 27926.99],\n",
+       "       [ 7685.  , 15369.  ],\n",
+       "       [ 7847.15, 15693.29]])"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import paramtools\n",
+    "\n",
+    "\n",
+    "class TaxParams(paramtools.Parameters):\n",
+    "    defaults = {\n",
+    "        \"schema\": {\n",
+    "            \"labels\": {\n",
+    "                \"year\": {\n",
+    "                    \"type\": \"int\",\n",
+    "                    \"validators\": {\"range\": {\"min\": 2013, \"max\": 2027}}\n",
+    "                },\n",
+    "                \"marital_status\": {\n",
+    "                    \"type\": \"str\",\n",
+    "                    \"validators\": {\"choice\": {\"choices\": [\"single\", \"joint\"]}}\n",
+    "                },\n",
+    "            }\n",
+    "        },\n",
+    "        \"standard_deduction\": {\n",
+    "            \"title\": \"Standard deduction amount\",\n",
+    "            \"description\": \"Amount filing unit can use as a standard deduction.\",\n",
+    "            \"type\": \"float\",\n",
+    "\n",
+    "            # Set indexed to True to extend standard_deduction with the built-in\n",
+    "            # extension logic.\n",
+    "            \"indexed\": True,\n",
+    "\n",
+    "            \"value\": [\n",
+    "                {\"year\": 2017, \"marital_status\": \"single\", \"value\": 6350},\n",
+    "                {\"year\": 2017, \"marital_status\": \"joint\", \"value\": 12700},\n",
+    "                {\"year\": 2018, \"marital_status\": \"single\", \"value\": 12000},\n",
+    "                {\"year\": 2018, \"marital_status\": \"joint\", \"value\": 24000},\n",
+    "                {\"year\": 2026, \"marital_status\": \"single\", \"value\": 7685},\n",
+    "                {\"year\": 2026, \"marital_status\": \"joint\", \"value\": 15369}],\n",
+    "            \"validators\": {\n",
+    "                \"range\": {\n",
+    "                    \"min\": 0,\n",
+    "                    \"max\": 9e+99\n",
+    "                }\n",
+    "            }\n",
+    "        },\n",
+    "    }\n",
+    "    array_first = True\n",
+    "    label_to_extend = \"year\"\n",
+    "    # Activate use of extend_func method.\n",
+    "    uses_extend_func = True\n",
+    "    # inflation rates from Tax-Calculator v2.5.0\n",
+    "    index_rates = {\n",
+    "        2013: 0.0148,\n",
+    "        2014: 0.0159,\n",
+    "        2015: 0.0012,\n",
+    "        2016: 0.0127,\n",
+    "        2017: 0.0187,\n",
+    "        2018: 0.0224,\n",
+    "        2019: 0.0186,\n",
+    "        2020: 0.0233,\n",
+    "        2021: 0.0229,\n",
+    "        2022: 0.0228,\n",
+    "        2023: 0.0221,\n",
+    "        2024: 0.0211,\n",
+    "        2025: 0.0209,\n",
+    "        2026: 0.0211,\n",
+    "        2027: 0.0208,\n",
+    "        2028: 0.021,\n",
+    "        2029: 0.021\n",
+    "    }\n",
+    "\n",
+    "\n",
+    "params = TaxParams()\n",
+    "params.standard_deduction"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[ 6074.92, 12149.84],\n",
+       "       [ 6164.83, 12329.66],\n",
+       "       [ 6262.85, 12525.7 ],\n",
+       "       [ 6270.37, 12540.73],\n",
+       "       [10000.  , 10000.  ],\n",
+       "       [10187.  , 10187.  ],\n",
+       "       [10415.19, 10415.19],\n",
+       "       [15000.  , 10608.91],\n",
+       "       [15349.5 , 20000.  ],\n",
+       "       [15701.  , 20458.  ],\n",
+       "       [16058.98, 20924.44],\n",
+       "       [16413.88, 21386.87],\n",
+       "       [16760.21, 21838.13],\n",
+       "       [17110.5 , 22294.55],\n",
+       "       [17471.53, 22764.97]])"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "params.adjust(\n",
+    "    {\n",
+    "        \"standard_deduction\": [\n",
+    "            {\"year\": 2017, \"value\": 10000},\n",
+    "            {\"year\": 2020, \"marital_status\": \"single\", \"value\": 15000},\n",
+    "            {\"year\": 2021, \"marital_status\": \"joint\", \"value\": 20000}\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "params.standard_deduction"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[ 5783.57, 11567.15],\n",
+       "       [ 5941.46, 11882.93],\n",
+       "       [ 6110.2 , 12220.41],\n",
+       "       [ 6193.91, 12387.83],\n",
+       "       [ 6350.  , 12700.  ],\n",
+       "       [12000.  , 24000.  ],\n",
+       "       [12418.8 , 24837.6 ],\n",
+       "       [12805.02, 25610.05],\n",
+       "       [13263.44, 26526.89],\n",
+       "       [13732.97, 27465.94],\n",
+       "       [14217.74, 28435.49],\n",
+       "       [14709.67, 29419.36],\n",
+       "       [15203.91, 30407.85],\n",
+       "       [ 7685.  , 15369.  ],\n",
+       "       [ 7943.22, 15885.4 ]])"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "params = TaxParams()\n",
+    "\n",
+    "offset = 0.0025\n",
+    "for year, rate in params.index_rates.items():\n",
+    "    params.index_rates[year] = rate + offset\n",
+    "\n",
+    "automatically_added = params.select_eq(\n",
+    "    \"standard_deduction\", strict=True, _auto=True\n",
+    ")\n",
+    "\n",
+    "params.delete(\n",
+    "    {\n",
+    "        \"standard_deduction\": automatically_added\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "params.standard_deduction"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[{'_auto': True, 'marital_status': 'single', 'year': 2013, 'value': 5840.42},\n",
+       " {'_auto': True, 'marital_status': 'single', 'year': 2014, 'value': 5985.26},\n",
+       " {'_auto': True, 'marital_status': 'single', 'year': 2015, 'value': 6140.28},\n",
+       " {'_auto': True, 'marital_status': 'single', 'year': 2016, 'value': 6209.05},\n",
+       " {'_auto': True, 'marital_status': 'single', 'year': 2019, 'value': 12388.8},\n",
+       " {'_auto': True, 'marital_status': 'single', 'year': 2020, 'value': 12743.12},\n",
+       " {'_auto': True, 'marital_status': 'single', 'year': 2021, 'value': 13167.47},\n",
+       " {'_auto': True, 'marital_status': 'single', 'year': 2022, 'value': 13600.68},\n",
+       " {'_auto': True, 'marital_status': 'single', 'year': 2023, 'value': 14046.78},\n",
+       " {'_auto': True, 'marital_status': 'single', 'year': 2024, 'value': 14497.68},\n",
+       " {'_auto': True, 'marital_status': 'single', 'year': 2025, 'value': 14948.56},\n",
+       " {'_auto': True, 'marital_status': 'single', 'year': 2027, 'value': 7924.0},\n",
+       " {'_auto': True, 'marital_status': 'joint', 'year': 2013, 'value': 11680.85},\n",
+       " {'_auto': True, 'marital_status': 'joint', 'year': 2014, 'value': 11970.54},\n",
+       " {'_auto': True, 'marital_status': 'joint', 'year': 2015, 'value': 12280.58},\n",
+       " {'_auto': True, 'marital_status': 'joint', 'year': 2016, 'value': 12418.12},\n",
+       " {'_auto': True, 'marital_status': 'joint', 'year': 2019, 'value': 24777.6},\n",
+       " {'_auto': True, 'marital_status': 'joint', 'year': 2020, 'value': 25486.24},\n",
+       " {'_auto': True, 'marital_status': 'joint', 'year': 2021, 'value': 26334.93},\n",
+       " {'_auto': True, 'marital_status': 'joint', 'year': 2022, 'value': 27201.35},\n",
+       " {'_auto': True, 'marital_status': 'joint', 'year': 2023, 'value': 28093.55},\n",
+       " {'_auto': True, 'marital_status': 'joint', 'year': 2024, 'value': 28995.35},\n",
+       " {'_auto': True, 'marital_status': 'joint', 'year': 2025, 'value': 29897.11},\n",
+       " {'_auto': True, 'marital_status': 'joint', 'year': 2027, 'value': 15846.98}]"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "params = TaxParams()\n",
+    "\n",
+    "params.select_eq(\n",
+    "    \"standard_deduction\", strict=True, _auto=True\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
@@ -144,7 +439,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.8.0"
   }
  },
  "nbformat": 4,

--- a/docs/docs/api/extend.md
+++ b/docs/docs/api/extend.md
@@ -104,6 +104,41 @@ params.standard_deduction
 
 ```
 
+### Clobber
+
+In the previous example, the new values _clobber_ the existing values in years after they are specified. By setting `clobber` to `False`, only values that were added automatically will be replaced by the new ones. User defined values such as those in 2026 will not be over-written by the new values:
+
+```python
+params = TaxParams()
+params.adjust(
+    {
+        "standard_deduction": [
+            {"year": 2017, "value": 10000},
+            {"year": 2020, "marital_status": "single", "value": 15000},
+            {"year": 2021, "marital_status": "joint", "value": 20000}
+        ]
+    },
+    clobber=False,
+)
+
+params.standard_deduction
+
+# array([[ 6350., 12700.],
+#        [ 6350., 12700.],
+#        [ 6350., 12700.],
+#        [ 6350., 12700.],
+#        [10000., 10000.],
+#        [12000., 24000.],
+#        [12000., 24000.],
+#        [15000., 24000.],
+#        [15000., 20000.],
+#        [15000., 20000.],
+#        [15000., 20000.],
+#        [15000., 20000.],
+#        [15000., 20000.],
+#        [ 7685., 15369.],
+#        [ 7685., 15369.]])
+```
 
 ## Extend behavior by validator
 
@@ -117,11 +152,11 @@ Note: You can view the grid of values for any label by inspecting the `label_gri
 
 ```json
 {
-    "range": {"min": 0, "max": 5}
+  "range": { "min": 0, "max": 5 }
 }
 ```
 
-*Extend values:*
+_Extend values:_
 
 ```python
 [0, 1, 2, 3, 4, 5]
@@ -131,11 +166,11 @@ Note: You can view the grid of values for any label by inspecting the `label_gri
 
 ```json
 {
-    "range": {"min": 0, "max": 2, "step": 0.5}
+  "range": { "min": 0, "max": 2, "step": 0.5 }
 }
 ```
 
-*Extend values:*
+_Extend values:_
 
 ```python
 [0, 0.5, 1.0, 1.5, 2.0]
@@ -145,11 +180,11 @@ Note: You can view the grid of values for any label by inspecting the `label_gri
 
 ```json
 {
-    "range": {"min": "2019-01-01", "max": "2019-01-05", "step": {"days": 2}}
+  "range": { "min": "2019-01-01", "max": "2019-01-05", "step": { "days": 2 } }
 }
 ```
 
-*Extend values:*
+_Extend values:_
 
 ```python
 [datetime.date(2019, 1, 1),
@@ -163,11 +198,11 @@ Note: You can view the grid of values for any label by inspecting the `label_gri
 
 ```json
 {
-    "choice": {"choices": [-1, -2, -3]}
+  "choice": { "choices": [-1, -2, -3] }
 }
 ```
 
-*Extend values:*
+_Extend values:_
 
 ```python
 [-1, -2, -3]
@@ -177,11 +212,11 @@ Note: You can view the grid of values for any label by inspecting the `label_gri
 
 ```json
 {
-    "choice": {"choices": ["january", "february", "march"]}
+  "choice": { "choices": ["january", "february", "march"] }
 }
 ```
 
-*Extend values:*
+_Extend values:_
 
 ```python
 ["january", "february", "march"]

--- a/docs/docs/api/indexing.md
+++ b/docs/docs/api/indexing.md
@@ -6,10 +6,10 @@ The [extend documentation](/api/extend/) may be useful for gaining a better unde
 
 To use the indexing feature:
 
- - Set the `label_to_extend` class attribute to the label that should be extended
- - Set the `indexing_rates` class attribute to a dictionary of inflation rates where the keys correspond to the value of `label_to_extend` and the values are the indexing rates.
- - Set the `uses_extend_func` class attribute to `True`.
- - In `defaults` or `defaults.json`, set `indexed` to `True` for each parameter that needs to be indexed.
+- Set the `label_to_extend` class attribute to the label that should be extended
+- Set the `indexing_rates` class attribute to a dictionary of inflation rates where the keys correspond to the value of `label_to_extend` and the values are the indexing rates.
+- Set the `uses_extend_func` class attribute to `True`.
+- In `defaults` or `defaults.json`, set `indexed` to `True` for each parameter that needs to be indexed.
 
 ## Example
 
@@ -138,6 +138,80 @@ params.standard_deduction
 
 ```
 
+All values that are added automatically via the `extend` method are given an `_auto` attribute. You can select them like this:
+
+```python
+params = TaxParams()
+
+params.select_eq(
+    "standard_deduction", strict=True, _auto=True
+)
+
+# [{'_auto': True, 'marital_status': 'single', 'year': 2013, 'value': 5840.42},
+#  {'_auto': True, 'marital_status': 'single', 'year': 2014, 'value': 5985.26},
+#  {'_auto': True, 'marital_status': 'single', 'year': 2015, 'value': 6140.28},
+#  {'_auto': True, 'marital_status': 'single', 'year': 2016, 'value': 6209.05},
+#  {'_auto': True, 'marital_status': 'single', 'year': 2019, 'value': 12388.8},
+#  {'_auto': True, 'marital_status': 'single', 'year': 2020, 'value': 12743.12},
+#  {'_auto': True, 'marital_status': 'single', 'year': 2021, 'value': 13167.47},
+#  {'_auto': True, 'marital_status': 'single', 'year': 2022, 'value': 13600.68},
+#  {'_auto': True, 'marital_status': 'single', 'year': 2023, 'value': 14046.78},
+#  {'_auto': True, 'marital_status': 'single', 'year': 2024, 'value': 14497.68},
+#  {'_auto': True, 'marital_status': 'single', 'year': 2025, 'value': 14948.56},
+#  {'_auto': True, 'marital_status': 'single', 'year': 2027, 'value': 7924.0},
+#  {'_auto': True, 'marital_status': 'joint', 'year': 2013, 'value': 11680.85},
+#  {'_auto': True, 'marital_status': 'joint', 'year': 2014, 'value': 11970.54},
+#  {'_auto': True, 'marital_status': 'joint', 'year': 2015, 'value': 12280.58},
+#  {'_auto': True, 'marital_status': 'joint', 'year': 2016, 'value': 12418.12},
+#  {'_auto': True, 'marital_status': 'joint', 'year': 2019, 'value': 24777.6},
+#  {'_auto': True, 'marital_status': 'joint', 'year': 2020, 'value': 25486.24},
+#  {'_auto': True, 'marital_status': 'joint', 'year': 2021, 'value': 26334.93},
+#  {'_auto': True, 'marital_status': 'joint', 'year': 2022, 'value': 27201.35},
+#  {'_auto': True, 'marital_status': 'joint', 'year': 2023, 'value': 28093.55},
+#  {'_auto': True, 'marital_status': 'joint', 'year': 2024, 'value': 28995.35},
+#  {'_auto': True, 'marital_status': 'joint', 'year': 2025, 'value': 29897.11},
+#  {'_auto': True, 'marital_status': 'joint', 'year': 2027, 'value': 15846.98}]
+
+
+```
+
+If you want to update the index rates and apply them to your existing values, then all you need to do is remove the values that were added automatically. ParamTools will fill in the missing values using the updated index rates:
+
+```python
+params = TaxParams()
+
+offset = 0.0025
+for year, rate in params.index_rates.items():
+    params.index_rates[year] = rate + offset
+
+automatically_added = params.select_eq(
+    "standard_deduction", strict=True, _auto=True
+)
+
+params.delete(
+    {
+        "standard_deduction": automatically_added
+    }
+)
+
+params.standard_deduction
+
+# array([[ 5783.57, 11567.15],
+#        [ 5941.46, 11882.93],
+#        [ 6110.2 , 12220.41],
+#        [ 6193.91, 12387.83],
+#        [ 6350.  , 12700.  ],
+#        [12000.  , 24000.  ],
+#        [12418.8 , 24837.6 ],
+#        [12805.02, 25610.05],
+#        [13263.44, 26526.89],
+#        [13732.97, 27465.94],
+#        [14217.74, 28435.49],
+#        [14709.67, 29419.36],
+#        [15203.91, 30407.85],
+#        [ 7685.  , 15369.  ],
+#        [ 7943.22, 15885.4 ]])
+```
 
 ### Code for getting Tax-Calculator index rates
 

--- a/paramtools/__init__.py
+++ b/paramtools/__init__.py
@@ -28,6 +28,7 @@ from paramtools.schema import (
 from paramtools.select import (
     select,
     select_eq,
+    select_ne,
     select_gt,
     select_gte,
     select_gt_ix,

--- a/paramtools/__init__.py
+++ b/paramtools/__init__.py
@@ -51,7 +51,7 @@ from paramtools.utils import (
 
 
 name = "paramtools"
-__version__ = "0.13.1"
+__version__ = "0.13.1-track-extend-vals"
 
 __all__ = [
     "SchemaFactory",

--- a/paramtools/exceptions.py
+++ b/paramtools/exceptions.py
@@ -40,6 +40,7 @@ collision_list = [
     "_errors",
     "_warnings",
     "select_eq",
+    "select_ne",
     "select_gt",
     "select_gte",
     "select_lt",

--- a/paramtools/parameters.py
+++ b/paramtools/parameters.py
@@ -220,7 +220,12 @@ class Parameters:
                                 gt,
                                 True,
                                 utils.filter_labels(
-                                    vo, drop=[self.label_to_extend, "value"]
+                                    vo,
+                                    drop=[
+                                        self.label_to_extend,
+                                        "value",
+                                        "pt_extend",
+                                    ],
                                 ),
                             )
                             to_delete[param] += [
@@ -604,7 +609,9 @@ class Parameters:
                 eq = select_eq(
                     gt,
                     False,
-                    utils.filter_labels(vo, drop=["value", label_to_extend]),
+                    utils.filter_labels(
+                        vo, drop=["value", label_to_extend, "pt_extend"]
+                    ),
                 )
                 extended_vos.update(map(utils.hashable_value_object, eq))
                 eq += [vo]
@@ -655,7 +662,7 @@ class Parameters:
                             utils.hashable_value_object(value_object)
                         )
                         extended[val].append(ext)
-                        adjustment[param].append(ext)
+                        adjustment[param].append(dict(ext, pt_extend=True))
         # Ensure that the adjust method of paramtools.Parameter is used
         # in case the child class also implements adjust.
         self._adjust(

--- a/paramtools/parameters.py
+++ b/paramtools/parameters.py
@@ -225,7 +225,7 @@ class Parameters:
                                 tree = self._search_trees.get(param)
                             else:
                                 queryset = self.select_eq(
-                                    param, strict=True, pt_extend=True
+                                    param, strict=True, _auto=True
                                 )
                                 tree = None
                             gt = select_gt_ix(
@@ -243,7 +243,7 @@ class Parameters:
                                     drop=[
                                         self.label_to_extend,
                                         "value",
-                                        "pt_extend",
+                                        "_auto",
                                     ],
                                 ),
                             )
@@ -637,7 +637,7 @@ class Parameters:
                     gt,
                     False,
                     utils.filter_labels(
-                        vo, drop=["value", label_to_extend, "pt_extend"]
+                        vo, drop=["value", label_to_extend, "_auto"]
                     ),
                 )
                 extended_vos.update(map(utils.hashable_value_object, eq))
@@ -689,7 +689,7 @@ class Parameters:
                             utils.hashable_value_object(value_object)
                         )
                         extended[val].append(ext)
-                        adjustment[param].append(dict(ext, pt_extend=True))
+                        adjustment[param].append(dict(ext, _auto=True))
         # Ensure that the adjust method of paramtools.Parameter is used
         # in case the child class also implements adjust.
         self._adjust(

--- a/paramtools/schema.py
+++ b/paramtools/schema.py
@@ -440,9 +440,7 @@ class BaseValidatorSchema(Schema):
             else:
                 oth_param = self.context["spec"]._data[oth_param_name]
             vals = oth_param["value"]
-        labs_to_check = {
-            k for k in param_spec if k not in ("value", "pt_extend")
-        }
+        labs_to_check = {k for k in param_spec if k not in ("value", "_auto")}
         if labs_to_check:
             res = [
                 val

--- a/paramtools/schema.py
+++ b/paramtools/schema.py
@@ -440,7 +440,9 @@ class BaseValidatorSchema(Schema):
             else:
                 oth_param = self.context["spec"]._data[oth_param_name]
             vals = oth_param["value"]
-        labs_to_check = {k for k in param_spec if k != "value"}
+        labs_to_check = {
+            k for k in param_spec if k not in ("value", "pt_extend")
+        }
         if labs_to_check:
             res = [
                 val

--- a/paramtools/schema_factory.py
+++ b/paramtools/schema_factory.py
@@ -60,7 +60,11 @@ class SchemaFactory:
         validator_dict = {}
         for k, v in self.defaults.items():
             fieldtype = get_type(v)
-            classattrs = {"value": fieldtype, **self.label_validators}
+            classattrs = {
+                "value": fieldtype,
+                "pt_extend": fields.Boolean(required=False, load_only=True),
+                **self.label_validators,
+            }
 
             # TODO: what about case where number_dims > 0
             # if not isinstance(v["value"], list):

--- a/paramtools/schema_factory.py
+++ b/paramtools/schema_factory.py
@@ -62,7 +62,7 @@ class SchemaFactory:
             fieldtype = get_type(v)
             classattrs = {
                 "value": fieldtype,
-                "pt_extend": fields.Boolean(required=False, load_only=True),
+                "_auto": fields.Boolean(required=False, load_only=True),
                 **self.label_validators,
             }
 

--- a/paramtools/select.py
+++ b/paramtools/select.py
@@ -7,13 +7,13 @@ from paramtools.typing import ValueObject, CmpFunc
 
 def select(
     value_objects: List[ValueObject],
-    exact_match: bool,
+    strict: bool,
     cmp_func: CmpFunc,
     labels: dict,
     tree: Tree = None,
 ) -> List[ValueObject]:
     """
-    Query a parameter along some labels. If exact_match is True,
+    Query a parameter along some labels. If strict is True,
     all values in `labels` must be equal to the corresponding label
     in the parameter's "value" dictionary.
 
@@ -25,7 +25,7 @@ def select(
         return value_objects
     if tree is None:
         tree = Tree(vos=value_objects, label_grid=None)
-    return tree.select(labels, cmp_func, exact_match)
+    return tree.select(labels, cmp_func, strict)
 
 
 def eq_func(x: Any, y: Iterable) -> bool:
@@ -59,41 +59,50 @@ def lte_func(x, y) -> bool:
 
 def select_eq(
     value_objects: List[ValueObject],
-    exact_match: bool,
+    strict: bool,
     labels: dict,
     tree: Tree = None,
 ) -> List[ValueObject]:
-    return select(value_objects, exact_match, eq_func, labels, tree)
+    return select(value_objects, strict, eq_func, labels, tree)
+
+
+def select_ne(
+    value_objects: List[ValueObject],
+    strict: bool,
+    labels: dict,
+    tree: Tree = None,
+) -> List[ValueObject]:
+    return select(value_objects, strict, ne_func, labels, tree)
 
 
 def select_gt(
     value_objects: List[ValueObject],
-    exact_match: bool,
+    strict: bool,
     labels: dict,
     tree: Tree = None,
 ) -> List[ValueObject]:
-    return select(value_objects, exact_match, gt_func, labels, tree)
+    return select(value_objects, strict, gt_func, labels, tree)
 
 
 def select_gte(
     value_objects: List[ValueObject],
-    exact_match: bool,
+    strict: bool,
     labels: dict,
     tree: Tree = None,
 ) -> List[ValueObject]:
-    return select(value_objects, exact_match, gte_func, labels, tree)
+    return select(value_objects, strict, gte_func, labels, tree)
 
 
 def select_gt_ix(
     value_objects: List[ValueObject],
-    exact_match: bool,
+    strict: bool,
     labels: dict,
     cmp_list: List,
     tree: Tree = None,
 ) -> List[ValueObject]:
     return select(
         value_objects,
-        exact_match,
+        strict,
         lambda x, y: gt_ix_func(cmp_list, x, y),
         labels,
         tree,
@@ -102,17 +111,17 @@ def select_gt_ix(
 
 def select_lt(
     value_objects: List[ValueObject],
-    exact_match: bool,
+    strict: bool,
     labels: dict,
     tree: Tree = None,
 ) -> List[ValueObject]:
-    return select(value_objects, exact_match, lt_func, labels, tree)
+    return select(value_objects, strict, lt_func, labels, tree)
 
 
 def select_lte(
     value_objects: List[ValueObject],
-    exact_match: bool,
+    strict: bool,
     labels: dict,
     tree: Tree = None,
 ) -> List[ValueObject]:
-    return select(value_objects, exact_match, lte_func, labels, tree)
+    return select(value_objects, strict, lte_func, labels, tree)

--- a/paramtools/tests/test_parameters.py
+++ b/paramtools/tests/test_parameters.py
@@ -1569,9 +1569,9 @@ class TestExtend:
         assert params.from_array("int_dense_array_param") == exp
         for val in params._data["int_dense_array_param"]["value"]:
             if val["label1"] in (2, 4, 5):
-                assert val["pt_extend"] is True
+                assert val["_auto"] is True
             else:
-                assert "pt_extend" not in val
+                assert "_auto" not in val
 
         assert params.dump()["int_dense_array_param"]["value"] == exp
 
@@ -1630,9 +1630,9 @@ class TestExtend:
 
         for val in params._data["int_dense_array_param"]["value"]:
             if val["label0"] == "zero":
-                assert val["pt_extend"] is True
+                assert val["_auto"] is True
             else:
-                assert "pt_extend" not in val
+                assert "_auto" not in val
 
     def test_extend_w_array(self, extend_ex_path):
         class ExtParams(Parameters):
@@ -1682,9 +1682,9 @@ class TestExtend:
         for val in params._data["extend_param"]["value"]:
             # 0, 1 extended at the beginning.
             if val["d0"] > 3 or val["d0"] in (0, 1):
-                assert val["pt_extend"] is True
+                assert val["_auto"] is True
             else:
-                assert "pt_extend" not in val
+                assert "_auto" not in val
 
         params = ExtParams()
         params.adjust(
@@ -2009,10 +2009,10 @@ class TestExtend:
         assert sorted(params.extend_param, key=lambda vo: vo["d0"]) == [
             {"d0": 2, "d1": "c1", "value": 1},
             {"d0": 2, "d1": "c2", "value": 2},
-            {"d0": 4, "d1": "c1", "value": 1, "pt_extend": True},
-            {"d0": 4, "d1": "c2", "value": 2, "pt_extend": True},
-            {"d0": 7, "d1": "c1", "value": 1, "pt_extend": True},
-            {"d0": 7, "d1": "c2", "value": 2, "pt_extend": True},
+            {"d0": 4, "d1": "c1", "value": 1, "_auto": True},
+            {"d0": 4, "d1": "c2", "value": 2, "_auto": True},
+            {"d0": 7, "d1": "c1", "value": 1, "_auto": True},
+            {"d0": 7, "d1": "c2", "value": 2, "_auto": True},
         ]
 
 
@@ -2052,9 +2052,9 @@ class TestIndex:
         for val in params._data["indexed_param"]["value"]:
             # 0, 1 extended at the beginning.
             if val["d0"] > 3 or val["d0"] in (0, 1):
-                assert val["pt_extend"] is True
+                assert val["_auto"] is True
             else:
-                assert "pt_extend" not in val
+                assert "_auto" not in val
 
         class IndexParams2(Parameters):
             defaults = extend_ex_path

--- a/paramtools/tests/test_parameters.py
+++ b/paramtools/tests/test_parameters.py
@@ -1567,6 +1567,13 @@ class TestExtend:
         params = AFParams()
         assert isinstance(params.int_dense_array_param, np.ndarray)
         assert params.from_array("int_dense_array_param") == exp
+        for val in params._data["int_dense_array_param"]["value"]:
+            if val["label1"] in (2, 4, 5):
+                assert val["pt_extend"] is True
+            else:
+                assert "pt_extend" not in val
+
+        assert params.dump()["int_dense_array_param"]["value"] == exp
 
         class AFParams(Parameters):
             defaults = array_first_defaults
@@ -1621,6 +1628,12 @@ class TestExtend:
         ]
         assert params.from_array("int_dense_array_param") == exp
 
+        for val in params._data["int_dense_array_param"]["value"]:
+            if val["label0"] == "zero":
+                assert val["pt_extend"] is True
+            else:
+                assert "pt_extend" not in val
+
     def test_extend_w_array(self, extend_ex_path):
         class ExtParams(Parameters):
             defaults = extend_ex_path
@@ -1665,6 +1678,13 @@ class TestExtend:
             [-1, -1],
             [-1, -1],
         ]
+
+        for val in params._data["extend_param"]["value"]:
+            # 0, 1 extended at the beginning.
+            if val["d0"] > 3 or val["d0"] in (0, 1):
+                assert val["pt_extend"] is True
+            else:
+                assert "pt_extend" not in val
 
         params = ExtParams()
         params.adjust(
@@ -1896,10 +1916,10 @@ class TestExtend:
         assert sorted(params.extend_param, key=lambda vo: vo["d0"]) == [
             {"d0": 2, "d1": "c1", "value": 1},
             {"d0": 2, "d1": "c2", "value": 2},
-            {"d0": 4, "d1": "c1", "value": 1},
-            {"d0": 4, "d1": "c2", "value": 2},
-            {"d0": 7, "d1": "c1", "value": 1},
-            {"d0": 7, "d1": "c2", "value": 2},
+            {"d0": 4, "d1": "c1", "value": 1, "pt_extend": True},
+            {"d0": 4, "d1": "c2", "value": 2, "pt_extend": True},
+            {"d0": 7, "d1": "c1", "value": 1, "pt_extend": True},
+            {"d0": 7, "d1": "c2", "value": 2, "pt_extend": True},
         ]
 
 
@@ -1935,6 +1955,13 @@ class TestIndex:
             [3, 3],
             [3, 3],
         ]
+
+        for val in params._data["indexed_param"]["value"]:
+            # 0, 1 extended at the beginning.
+            if val["d0"] > 3 or val["d0"] in (0, 1):
+                assert val["pt_extend"] is True
+            else:
+                assert "pt_extend" not in val
 
         class IndexParams2(Parameters):
             defaults = extend_ex_path

--- a/paramtools/tests/test_parameters.py
+++ b/paramtools/tests/test_parameters.py
@@ -1714,30 +1714,6 @@ class TestExtend:
         params.adjust(
             {
                 "extend_param": [
-                    {"d0": 3, "d1": "c1", "value": -1},
-                    {"d0": 3, "d1": "c2", "value": 1},
-                ]
-            }
-        )
-
-        assert params.extend_param.tolist() == [
-            [1, 2],
-            [1, 2],
-            [1, 2],
-            [-1, 1],
-            [-1, 1],
-            [-1, 1],
-            [-1, 1],
-            [-1, 1],
-            [-1, 1],
-            [-1, 1],
-            [-1, 1],
-        ]
-
-        params = ExtParams()
-        params.adjust(
-            {
-                "extend_param": [
                     {"d0": 3, "value": -1},
                     {"d0": 5, "d1": "c1", "value": 0},
                     {"d0": 5, "d1": "c2", "value": 1},
@@ -1787,8 +1763,125 @@ class TestExtend:
 
         params = ExtParams()
         params.adjust({"extend_param": [{"d0": 0, "value": 1}]})
-
         assert params.extend_param.tolist() == [[1, 1]] * 11
+
+    def test_extend_adj_without_clobber(self, extend_ex_path):
+        class ExtParams(Parameters):
+            defaults = extend_ex_path
+            label_to_extend = "d0"
+            array_first = True
+
+        params = ExtParams()
+        params.adjust(
+            {"extend_param": [{"d0": 3, "value": -1}]}, clobber=False
+        )
+        assert params.extend_param.tolist() == [
+            [1, 2],
+            [1, 2],
+            [1, 2],
+            [-1, -1],
+            [-1, -1],
+            [5, 6],
+            [5, 6],
+            [7, 8],
+            [7, 8],
+            [7, 8],
+            [7, 8],
+        ]
+
+        params = ExtParams()
+        params.adjust(
+            {
+                "extend_param": [
+                    {"d0": 3, "d1": "c1", "value": -1},
+                    {"d0": 3, "d1": "c2", "value": 1},
+                ]
+            },
+            clobber=False,
+        )
+
+        assert params.extend_param.tolist() == [
+            [1, 2],
+            [1, 2],
+            [1, 2],
+            [-1, 1],
+            [-1, 1],
+            [5, 6],
+            [5, 6],
+            [7, 8],
+            [7, 8],
+            [7, 8],
+            [7, 8],
+        ]
+
+        params = ExtParams()
+        params.adjust(
+            {
+                "extend_param": [
+                    {"d0": 3, "value": -1},
+                    {"d0": 5, "d1": "c1", "value": 0},
+                    {"d0": 5, "d1": "c2", "value": 1},
+                    {"d0": 8, "d1": "c1", "value": 22},
+                    {"d0": 8, "d1": "c2", "value": 23},
+                ]
+            },
+            clobber=False,
+        )
+
+        assert params.extend_param.tolist() == [
+            [1, 2],
+            [1, 2],
+            [1, 2],
+            [-1, -1],
+            [-1, -1],
+            [0, 1],
+            [0, 1],
+            [7, 8],
+            [22, 23],
+            [22, 23],
+            [22, 23],
+        ]
+
+        params = ExtParams()
+        params.adjust(
+            {
+                "extend_param": [
+                    {"d0": 3, "value": -1},
+                    {"d0": 5, "d1": "c1", "value": 0},
+                    {"d0": 6, "d1": "c2", "value": 1},
+                ]
+            },
+            clobber=False,
+        )
+        assert params.extend_param.tolist() == [
+            [1, 2],
+            [1, 2],
+            [1, 2],
+            [-1, -1],
+            [-1, -1],
+            [0, 6],
+            [0, 1],
+            [7, 8],
+            [7, 8],
+            [7, 8],
+            [7, 8],
+        ]
+
+        params = ExtParams()
+        params.adjust({"extend_param": [{"d0": 0, "value": 1}]}, clobber=False)
+        assert params.extend_param.tolist() == [
+            [1, 1],
+            [1, 1],
+            [1, 2],
+            [3, 4],
+            [3, 4],
+            [5, 6],
+            [5, 6],
+            [7, 8],
+            [7, 8],
+            [7, 8],
+            [7, 8],
+        ]
 
     def test_extend_adj_w_errors(self, extend_ex_path):
         class ExtParams(Parameters):

--- a/paramtools/tests/test_select.py
+++ b/paramtools/tests/test_select.py
@@ -45,6 +45,13 @@ def test_select_eq_strict(vos):
         {"d0": 2, "d1": "hello", "value": 1},
     ]
 
+    vos[2]["_auto"] = True
+    vos[3]["_auto"] = True
+    assert list(select_eq(vos, False, labels={"_auto": False})) == [
+        {"d0": 1, "d1": "hello", "value": 1},
+        {"d0": 1, "d1": "world", "value": 1},
+    ]
+
 
 def test_select_ne(vos):
     assert list(select_ne(vos, False, labels={"d0": 1, "d1": "hello"})) == [

--- a/paramtools/tests/test_select.py
+++ b/paramtools/tests/test_select.py
@@ -2,6 +2,7 @@ import pytest
 
 from paramtools.select import (
     select_eq,
+    select_ne,
     select_gt,
     select_gte,
     select_lt,
@@ -20,6 +21,19 @@ def vos():
 
 
 def test_select_eq(vos):
+    assert list(select_eq(vos, False, labels={"d0": 1, "d1": "hello"})) == [
+        {"d0": 1, "d1": "hello", "value": 1}
+    ]
+
+    assert list(
+        select_eq(vos, False, labels={"d0": [1, 2], "d1": "hello"})
+    ) == [
+        {"d0": 1, "d1": "hello", "value": 1},
+        {"d0": 2, "d1": "hello", "value": 1},
+    ]
+
+
+def test_select_eq_strict(vos):
     assert list(select_eq(vos, True, labels={"d0": 1, "d1": "hello"})) == [
         {"d0": 1, "d1": "hello", "value": 1}
     ]
@@ -32,22 +46,33 @@ def test_select_eq(vos):
     ]
 
 
+def test_select_ne(vos):
+    assert list(select_ne(vos, False, labels={"d0": 1, "d1": "hello"})) == [
+        {"d0": 3, "d1": "world", "value": 1}
+    ]
+
+    assert list(select_ne(vos, False, labels={"d0": [2, 3]})) == [
+        {"d0": 1, "d1": "hello", "value": 1},
+        {"d0": 1, "d1": "world", "value": 1},
+    ]
+
+
 def test_select_gt(vos):
-    assert list(select_gt(vos, True, labels={"d0": 1})) == [
+    assert list(select_gt(vos, False, labels={"d0": 1})) == [
         {"d0": 2, "d1": "hello", "value": 1},
         {"d0": 3, "d1": "world", "value": 1},
     ]
 
 
 def test_select_gte(vos):
-    assert list(select_gte(vos, True, labels={"d0": 2})) == [
+    assert list(select_gte(vos, False, labels={"d0": 2})) == [
         {"d0": 2, "d1": "hello", "value": 1},
         {"d0": 3, "d1": "world", "value": 1},
     ]
 
 
 def test_select_lt(vos):
-    assert list(select_lt(vos, True, labels={"d0": 3})) == [
+    assert list(select_lt(vos, False, labels={"d0": 3})) == [
         {"d0": 1, "d1": "hello", "value": 1},
         {"d0": 1, "d1": "world", "value": 1},
         {"d0": 2, "d1": "hello", "value": 1},
@@ -55,7 +80,7 @@ def test_select_lt(vos):
 
 
 def test_select_lte(vos):
-    assert list(select_lte(vos, True, labels={"d0": 2})) == [
+    assert list(select_lte(vos, False, labels={"d0": 2})) == [
         {"d0": 1, "d1": "hello", "value": 1},
         {"d0": 1, "d1": "world", "value": 1},
         {"d0": 2, "d1": "hello", "value": 1},

--- a/paramtools/tests/test_tree.py
+++ b/paramtools/tests/test_tree.py
@@ -166,5 +166,4 @@ def test_select(vos, label_grid):
     res = tree.select({"d0": 1, "d1": "world"}, eq_func)
     assert res == [{"d0": 1, "d1": "world", "value": 1}]
 
-    with pytest.raises(KeyError):
-        tree.select({"d2": 1}, eq_func, exact_match=True)
+    assert tree.select({"d2": 1}, eq_func, strict=True) == []

--- a/paramtools/tree.py
+++ b/paramtools/tree.py
@@ -17,7 +17,7 @@ class Tree:
 
     def __init__(self, vos: List[ValueObject], label_grid: dict):
         self.vos = vos
-        self.label_grid = dict(label_grid or {}, pt_extend=[False, True])
+        self.label_grid = dict(label_grid or {}, _auto=[False, True])
         self.tree = None
         self.new_values = None
         self.needs_build = True
@@ -126,7 +126,7 @@ class Tree:
             # The indices in the sets at the end are the search hits.
             search_hits = {ix: set([]) for ix in range(len(tree.vos))}
             for label in self.label_grid:
-                if label in ("pt_extend",):
+                if label in ("_auto",):
                     continue
                 if label in tree.tree and label in self.tree:
                     # All label values that exist in both trees.

--- a/paramtools/tree.py
+++ b/paramtools/tree.py
@@ -224,6 +224,7 @@ class Tree:
         self.init()
         if not self.tree:
             return self.vos
+        all_ixs = set(range(len(self.vos)))
         for label, _label_value in labels.items():
             if not isinstance(_label_value, list):
                 label_value = (_label_value,)
@@ -239,4 +240,8 @@ class Tree:
                     search_hits &= label_search_hits
                 elif not strict or label_search_hits:
                     search_hits |= label_search_hits
+                if not strict:
+                    search_hits |= all_ixs - set.union(
+                        *self.tree[label].values()
+                    )
         return [self.vos[ix] for ix in search_hits]

--- a/paramtools/tree.py
+++ b/paramtools/tree.py
@@ -201,11 +201,11 @@ class Tree:
         return self.vos
 
     def select(
-        self, labels: dict, cmp_func: CmpFunc, exact_match: bool = False
+        self, labels: dict, cmp_func: CmpFunc, strict: bool = False
     ) -> List[ValueObject]:
         """
         Select all value objects from self.vos according to the label query,
-        labels, and the comparison function, cmp_func. exact_match dictates
+        labels, and the comparison function, cmp_func. strict dictates
         whether vos missing a label in the query are eligble for inclusion
         in the select results.
 
@@ -219,8 +219,8 @@ class Tree:
             List of value objects satisfying the query.
 
         Raises:
-            KeyError if exact_match is true and a label is used in the query
-                that is not present in one or more of the value objects.
+            KeyError if strict is true and a label is used in the query
+                that is not present in all of the value objects.
         """
         if not labels:
             return self.vos
@@ -241,10 +241,6 @@ class Tree:
                         label_search_hits |= ixs
                 if search_hits:
                     search_hits &= label_search_hits
-                else:
+                elif not strict or label_search_hits:
                     search_hits |= label_search_hits
-            elif exact_match:
-                raise KeyError(
-                    f"Label {label} is not used for this parameter."
-                )
         return [self.vos[ix] for ix in search_hits]

--- a/paramtools/tree.py
+++ b/paramtools/tree.py
@@ -217,10 +217,6 @@ class Tree:
 
         Returns:
             List of value objects satisfying the query.
-
-        Raises:
-            KeyError if strict is true and a label is used in the query
-                that is not present in all of the value objects.
         """
         if not labels:
             return self.vos

--- a/paramtools/tree.py
+++ b/paramtools/tree.py
@@ -17,7 +17,7 @@ class Tree:
 
     def __init__(self, vos: List[ValueObject], label_grid: dict):
         self.vos = vos
-        self.label_grid = label_grid
+        self.label_grid = dict(label_grid or {}, pt_extend=[False, True])
         self.tree = None
         self.new_values = None
         self.needs_build = True
@@ -126,6 +126,8 @@ class Tree:
             # The indices in the sets at the end are the search hits.
             search_hits = {ix: set([]) for ix in range(len(tree.vos))}
             for label in self.label_grid:
+                if label in ("pt_extend",):
+                    continue
                 if label in tree.tree and label in self.tree:
                     # All label values that exist in both trees.
                     for label_value in (

--- a/paramtools/utils.py
+++ b/paramtools/utils.py
@@ -82,9 +82,9 @@ def consistent_labels(value_items: List[ValueObject]):
     """
     if not value_items:
         return set([])
-    used = set(k for k in value_items[0] if k != "value")
+    used = set(k for k in value_items[0] if k not in ("value", "pt_extend"))
     for vo in value_items:
-        if used != set(k for k in vo if k != "value"):
+        if used != set(k for k in vo if k not in ("value", "pt_extend")):
             return None
     return used
 
@@ -102,7 +102,11 @@ def hashable_value_object(vo: ValueObject) -> tuple:
     Helper function convertinga value object into a format
     that can be stored in a set.
     """
-    return tuple(sorted(vo.items()))
+    return tuple(
+        (label, value)
+        for label, value in sorted(vo.items())
+        if label not in ("pt_extend",)
+    )
 
 
 def filter_labels(vo: ValueObject, drop=None, keep=None) -> ValueObject:
@@ -124,7 +128,11 @@ def make_label_str(vo: ValueObject) -> str:
     Create string from labels. This is used to create error messages.
     """
     lab_str = ", ".join(
-        [f"{lab}={vo[lab]}" for lab in sorted(vo) if lab != "value"]
+        [
+            f"{lab}={vo[lab]}"
+            for lab in sorted(vo)
+            if lab not in ("value", "pt_extend")
+        ]
     )
     if lab_str:
         return f"[{lab_str}]"

--- a/paramtools/utils.py
+++ b/paramtools/utils.py
@@ -82,9 +82,9 @@ def consistent_labels(value_items: List[ValueObject]):
     """
     if not value_items:
         return set([])
-    used = set(k for k in value_items[0] if k not in ("value", "pt_extend"))
+    used = set(k for k in value_items[0] if k not in ("value", "_auto"))
     for vo in value_items:
-        if used != set(k for k in vo if k not in ("value", "pt_extend")):
+        if used != set(k for k in vo if k not in ("value", "_auto")):
             return None
     return used
 
@@ -105,7 +105,7 @@ def hashable_value_object(vo: ValueObject) -> tuple:
     return tuple(
         (label, value)
         for label, value in sorted(vo.items())
-        if label not in ("pt_extend",)
+        if label not in ("_auto",)
     )
 
 
@@ -131,7 +131,7 @@ def make_label_str(vo: ValueObject) -> str:
         [
             f"{lab}={vo[lab]}"
             for lab in sorted(vo)
-            if lab not in ("value", "pt_extend")
+            if lab not in ("value", "_auto")
         ]
     )
     if lab_str:


### PR DESCRIPTION
PT can automatically extend parameter values using the the label `label_to_extend` and its range of possible values. This PR adds an attribute to each value object that is added automatically. It could be helpful to know which values are added automatically and which are set for a specific reason:

```python
In [1]: from taxcalc import Policy                                                                                                                                                            

In [2]: pol = Policy()                                                                                                                                                                        

In [3]: pol.STD                                                                                                                                                                               
Out[3]: array([[ 6100., 12200.,  6100.,  8950., 12200.]])

In [4]: pol.select_eq("STD", pt_extend=True)                                                                                                                                                  
Out[4]: 
[{'MARS': 'single', 'year': 2027, 'pt_extend': True, 'value': 7805.55},
 {'MARS': 'single', 'year': 2028, 'pt_extend': True, 'value': 7961.66},
 {'MARS': 'single', 'year': 2029, 'pt_extend': True, 'value': 8119.3},
 {'MARS': 'single', 'year': 2030, 'pt_extend': True, 'value': 8280.87},
 {'MARS': 'mjoint', 'year': 2027, 'pt_extend': True, 'value': 15612.12},
 {'MARS': 'mjoint', 'year': 2028, 'pt_extend': True, 'value': 15924.36},
 {'MARS': 'mjoint', 'year': 2029, 'pt_extend': True, 'value': 16239.66},
 {'MARS': 'mjoint', 'year': 2030, 'pt_extend': True, 'value': 16562.83},
 {'MARS': 'mseparate', 'year': 2027, 'pt_extend': True, 'value': 7805.55},
 {'MARS': 'mseparate', 'year': 2028, 'pt_extend': True, 'value': 7961.66},
 {'MARS': 'mseparate', 'year': 2029, 'pt_extend': True, 'value': 8119.3},
 {'MARS': 'mseparate', 'year': 2030, 'pt_extend': True, 'value': 8280.87},
 {'MARS': 'headhh', 'year': 2027, 'pt_extend': True, 'value': 11493.57},
 {'MARS': 'headhh', 'year': 2028, 'pt_extend': True, 'value': 11723.44},
 {'MARS': 'headhh', 'year': 2029, 'pt_extend': True, 'value': 11955.56},
 {'MARS': 'headhh', 'year': 2030, 'pt_extend': True, 'value': 12193.48},
 {'MARS': 'widow', 'year': 2027, 'pt_extend': True, 'value': 15612.12},
 {'MARS': 'widow', 'year': 2028, 'pt_extend': True, 'value': 15924.36},
 {'MARS': 'widow', 'year': 2029, 'pt_extend': True, 'value': 16239.66},
 {'MARS': 'widow', 'year': 2030, 'pt_extend': True, 'value': 16562.83}]

In [5]:  

```