### PR TITLE
Minor readability and performance improvements for extend method

### DIFF
--- a/paramtools/__init__.py
+++ b/paramtools/__init__.py
@@ -47,6 +47,7 @@ from paramtools.utils import (
     hashable_value_object,
     filter_labels,
     make_label_str,
+    SortedKeyList,
 )
 
 
@@ -95,5 +96,6 @@ __all__ = [
     "hashable_value_object",
     "filter_labels",
     "make_label_str",
+    "SortedKeyList",
     "ValueObject",
 ]

--- a/paramtools/parameters.py
+++ b/paramtools/parameters.py
@@ -216,7 +216,13 @@ class Parameters:
         """
         # Validate user adjustments.
         if is_deserialized:
-            parsed_params = params_or_path
+            parsed_params = {}
+            try:
+                parsed_params = self._validator_schema.load(
+                    params_or_path, ignore_warnings, is_deserialized=True
+                )
+            except MarshmallowValidationError as ve:
+                self._parse_validation_messages(ve.messages, params_or_path)
         else:
             params = self.read_params(params_or_path)
             parsed_params = {}
@@ -777,6 +783,7 @@ class Parameters:
             extend_adj=False,
             ignore_warnings=ignore_warnings,
             raise_errors=raise_errors,
+            is_deserialized=True,
         )
 
     def extend_func(

--- a/paramtools/parameters.py
+++ b/paramtools/parameters.py
@@ -761,32 +761,15 @@ class Parameters:
                     extended[vo[label]].append(vo)
 
                 for val in missing_vals:
-                    full_eg_ix = full_extend_grid.index(val)
-                    eg_ix = extend_grid.index(val)
-                    if eg_ix == 0 and full_eg_ix == 0:
-                        first_defined_value = min(
-                            defined_vals, key=cmp_funcs["key"]
-                        )
-                        value_objects = select_eq(
-                            eq, False, {label: first_defined_value}
-                        )
-                    elif eg_ix == 0:
-                        closest_val = get_closest_val(
-                            val, extended.keys(), cmp_funcs["key"]
-                        )
+                    closest_val = get_closest_val(
+                        val, extended.keys(), cmp_funcs["key"]
+                    )
+                    if closest_val in extended:
+                        value_objects = extended.pop(closest_val)
+                    else:
                         value_objects = select_eq(
                             eq, False, {label: closest_val}
                         )
-                    else:
-                        closest_val = get_closest_val(
-                            val, extended.keys(), cmp_funcs["key"]
-                        )
-                        if closest_val in extended:
-                            value_objects = extended.pop(closest_val)
-                        else:
-                            value_objects = select_eq(
-                                eq, False, {label: closest_val}
-                            )
                     # In practice, value_objects has length one.
                     # Theoretically, there could be multiple if the inital value
                     # object had less labels than later value objects and thus

--- a/paramtools/tests/test_parameters.py
+++ b/paramtools/tests/test_parameters.py
@@ -1166,6 +1166,22 @@ class TestValidationMessages:
         with pytest.raises(ValidationError):
             params.adjust({"param": params.when_param - 1})
 
+    def test_is_deserialized(self, TestParams):
+        params = TestParams()
+        params._adjust({"min_int_param": [{"value": 1}]}, is_deserialized=True)
+        assert params.min_int_param == [
+            {"label0": "zero", "label1": 1, "value": 1},
+            {"label0": "one", "label1": 2, "value": 1},
+        ]
+
+        params._adjust(
+            {"min_int_param": [{"value": -1}]},
+            raise_errors=False,
+            is_deserialized=True,
+        )
+
+        assert params.errors["min_int_param"] == ["min_int_param -1 < min 0 "]
+
 
 class TestArray:
     def test_to_array(self, TestParams):

--- a/paramtools/tests/test_utils.py
+++ b/paramtools/tests/test_utils.py
@@ -6,6 +6,7 @@ from paramtools import (
     hashable_value_object,
     filter_labels,
     make_label_str,
+    SortedKeyList,
 )
 
 
@@ -95,3 +96,38 @@ def test_make_label_str():
     assert make_label_str({"value": 0}) == ""
     assert make_label_str({}) == ""
     assert make_label_str({"b": 0, "c": 1, "a": 2}) == "[a=2, b=0, c=1]"
+
+
+def test_sorted_key_list():
+    [(2, 2), (3, 3), (5, 5), (7, 7)]
+    values = {
+        "red": 2,
+        "blue": 3,
+        "orange": 5,
+        "white": 6,
+        "yellow": 7,
+        "green": 9,
+        "black": 0,
+    }
+
+    to_insert = {"red": 2, "blue": 3, "orange": 5, "yellow": 7}
+
+    skl = SortedKeyList(to_insert, keyfunc=lambda x: values[x])
+
+    assert skl.gte("black") == "red"
+    assert skl.lte("black") is None
+    skl.insert("black")
+    assert skl.gte("black") == "black"
+    assert skl.lte("black") == "black"
+
+    assert skl.gte("white") == "yellow"
+    assert skl.lte("white") == "orange"
+    skl.insert("white")
+    assert skl.gte("white") == "white"
+    assert skl.lte("white") == "white"
+
+    assert skl.gte("green") is None
+    assert skl.lte("green") == "yellow"
+    skl.insert("green")
+    assert skl.gte("green") == "green"
+    assert skl.lte("green") == "green"

--- a/paramtools/utils.py
+++ b/paramtools/utils.py
@@ -1,5 +1,6 @@
 import json
 import os
+from bisect import bisect_left, bisect_right
 from collections import OrderedDict
 from typing import List
 
@@ -148,3 +149,36 @@ def grid_sort(vos, label_to_extend, grid):
             return grid[0]
 
     return sorted(vos, key=key)
+
+
+class SortedKeyList:
+    """
+    Sorted key list inspired by SortedContainers and the Python docs:
+
+    - http://www.grantjenks.com/docs/sortedcontainers/
+    - https://docs.python.org/3.9/library/bisect.html
+    """
+
+    def __init__(self, values, keyfunc):
+        self.sorted_key_list = [(val, keyfunc(val)) for val in values]
+        self.sorted_key_list.sort(key=lambda r: r[1])
+        self.keys = [r[1] for r in self.sorted_key_list]
+        self.keyfunc = keyfunc
+
+    def lte(self, value):
+        i = bisect_right(self.keys, self.keyfunc(value))
+        if i:
+            return self.sorted_key_list[i - 1][0]
+        return None
+
+    def gte(self, value):
+        i = bisect_left(self.keys, self.keyfunc(value))
+        if i != len(self.keys):
+            return self.sorted_key_list[i][0]
+        return None
+
+    def insert(self, value):
+        key_value = self.keyfunc(value)
+        i = bisect_left(self.keys, key_value)
+        self.sorted_key_list.insert(i, (value, key_value))
+        self.keys.insert(i, key_value)


### PR DESCRIPTION
This PR:
- Simplifies the process for finding the "closest" value to extend from in the `extend` method. The key insight is that the value to extend from is the one with the label-to-extend value being closest to the current missing value with a a preference towards that value being less than the missing value.
- Implements a basic sorted key list data structure for finding the closest value. This was inspired by [Sorted Containers](http://www.grantjenks.com/docs/sortedcontainers/) and the [`bisect` module docs](https://docs.python.org/3.9/library/bisect.html).
- Bypasses deserialization when using the `extend` method. Deserialization isn't needed because the values that are being passed to `_adjust` are pulled from the already deserialized data in `_data`. This saves a considerable chunk of time when extending many values.