### PR TITLE
Fixes to extend logic and label validation

### DIFF
--- a/docs/docs/api/reference.md
+++ b/docs/docs/api/reference.md
@@ -2,4 +2,4 @@
 
 ::: paramtools.Parameters
     :docstring:
-    :members:
+    :members: set_state adjust view_state clear_state specification extend extend_func to_array from_array parse_labels sort_values

--- a/paramtools/contrib/fields.py
+++ b/paramtools/contrib/fields.py
@@ -58,6 +58,25 @@ class MeshFieldMixin:
         assert len(self.validators) == 1
         return self.validators[0].grid()
 
+    def cmp_funcs(self, **kwargs):
+        default_cmps = {
+            "key": lambda x: x,
+            "gt": lambda x, y: x > y,
+            "gte": lambda x, y: x >= y,
+            "lt": lambda x, y: x < y,
+            "lte": lambda x, y: x <= y,
+            "ne": lambda x, y: x != y,
+            "eq": lambda x, y: x == y,
+        }
+        if not self.validators:
+            return default_cmps
+        assert len(self.validators) == 1
+        cmp_funcs = self.validators[0].cmp_funcs(**kwargs)
+        if cmp_funcs is None:
+            return default_cmps
+        else:
+            return cmp_funcs
+
 
 class Str(MeshFieldMixin, marshmallow_fields.Str):
     """

--- a/paramtools/contrib/validate.py
+++ b/paramtools/contrib/validate.py
@@ -133,6 +133,9 @@ class When(ma.validate.Validator):
         """
         return self.then_validators[0].grid()
 
+    def cmp_funcs(self, **kwargs):
+        return None
+
 
 class Range(ma.validate.Range):
     """
@@ -221,6 +224,9 @@ class Range(ma.validate.Range):
         max_ = self.max[0]["value"] + self.step
         arr = np.arange(self.min[0]["value"], max_, self.step)
         return arr[arr <= self.max[0]["value"]].tolist()
+
+    def cmp_funcs(self, **kwargs):
+        return None
 
 
 class DateRange(Range):
@@ -334,3 +340,16 @@ class OneOf(ma.validate.OneOf):
 
     def grid(self):
         return self.choices
+
+    def cmp_funcs(self, choices=None, **kwargs):
+        if choices is None:
+            choices = self.choices
+        return {
+            "key": lambda x: choices.index(x),
+            "gt": lambda x, y: choices.index(x) > choices.index(y),
+            "gte": lambda x, y: choices.index(x) >= choices.index(y),
+            "lt": lambda x, y: choices.index(x) < choices.index(y),
+            "lte": lambda x, y: choices.index(x) <= choices.index(y),
+            "ne": lambda x, y: x != y,
+            "eq": lambda x, y: x == y,
+        }

--- a/paramtools/exceptions.py
+++ b/paramtools/exceptions.py
@@ -72,6 +72,7 @@ collision_list = [
     "errors",
     "warnings",
     "from_array",
+    "parse_labels",
     "read_params",
     "set_state",
     "specification",

--- a/paramtools/parameters.py
+++ b/paramtools/parameters.py
@@ -459,7 +459,7 @@ class Parameters:
         Query value(s) of all parameters along labels specified in
         `labels`.
 
-        Parameters:
+        **Parameters**
 
           - `use_state`: Use the instance's state for the select operation.
           - `meta_data`: Include information like the parameter
@@ -468,6 +468,9 @@ class Parameters:
           - `serializable`: Return data that is compatible with `json.dumps`.
           - `sort_values`: Sort values by the `label` order.
 
+        **Returns**
+
+          - `dict` of parameter names and data.
         """
         if use_state:
             labels.update(self._state)

--- a/paramtools/parameters.py
+++ b/paramtools/parameters.py
@@ -240,13 +240,6 @@ class Parameters:
                                 labels=query_args,
                                 tree=tree,
                             )
