### PR TITLE
Fix case where overriding class attr to use default

### DIFF
--- a/paramtools/parameters.py
+++ b/paramtools/parameters.py
@@ -43,7 +43,6 @@ class Parameters:
     def __init__(
         self,
         initial_state: Optional[dict] = None,
-        uses_extend_func: bool = None,
         index_rates: Optional[dict] = None,
         **ops,
     ):

--- a/paramtools/parameters.py
+++ b/paramtools/parameters.py
@@ -43,10 +43,9 @@ class Parameters:
     def __init__(
         self,
         initial_state: Optional[dict] = None,
-        array_first: Optional[bool] = None,
-        label_to_extend: str = None,
         uses_extend_func: bool = None,
         index_rates: Optional[dict] = None,
+        **ops,
     ):
         schemafactory = SchemaFactory(self.defaults)
         (
@@ -75,21 +74,21 @@ class Parameters:
         # class attribute: middle importance
         # schema action: least important
         # default value if three above are not specified.
-        ops = [
-            ("array_first", array_first, False),
-            ("label_to_extend", label_to_extend, None),
-            ("uses_extend_func", uses_extend_func, False),
+        default_ops = [
+            ("array_first", False),
+            ("label_to_extend", None),
+            ("uses_extend_func", False),
         ]
         schema_ops = self._schema.get("operators", {})
-        for name, init_value, default in ops:
-            if init_value is not None:
-                setattr(self, name, init_value)
-                continue
-            user_vals = [getattr(self, name), schema_ops.get(name)]
-            for value in user_vals:
-                if value != default and value is not None:
-                    setattr(self, name, value)
-                    break
+        for name, default in default_ops:
+            if name in ops:
+                setattr(self, name, ops.get(name))
+            elif getattr(self, name, None) != default:
+                setattr(self, name, getattr(self, name))
+            elif name in schema_ops:
+                setattr(self, name, schema_ops[name])
+            else:
+                setattr(self, name, default)
 
         if self.label_to_extend:
             prev_array_first = self.array_first

--- a/paramtools/parameters.py
+++ b/paramtools/parameters.py
@@ -43,9 +43,9 @@ class Parameters:
     def __init__(
         self,
         initial_state: Optional[dict] = None,
-        array_first: Optional[bool] = False,
+        array_first: Optional[bool] = None,
         label_to_extend: str = None,
-        uses_extend_func: bool = False,
+        uses_extend_func: bool = None,
         index_rates: Optional[dict] = None,
     ):
         schemafactory = SchemaFactory(self.defaults)
@@ -82,7 +82,10 @@ class Parameters:
         ]
         schema_ops = self._schema.get("operators", {})
         for name, init_value, default in ops:
-            user_vals = [init_value, getattr(self, name), schema_ops.get(name)]
+            if init_value is not None:
+                setattr(self, name, init_value)
+                continue
+            user_vals = [getattr(self, name), schema_ops.get(name)]
             for value in user_vals:
                 if value != default and value is not None:
                     setattr(self, name, value)

--- a/paramtools/tests/test_parameters.py
+++ b/paramtools/tests/test_parameters.py
@@ -219,6 +219,17 @@ class TestSchema:
             "uses_extend_func": False,
         }
 
+        class Params3(Parameters):
+            array_first = True
+            defaults = {"schema": {"operators": {"array_first": True}}}
+
+        params = Params3(array_first=False)
+        assert params.operators == {
+            "array_first": False,
+            "label_to_extend": None,
+            "uses_extend_func": False,
+        }
+
     def test_when_schema(self):
         class Params(Parameters):
             defaults = {

--- a/paramtools/tests/test_parameters.py
+++ b/paramtools/tests/test_parameters.py
@@ -221,9 +221,10 @@ class TestSchema:
 
         class Params3(Parameters):
             array_first = True
+            label_to_extend = "hello"
             defaults = {"schema": {"operators": {"array_first": True}}}
 
-        params = Params3(array_first=False)
+        params = Params3(array_first=False, label_to_extend=None)
         assert params.operators == {
             "array_first": False,
             "label_to_extend": None,


### PR DESCRIPTION
Fixes bug where the user isn't able to revert an ops argument back to the default value:

```python
class Params3(Parameters):
    array_first = True
    defaults = {"schema": {"operators": {"array_first": True}}}

params = Params3(array_first=False)
# Bug: params.array_first == True
# Fix: params.array_first == False
```