### PR TITLE
Fix attribute order when dumping parameters to JSON

### DIFF
--- a/paramtools/parameters.py
+++ b/paramtools/parameters.py
@@ -1196,16 +1196,9 @@ class Parameters:
                     data[param]["value"] = sorted(
                         data[param]["value"], key=pfunc
                     )
-                    for value in data[param]["value"]:
-                        v = value.pop("value")
-                        value["value"] = v
 
                 else:
                     data[param] = sorted(data[param], key=pfunc)
-
-                    for value in data[param]:
-                        v = value.pop("value")
-                        value["value"] = v
 
             # Only update attributes when array first is off, since
             # value order will not affect how arrays are constructed.

--- a/paramtools/parameters.py
+++ b/paramtools/parameters.py
@@ -1196,8 +1196,16 @@ class Parameters:
                     data[param]["value"] = sorted(
                         data[param]["value"], key=pfunc
                     )
+                    for value in data[param]["value"]:
+                        v = value.pop("value")
+                        value["value"] = v
+
                 else:
                     data[param] = sorted(data[param], key=pfunc)
+
+                    for value in data[param]:
+                        v = value.pop("value")
+                        value["value"] = v
 
             # Only update attributes when array first is off, since
             # value order will not affect how arrays are constructed.

--- a/paramtools/parameters.py
+++ b/paramtools/parameters.py
@@ -446,7 +446,7 @@ class Parameters:
             "uses_extend_func": self.uses_extend_func,
         }
 
-    def dump(self, sort_values=True):
+    def dump(self, sort_values: bool = True, use_state: bool = True):
         """
         Dump a representation of this instance to JSON. This makes it
         possible to load this instance's data after sending the data
@@ -458,9 +458,12 @@ class Parameters:
             include_empty=True,
             serializable=True,
             sort_values=sort_values,
+            use_state=use_state,
         )
         schema = ParamToolsSchema().dump(self._schema)
-        return {**spec, **{"schema": schema}}
+        result = {"schema": schema}
+        result.update(spec)
+        return result
 
     def specification(
         self,
@@ -931,7 +934,7 @@ class Parameters:
         used = utils.consistent_labels(value_items)
         if used is None:
             raise InconsistentLabelsException(
-                f"were added or omitted for some value object(s)."
+                "Labels were added or omitted for some value object(s)."
             )
         label_order, value_order = [], {}
         for label_name, label_values in label_grid.items():

--- a/paramtools/schema.py
+++ b/paramtools/schema.py
@@ -110,6 +110,9 @@ class BaseParamSchema(Schema):
     )
     indexed = fields.Boolean(required=False)
 
+    class Meta:
+        ordered = True
+
 
 class EmptySchema(Schema):
     """

--- a/paramtools/schema_factory.py
+++ b/paramtools/schema_factory.py
@@ -1,7 +1,6 @@
 from marshmallow import fields
 
 from paramtools.schema import (
-    EmptySchema,
     OrderedSchema,
     BaseValidatorSchema,
     ValueObject,
@@ -71,7 +70,7 @@ class SchemaFactory:
             #     v["value"] = [{"value": v["value"]}]
 
             validator_dict[k] = type(
-                "ValidatorItem", (EmptySchema,), classattrs
+                "ValidatorItem", (OrderedSchema,), classattrs
             )
 
             classattrs = {"value": ValueObject(validator_dict[k], many=True)}


### PR DESCRIPTION
This PR fixes the order for:
- schema vs other parameter names when using `params.dump()`
- exposes the `use_state` kwarg to easily dump without having to run `params.clear_state()` beforehand. 
- makes the value objects ordered by having their marshmallow schema inherit from `OrderedSchema`

cc @Peter-Metz 