### PR TITLE
Add pip to environment.yml to avoid warning

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,6 +6,7 @@ dependencies:
   - "numpy>=1.13"
   - "python-dateutil>=2.8.0"
   - pytest
+  - pip
   - pip:
     - pre-commit
     - black


### PR DESCRIPTION
```
(base) mghenis@penguin:~/ParamTools$ conda env create
Warning: you have pip-installed dependencies in your environment file, but you do not list pip itself as one of your conda dependencies.  Conda may not use the correct pip to install your packages, and they may end up in the wrong place.  Please add an explicit pip dependency.  I'm adding one for you, but still nagging you.
```