-                            # gt = select_gt_ix(
-                            #     queryset,
-                            #     strict=False,
-                            #     labels=query_args,
-                            #     cmp_list=extend_grid,
-                            #     tree=tree,
-                            # )
                             to_delete[param] += select_eq(
                                 gt,
                                 strict=False,

--- a/paramtools/select.py
+++ b/paramtools/select.py
@@ -1,4 +1,4 @@
-from typing import Any, Iterable, List
+from typing import Any, Iterable, List, Callable
 
 
 from paramtools.tree import Tree
@@ -55,6 +55,13 @@ def lt_func(x, y) -> bool:
 
 def lte_func(x, y) -> bool:
     return all(x <= item for item in y)
+
+
+def make_cmp_func(
+    cmp: Callable[[Any, Iterable], bool],
+    all_or_any: Callable[[Iterable], bool],
+) -> CmpFunc:
+    return lambda x, y: all_or_any(cmp(x, item) for item in y)
 
 
 def select_eq(

--- a/paramtools/tests/test_parameters.py
+++ b/paramtools/tests/test_parameters.py
@@ -1267,32 +1267,32 @@ class TestState:
         params = TestParams()
         assert params.view_state() == {}
         params.set_state(label0="zero")
-        assert params.view_state() == {"label0": "zero"}
+        assert params.view_state() == {"label0": ["zero"]}
         params.set_state(label1=0)
-        assert params.view_state() == {"label0": "zero", "label1": 0}
+        assert params.view_state() == {"label0": ["zero"], "label1": [0]}
         params.set_state(label0="one", label2=1)
         assert params.view_state() == {
-            "label0": "one",
-            "label1": 0,
-            "label2": 1,
+            "label0": ["one"],
+            "label1": [0],
+            "label2": [1],
         }
         params.set_state(**{})
         assert params.view_state() == {
-            "label0": "one",
-            "label1": 0,
-            "label2": 1,
+            "label0": ["one"],
+            "label1": [0],
+            "label2": [1],
         }
         params.set_state()
         assert params.view_state() == {
-            "label0": "one",
-            "label1": 0,
-            "label2": 1,
+            "label0": ["one"],
+            "label1": [0],
+            "label2": [1],
         }
         params.set_state(label1=[1, 2, 3])
         assert params.view_state() == {
-            "label0": "one",
+            "label0": ["one"],
             "label1": [1, 2, 3],
-            "label2": 1,
+            "label2": [1],
         }
 
     def test_label_grid(self, TestParams):
@@ -1984,7 +1984,7 @@ class TestExtend:
             [-1, -1],
         ]
 
-    def test_custom_extend(self, extend_ex_path):
+    def test_extend_method(self, extend_ex_path):
         class ExtParams(Parameters):
             defaults = extend_ex_path
             # label_to_extend = "d0"
@@ -2013,6 +2013,51 @@ class TestExtend:
             {"d0": 4, "d1": "c2", "value": 2, "_auto": True},
             {"d0": 7, "d1": "c1", "value": 1, "_auto": True},
             {"d0": 7, "d1": "c2", "value": 2, "_auto": True},
+        ]
+
+        params = ExtParams()
+        init = params.select_eq("extend_param")
+        params.extend(label_to_extend="d0", label_to_extend_values=[])
+        assert init == params.select_eq("extend_param")
+
+        params.extend(label_to_extend="d0", label_to_extend_values=[8, 9, 10])
+        assert sorted(params.extend_param, key=lambda vo: vo["d0"]) == [
+            {"d0": 2, "d1": "c1", "value": 1},
+            {"d0": 2, "d1": "c2", "value": 2},
+            {"d0": 3, "d1": "c1", "value": 3},
+            {"d0": 3, "d1": "c2", "value": 4},
+            {"d0": 5, "d1": "c1", "value": 5},
+            {"d0": 5, "d1": "c2", "value": 6},
+            {"d0": 7, "d1": "c1", "value": 7},
+            {"d0": 7, "d1": "c2", "value": 8},
+            {"d0": 8, "d1": "c1", "value": 7, "_auto": True},
+            {"d0": 8, "d1": "c2", "value": 8, "_auto": True},
+            {"d0": 9, "d1": "c1", "value": 7, "_auto": True},
+            {"d0": 9, "d1": "c2", "value": 8, "_auto": True},
+            {"d0": 10, "d1": "c1", "value": 7, "_auto": True},
+            {"d0": 10, "d1": "c2", "value": 8, "_auto": True},
+        ]
+
+        params.extend(
+            label_to_extend="d0", label_to_extend_values=[0, 8, 9, 10]
+        )
+        assert sorted(params.extend_param, key=lambda vo: vo["d0"]) == [
+            {"d0": 0, "d1": "c1", "value": 1, "_auto": True},
+            {"d0": 0, "d1": "c2", "value": 2, "_auto": True},
+            {"d0": 2, "d1": "c1", "value": 1},
+            {"d0": 2, "d1": "c2", "value": 2},
+            {"d0": 3, "d1": "c1", "value": 3},
+            {"d0": 3, "d1": "c2", "value": 4},
+            {"d0": 5, "d1": "c1", "value": 5},
+            {"d0": 5, "d1": "c2", "value": 6},
+            {"d0": 7, "d1": "c1", "value": 7},
+            {"d0": 7, "d1": "c2", "value": 8},
+            {"d0": 8, "d1": "c1", "value": 7, "_auto": True},
+            {"d0": 8, "d1": "c2", "value": 8, "_auto": True},
+            {"d0": 9, "d1": "c1", "value": 7, "_auto": True},
+            {"d0": 9, "d1": "c2", "value": 8, "_auto": True},
+            {"d0": 10, "d1": "c1", "value": 7, "_auto": True},
+            {"d0": 10, "d1": "c2", "value": 8, "_auto": True},
         ]
 
 

