### PR TITLE
Fix bug when value (maybe) has already been deserialized

### DIFF
--- a/paramtools/contrib/fields.py
+++ b/paramtools/contrib/fields.py
@@ -6,7 +6,10 @@ from marshmallow import fields as marshmallow_fields
 
 class NumPySerializeMixin:
     def _serialize(self, value, attr, obj, **kwargs):
-        return value.tolist()
+        if hasattr(value, "tolist"):
+            return value.tolist()
+        else:
+            return value
 
     def _validated(self, value):
         value = super()._validated(value)


### PR DESCRIPTION
This fixes the following deserialization bug:

```
  File "make_uguide.py", line 84, in reformat_params
    params = pol.specification(serializable=True)
  File "/home/hankdoupe/Documents/ParamTools/paramtools/parameters.py", line 500, in specification
    ser = self._defaults_schema.dump(all_params)
  File "/home/hankdoupe/miniconda3/envs/taxcalc-dev/lib/python3.8/site-packages/marshmallow/schema.py", line 556, in dump
    result = self._serialize(processed_obj, many=many)
  File "/home/hankdoupe/miniconda3/envs/taxcalc-dev/lib/python3.8/site-packages/marshmallow/schema.py", line 520, in _serialize
    value = field_obj.serialize(attr_name, obj, accessor=self.get_attribute)
  File "/home/hankdoupe/miniconda3/envs/taxcalc-dev/lib/python3.8/site-packages/marshmallow/fields.py", line 311, in serialize
    return self._serialize(value, attr, obj, **kwargs)
  File "/home/hankdoupe/miniconda3/envs/taxcalc-dev/lib/python3.8/site-packages/marshmallow/fields.py", line 566, in _serialize
    return schema.dump(nested_obj, many=many)
  File "/home/hankdoupe/miniconda3/envs/taxcalc-dev/lib/python3.8/site-packages/marshmallow/schema.py", line 556, in dump
    result = self._serialize(processed_obj, many=many)
  File "/home/hankdoupe/miniconda3/envs/taxcalc-dev/lib/python3.8/site-packages/marshmallow/schema.py", line 520, in _serialize
    value = field_obj.serialize(attr_name, obj, accessor=self.get_attribute)
  File "/home/hankdoupe/miniconda3/envs/taxcalc-dev/lib/python3.8/site-packages/marshmallow/fields.py", line 311, in serialize
    return self._serialize(value, attr, obj, **kwargs)
  File "/home/hankdoupe/miniconda3/envs/taxcalc-dev/lib/python3.8/site-packages/marshmallow/fields.py", line 566, in _serialize
    return schema.dump(nested_obj, many=many)
  File "/home/hankdoupe/miniconda3/envs/taxcalc-dev/lib/python3.8/site-packages/marshmallow/schema.py", line 556, in dump
    result = self._serialize(processed_obj, many=many)
  File "/home/hankdoupe/miniconda3/envs/taxcalc-dev/lib/python3.8/site-packages/marshmallow/schema.py", line 514, in _serialize
    return [
  File "/home/hankdoupe/miniconda3/envs/taxcalc-dev/lib/python3.8/site-packages/marshmallow/schema.py", line 515, in <listcomp>
    self._serialize(d, many=False)
  File "/home/hankdoupe/miniconda3/envs/taxcalc-dev/lib/python3.8/site-packages/marshmallow/schema.py", line 520, in _serialize
    value = field_obj.serialize(attr_name, obj, accessor=self.get_attribute)
  File "/home/hankdoupe/miniconda3/envs/taxcalc-dev/lib/python3.8/site-packages/marshmallow/fields.py", line 311, in serialize
    return self._serialize(value, attr, obj, **kwargs)
  File "/home/hankdoupe/Documents/ParamTools/paramtools/contrib/fields.py", line 9, in _serialize
    return value.tolist()
AttributeError: 'float' object has no attribute 'tolist'
```
