### PR TITLE
Read more file sources

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,8 @@ dependencies:
   - "numpy>=1.13"
   - "python-dateutil>=2.8.0"
   - pytest
+  - s3fs # required for tests, but not for most usage.
   - pip:
-    - pre-commit
-    - black
-    - flake8
+      - pre-commit
+      - black
+      - flake8

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,9 @@ dependencies:
   - "numpy>=1.13"
   - "python-dateutil>=2.8.0"
   - pytest
-  - s3fs # required for tests, but not for most usage.
+  - fsspec
+  - s3fs # required for tests but not most usage.
+  - gcsfs # required for tests but not most usage.
   - pip:
       - pre-commit
       - black

--- a/paramtools/__init__.py
+++ b/paramtools/__init__.py
@@ -38,7 +38,6 @@ from paramtools.select import (
 from paramtools.typing import ValueObject
 from paramtools.utils import (
     read_json,
-    read,
     get_example_paths,
     LeafGetter,
     get_leaves,
@@ -87,7 +86,6 @@ __all__ = [
     "select_lt",
     "select_lte",
     "select_ne",
-    "read",
     "read_json",
     "get_example_paths",
     "LeafGetter",

--- a/paramtools/__init__.py
+++ b/paramtools/__init__.py
@@ -38,6 +38,7 @@ from paramtools.select import (
 from paramtools.typing import ValueObject
 from paramtools.utils import (
     read_json,
+    read,
     get_example_paths,
     LeafGetter,
     get_leaves,
@@ -86,6 +87,7 @@ __all__ = [
     "select_lt",
     "select_lte",
     "select_ne",
+    "read",
     "read_json",
     "get_example_paths",
     "LeafGetter",

--- a/paramtools/parameters.py
+++ b/paramtools/parameters.py
@@ -1,6 +1,4 @@
 import copy
-import os
-import json
 import itertools
 from collections import OrderedDict, defaultdict
 from functools import partial, reduce
@@ -23,7 +21,7 @@ from paramtools.select import (
     make_cmp_func,
 )
 from paramtools.tree import Tree
-from paramtools.typing import ValueObject
+from paramtools.typing import ValueObject, FileDictStringLike
 from paramtools.exceptions import (
     ParamToolsError,
     SparseValueObjectsException,
@@ -136,16 +134,12 @@ class Parameters:
         """
         return self._state
 
-    def read_params(self, params_or_path):
-        if isinstance(params_or_path, str) and os.path.exists(params_or_path):
-            params = utils.read_json(params_or_path)
-        elif isinstance(params_or_path, str):
-            params = json.loads(params_or_path)
-        elif isinstance(params_or_path, dict):
-            params = params_or_path
-        else:
-            raise ValueError("params_or_path is not dict or file path")
-        return params
+    def read_params(
+        self,
+        params_or_path: FileDictStringLike,
+        storage_options: Optional[Dict[str, Any]] = None,
+    ):
+        return utils.read(params_or_path, storage_options)
 
     def adjust(
         self,

--- a/paramtools/parameters.py
+++ b/paramtools/parameters.py
@@ -139,7 +139,7 @@ class Parameters:
         params_or_path: FileDictStringLike,
         storage_options: Optional[Dict[str, Any]] = None,
     ):
-        return utils.read(params_or_path, storage_options)
+        return utils.read_json(params_or_path, storage_options)
 
     def adjust(
         self,

--- a/paramtools/tests/test_utils.py
+++ b/paramtools/tests/test_utils.py
@@ -53,10 +53,10 @@ class TestRead:
         with pytest.raises(ValueError):
             read_json(f":{['a'] * 200}")
 
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError):
             read_json(("hello", "world"))
 
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError):
             read_json(None)
 
 

--- a/paramtools/tests/test_utils.py
+++ b/paramtools/tests/test_utils.py
@@ -10,17 +10,17 @@ from paramtools import (
     filter_labels,
     make_label_str,
     SortedKeyList,
-    read,
+    read_json,
 )
 
 
 class TestRead:
     def test_read_s3(self):
-        res = read("s3://paramtools-test/defaults.json", {"anon": True})
+        res = read_json("s3://paramtools-test/defaults.json", {"anon": True})
         assert isinstance(res, dict)
 
     def test_read_gcp(self):
-        res = read("gs://cs-inputs-dev/defaults.json", {"token": "anon"})
+        res = read_json("gs://cs-inputs-dev/defaults.json", {"token": "anon"})
         assert isinstance(res, dict)
 
     def test_read_http(self):
@@ -28,35 +28,36 @@ class TestRead:
             "https://raw.githubusercontent.com/PSLmodels/ParamTools/master/"
             "paramtools/tests/defaults.json"
         )
-        res = read(http_path)
+        res = read_json(http_path)
         assert isinstance(res, dict)
 
     def test_read_github(self):
         gh_path = "github://PSLmodels:ParamTools@master/paramtools/tests/defaults.json"
-        res = read(gh_path)
+        res = read_json(gh_path)
         assert isinstance(res, dict)
 
     def test_read_file_path(self):
         CURRENT_PATH = os.path.abspath(os.path.dirname(__file__))
         defaults_path = os.path.join(CURRENT_PATH, "defaults.json")
-        res = read(defaults_path)
+        res = read_json(defaults_path)
         assert isinstance(res, dict)
 
     def test_read_string(self):
-        res = read('{"hello": "world"}')
+        res = read_json('{"hello": "world"}')
         assert isinstance(res, dict)
 
+    def test_read_invalid(self):
         with pytest.raises(ValueError):
-            read('{"hello": "world"')
+            read_json('{"hello": "world"')
 
         with pytest.raises(ValueError):
-            read(f":{['a'] * 200}")
+            read_json(f":{['a'] * 200}")
 
         with pytest.raises(ValueError):
-            read(("hello", "world"))
+            read_json(("hello", "world"))
 
         with pytest.raises(ValueError):
-            read(None)
+            read_json(None)
 
 
 def test_get_leaves():

--- a/paramtools/tests/test_utils.py
+++ b/paramtools/tests/test_utils.py
@@ -1,3 +1,6 @@
+import os
+import pytest
+
 from paramtools import (
     get_leaves,
     ravel,
@@ -7,7 +10,53 @@ from paramtools import (
     filter_labels,
     make_label_str,
     SortedKeyList,
+    read,
 )
+
+
+class TestRead:
+    def test_read_s3(self):
+        res = read("s3://paramtools-test/defaults.json", {"anon": True})
+        assert isinstance(res, dict)
+
+    def test_read_gcp(self):
+        res = read("gs://cs-inputs-dev/defaults.json", {"token": "anon"})
+        assert isinstance(res, dict)
+
+    def test_read_http(self):
+        http_path = (
+            "https://raw.githubusercontent.com/PSLmodels/ParamTools/master/"
+            "paramtools/tests/defaults.json"
+        )
+        res = read(http_path)
+        assert isinstance(res, dict)
+
+    def test_read_github(self):
+        gh_path = "github://PSLmodels:ParamTools@master/paramtools/tests/defaults.json"
+        res = read(gh_path)
+        assert isinstance(res, dict)
+
+    def test_read_file_path(self):
+        CURRENT_PATH = os.path.abspath(os.path.dirname(__file__))
+        defaults_path = os.path.join(CURRENT_PATH, "defaults.json")
+        res = read(defaults_path)
+        assert isinstance(res, dict)
+
+    def test_read_string(self):
+        res = read('{"hello": "world"}')
+        assert isinstance(res, dict)
+
+        with pytest.raises(ValueError):
+            read('{"hello": "world"')
+
+        with pytest.raises(ValueError):
+            read(f":{['a'] * 200}")
+
+        with pytest.raises(ValueError):
+            read(("hello", "world"))
+
+        with pytest.raises(ValueError):
+            read(None)
 
 
 def test_get_leaves():

--- a/paramtools/typing.py
+++ b/paramtools/typing.py
@@ -1,4 +1,7 @@
-from typing import NewType, Dict, Any, Callable, Iterable
+from typing import NewType, Dict, Any, Callable, Iterable, Union, IO, AnyStr
+from pathlib import Path
 
 ValueObject = NewType("ValueObject", Dict[str, Any])
 CmpFunc = NewType("CmpFunc", Callable[[Any, Iterable], bool])
+
+FileDictStringLike = Union[str, Path, IO[AnyStr], Dict[str, any]]

--- a/paramtools/utils.py
+++ b/paramtools/utils.py
@@ -35,8 +35,8 @@ def _read(
         return params_or_path
     else:
         raise TypeError(
-            f"ParamTools is unable to read data of type: {type(params_or_path)}\n"
-            "It must be a File Path, URL, String, or Dict."
+            f"Unable to read data of type: {type(params_or_path)}\n"
+            "           Data must be a File Path, URL, String, or Dict."
         )
 
 

--- a/paramtools/utils.py
+++ b/paramtools/utils.py
@@ -34,7 +34,7 @@ def _read(
     elif isinstance(params_or_path, dict):
         return params_or_path
     else:
-        raise ValueError(
+        raise TypeError(
             f"ParamTools is unable to read data of type: {type(params_or_path)}\n"
             "It must be a File Path, URL, String, or Dict."
         )
@@ -57,7 +57,7 @@ def read_json(
 
     """
     res = _read(params_or_path, storage_options)
-    print(res)
+
     if isinstance(res, str):
         try:
             return json.loads(res, object_pairs_hook=OrderedDict)

--- a/paramtools/utils.py
+++ b/paramtools/utils.py
@@ -9,14 +9,13 @@ import fsspec
 from paramtools.typing import ValueObject, FileDictStringLike
 
 
-def read(
+def _read(
     params_or_path: FileDictStringLike,
     storage_options: Optional[Dict[str, Any]] = None,
 ):
     """
-    Read JSON files of the form:
+    Read files of the form:
     - Local file path.
-
     - Any URL readable by fsspec. For example:
       - s3: s3://paramtools-test/defaults.json
       - gcs: gs://cs-inputs-dev/defaults.json
@@ -26,39 +25,52 @@ def read(
     """
     if isinstance(params_or_path, str) and os.path.exists(params_or_path):
         with open(params_or_path, "r") as f:
-            params = json.loads(f.read(), object_pairs_hook=OrderedDict)
+            return f.read()
     elif isinstance(params_or_path, str) and "://" in params_or_path:
         with fsspec.open(params_or_path, "r", **(storage_options or {})) as f:
-            params = json.loads(f.read(), object_pairs_hook=OrderedDict)
+            return f.read()
     elif isinstance(params_or_path, str):
-        try:
-            params = json.loads(params_or_path)
-        except json.JSONDecodeError as je:
-            if len(params_or_path) > 100:
-                params_or_path = (
-                    params_or_path[:100] + "..." + params_or_path[-10:]
-                )
-            raise ValueError(
-                f"Unable to decode JSON string: {params_or_path}"
-            ) from je
+        return params_or_path
     elif isinstance(params_or_path, dict):
-        params = params_or_path
+        return params_or_path
     else:
         raise ValueError(
             f"ParamTools is unable to read data of type: {type(params_or_path)}\n"
             "It must be a File Path, URL, String, or Dict."
         )
 
-    return params
 
-
-def read_json(path):
+def read_json(
+    params_or_path: FileDictStringLike,
+    storage_options: Optional[Dict[str, Any]] = None,
+):
     """
-    Read JSON data.
+    Read JSON data of the form:
+    - Dict.
+    - JSON string.
+    - Local file path.
+    - Any URL readable by fsspec. For example:
+      - s3: s3://paramtools-test/defaults.json
+      - gcs: gs://cs-inputs-dev/defaults.json
+      - http: https://somedomain.com/defaults.json
+      - github: github://PSLmodels:ParamTools@master/paramtools/tests/defaults.json
 
-    Legacy method for read function.
     """
-    return read(path)
+    res = _read(params_or_path, storage_options)
+    print(res)
+    if isinstance(res, str):
+        try:
+            return json.loads(res, object_pairs_hook=OrderedDict)
+        except json.JSONDecodeError as je:
+            if len(res) > 100:
+                res = res[:100] + "..." + res[-10:]
+            raise ValueError(f"Unable to decode JSON string: {res}") from je
+
+    if isinstance(res, dict):
+        return res
+
+    # Error should be thrown in `_read`
+    raise TypeError(f"Unknown type: {type(res)}")
 
 
 def get_example_paths(name):

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,12 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/hdoupe/ParamTools",
     packages=setuptools.find_packages(),
-    install_requires=["marshmallow>=3.0.0", "numpy", "python-dateutil>=2.8.0"],
+    install_requires=[
+        "marshmallow>=3.0.0",
+        "numpy",
+        "python-dateutil>=2.8.0",
+        "fsspec",
+    ],
     include_package_data=True,
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
- Add `fsspec` to read many types of files. This makes it easy to add support for:
  - s3 files: s3://paramtools-test/defaults.json
  - google cloud storage files: gs://cs-inputs-dev/defaults.json
  - http files: https://raw.githubusercontent.com/PSLmodels/ParamTools/master/paramtools/tests/defaults.json
  - files on github: github://PSLmodels:ParamTools@master/paramtools/tests/defaults.json
- Improves error messages and error handling for invalid data:

**Invalid JSON String:**
```
In [2]: read_json('{"hello": "world"')                                                                                                                                                        
---------------------------------------------------------------------------
JSONDecodeError                           Traceback (most recent call last)
~/Documents/ParamTools/paramtools/utils.py in read_json(params_or_path, storage_options)
     62         try:
---> 63             return json.loads(res, object_pairs_hook=OrderedDict)
     64         except json.JSONDecodeError as je:

~/miniconda3/envs/paramtools-dev/lib/python3.8/json/__init__.py in loads(s, cls, object_hook, parse_float, parse_int, parse_constant, object_pairs_hook, **kw)
    369         kw['parse_constant'] = parse_constant
--> 370     return cls(**kw).decode(s)

~/miniconda3/envs/paramtools-dev/lib/python3.8/json/decoder.py in decode(self, s, _w)
    336         """
--> 337         obj, end = self.raw_decode(s, idx=_w(s, 0).end())
    338         end = _w(s, end).end()

~/miniconda3/envs/paramtools-dev/lib/python3.8/json/decoder.py in raw_decode(self, s, idx)
    352         try:
--> 353             obj, end = self.scan_once(s, idx)
    354         except StopIteration as err:

JSONDecodeError: Expecting ',' delimiter: line 1 column 18 (char 17)

The above exception was the direct cause of the following exception:

ValueError                                Traceback (most recent call last)
<ipython-input-2-630679848444> in <module>
----> 1 read_json('{"hello": "world"')

~/Documents/ParamTools/paramtools/utils.py in read_json(params_or_path, storage_options)
     65             if len(res) > 100:
     66                 res = res[:100] + "..." + res[-10:]
---> 67             raise ValueError(f"Unable to decode JSON string: {res}") from je
     68 
     69     if isinstance(res, dict):

ValueError: Unable to decode JSON string: {"hello": "world"
```

**Invalid long JSON string:**
```
In [3]: read_json(f":{['a'] * 200}")                                                                                                                                                          
---------------------------------------------------------------------------
JSONDecodeError                           Traceback (most recent call last)
~/Documents/ParamTools/paramtools/utils.py in read_json(params_or_path, storage_options)
     62         try:
---> 63             return json.loads(res, object_pairs_hook=OrderedDict)
     64         except json.JSONDecodeError as je:

~/miniconda3/envs/paramtools-dev/lib/python3.8/json/__init__.py in loads(s, cls, object_hook, parse_float, parse_int, parse_constant, object_pairs_hook, **kw)
    369         kw['parse_constant'] = parse_constant
--> 370     return cls(**kw).decode(s)

~/miniconda3/envs/paramtools-dev/lib/python3.8/json/decoder.py in decode(self, s, _w)
    336         """
--> 337         obj, end = self.raw_decode(s, idx=_w(s, 0).end())
    338         end = _w(s, end).end()

~/miniconda3/envs/paramtools-dev/lib/python3.8/json/decoder.py in raw_decode(self, s, idx)
    354         except StopIteration as err:
--> 355             raise JSONDecodeError("Expecting value", s, err.value) from None
    356         return obj, end

JSONDecodeError: Expecting value: line 1 column 1 (char 0)

The above exception was the direct cause of the following exception:

ValueError                                Traceback (most recent call last)
<ipython-input-3-f5982e150c39> in <module>
----> 1 read_json(f":{['a'] * 200}")

~/Documents/ParamTools/paramtools/utils.py in read_json(params_or_path, storage_options)
     65             if len(res) > 100:
     66                 res = res[:100] + "..." + res[-10:]
---> 67             raise ValueError(f"Unable to decode JSON string: {res}") from je
     68 
     69     if isinstance(res, dict):

ValueError: Unable to decode JSON string: :['a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a'... 'a', 'a']

```

**TypeError on invalid types:**
```
In [4]: read_json(None)                                                                                                                                                                       
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-4-e871a78c1190> in <module>
----> 1 read_json(None)

~/Documents/ParamTools/paramtools/utils.py in read_json(params_or_path, storage_options)
     57 
     58     """
---> 59     res = _read(params_or_path, storage_options)
     60 
     61     if isinstance(res, str):

~/Documents/ParamTools/paramtools/utils.py in _read(params_or_path, storage_options)
     35         return params_or_path
     36     else:
---> 37         raise TypeError(
     38             f"ParamTools is unable to read data of type: {type(params_or_path)}\n"
     39             "It must be a File Path, URL, String, or Dict."

TypeError: ParamTools is unable to read data of type: <class 'NoneType'>
It must be a File Path, URL, String, or Dict.


```