--- a/paramtools/tests/test_parameters.py
+++ b/paramtools/tests/test_parameters.py
@@ -2005,8 +2005,8 @@ class TestExtend:
             label_to_extend_values=[2, 4, 7],
             params="extend_param",
         )
-
-        assert sorted(params.extend_param, key=lambda vo: vo["d0"]) == [
+        params.sort_values()
+        assert params.extend_param == [
             {"d0": 2, "d1": "c1", "value": 1},
             {"d0": 2, "d1": "c2", "value": 2},
             {"d0": 4, "d1": "c1", "value": 1, "_auto": True},
@@ -2022,7 +2022,8 @@ class TestExtend:
 
         params = ExtParams()
         params.extend(label_to_extend="d0", label_to_extend_values=[8, 9, 10])
-        assert sorted(params.extend_param, key=lambda vo: vo["d0"]) == [
+        params.sort_values()
+        assert params.extend_param == [
             {"d0": 2, "d1": "c1", "value": 1},
             {"d0": 2, "d1": "c2", "value": 2},
             {"d0": 3, "d1": "c1", "value": 3},
@@ -2043,7 +2044,8 @@ class TestExtend:
         params.extend(
             label_to_extend="d0", label_to_extend_values=[0, 8, 9, 10]
         )
-        assert sorted(params.extend_param, key=lambda vo: vo["d0"]) == [
+        params.sort_values()
+        assert params.extend_param == [
             {"d0": 0, "d1": "c1", "value": 1, "_auto": True},
             {"d0": 0, "d1": "c2", "value": 2, "_auto": True},
             {"d0": 2, "d1": "c1", "value": 1},

--- a/paramtools/tests/test_parameters.py
+++ b/paramtools/tests/test_parameters.py
@@ -2020,6 +2020,7 @@ class TestExtend:
         params.extend(label_to_extend="d0", label_to_extend_values=[])
         assert init == params.select_eq("extend_param")
 
+        params = ExtParams()
         params.extend(label_to_extend="d0", label_to_extend_values=[8, 9, 10])
         assert sorted(params.extend_param, key=lambda vo: vo["d0"]) == [
             {"d0": 2, "d1": "c1", "value": 1},
@@ -2038,6 +2039,7 @@ class TestExtend:
             {"d0": 10, "d1": "c2", "value": 8, "_auto": True},
         ]
 
+        params = ExtParams()
         params.extend(
             label_to_extend="d0", label_to_extend_values=[0, 8, 9, 10]
         )

--- a/paramtools/tests/test_parameters.py
+++ b/paramtools/tests/test_parameters.py
@@ -2013,9 +2013,7 @@ class TestExtend:
             }
         )
         params.extend(
-            label_to_extend="d0",
-            label_to_extend_values=[2, 4, 7],
-            params="extend_param",
+            label="d0", label_values=[2, 4, 7], params="extend_param"
         )
         params.sort_values()
         assert params.extend_param == [
@@ -2029,11 +2027,11 @@ class TestExtend:
 
         params = ExtParams()
         init = params.select_eq("extend_param")
-        params.extend(label_to_extend="d0", label_to_extend_values=[])
+        params.extend(label="d0", label_values=[])
         assert init == params.select_eq("extend_param")
 
         params = ExtParams()
-        params.extend(label_to_extend="d0", label_to_extend_values=[8, 9, 10])
+        params.extend(label="d0", label_values=[8, 9, 10])
         params.sort_values()
         assert params.extend_param == [
             {"d0": 2, "d1": "c1", "value": 1},
@@ -2053,9 +2051,7 @@ class TestExtend:
         ]
 
         params = ExtParams()
-        params.extend(
-            label_to_extend="d0", label_to_extend_values=[0, 8, 9, 10]
-        )
+        params.extend(label="d0", label_values=[0, 8, 9, 10])
         params.sort_values()
         assert params.extend_param == [
             {"d0": 0, "d1": "c1", "value": 1, "_auto": True},


### PR DESCRIPTION
- Updates for edge cases in extend logic when directly using the `extend` method and setting `label_to_extend_values`.
  - Case 1: `label_to_extend values` is an empty list:
    ```python
    params = ExtParams()
    init = params.select_eq("extend_param")
    params.extend(label_to_extend="d0", label_to_extend_values=[])
    assert init == params.select_eq("extend_param")
    ```
  - Case 2: `label_to_extend_values` are all values greater than the defined values:
    ```python
    params = ExtParams()
    params.extend(label_to_extend="d0", label_to_extend_values=[8, 9, 10])
    params.sort_values()
    assert params.extend_param == [
        {"d0": 2, "d1": "c1", "value": 1},
        {"d0": 2, "d1": "c2", "value": 2},
        {"d0": 3, "d1": "c1", "value": 3},
        {"d0": 3, "d1": "c2", "value": 4},
        {"d0": 5, "d1": "c1", "value": 5},
        {"d0": 5, "d1": "c2", "value": 6},
        {"d0": 7, "d1": "c1", "value": 7},
        {"d0": 7, "d1": "c2", "value": 8},
        {"d0": 8, "d1": "c1", "value": 7, "_auto": True},
        {"d0": 8, "d1": "c2", "value": 8, "_auto": True},
        {"d0": 9, "d1": "c1", "value": 7, "_auto": True},
        {"d0": 9, "d1": "c2", "value": 8, "_auto": True},
        {"d0": 10, "d1": "c1", "value": 7, "_auto": True},
        {"d0": 10, "d1": "c2", "value": 8, "_auto": True},
    ]
    ```
    
    - Case 3: Some extend values are less than the defined values:
    ```python
    params = ExtParams()
    params.extend(
        label_to_extend="d0", label_to_extend_values=[0, 8, 9, 10]
    )
    params.sort_values()
    assert params.extend_param == [
        {"d0": 0, "d1": "c1", "value": 1, "_auto": True},
        {"d0": 0, "d1": "c2", "value": 2, "_auto": True},
        {"d0": 2, "d1": "c1", "value": 1},
        {"d0": 2, "d1": "c2", "value": 2},
        {"d0": 3, "d1": "c1", "value": 3},
        {"d0": 3, "d1": "c2", "value": 4},
        {"d0": 5, "d1": "c1", "value": 5},
        {"d0": 5, "d1": "c2", "value": 6},
        {"d0": 7, "d1": "c1", "value": 7},
        {"d0": 7, "d1": "c2", "value": 8},
        {"d0": 8, "d1": "c1", "value": 7, "_auto": True},
        {"d0": 8, "d1": "c2", "value": 8, "_auto": True},
        {"d0": 9, "d1": "c1", "value": 7, "_auto": True},
        {"d0": 9, "d1": "c2", "value": 8, "_auto": True},
        {"d0": 10, "d1": "c1", "value": 7, "_auto": True},
        {"d0": 10, "d1": "c2", "value": 8, "_auto": True},
    ]
    ```
- Minor performance improvements from defining comparison functions for each marshmallow field. This means that integer, float, and date can use the `>` operator for look ups in the `adjust` and `extend` method instead of comparing values' indices in the `extend_grid`.
- A new `parse_labels` method for validating label values that are set by the user via `set_state` or `extend`.
