### PR TITLE
Check for changes to operator attributes when getting the schema

### DIFF
--- a/paramtools/exceptions.py
+++ b/paramtools/exceptions.py
@@ -74,6 +74,7 @@ collision_list = [
     "from_array",
     "parse_labels",
     "read_params",
+    "schema",
     "set_state",
     "specification",
     "sort_values",

--- a/paramtools/parameters.py
+++ b/paramtools/parameters.py
@@ -439,6 +439,12 @@ class Parameters:
         return ValidationError(messages=messages, labels=labels)
 
     @property
+    def schema(self):
+        pre = dict(self._schema)
+        pre["operators"] = self.operators
+        return ParamToolsSchema().dump(pre)
+
+    @property
     def operators(self):
         return {
             "array_first": self.array_first,
@@ -460,8 +466,7 @@ class Parameters:
             sort_values=sort_values,
             use_state=use_state,
         )
-        schema = ParamToolsSchema().dump(self._schema)
-        result = {"schema": schema}
+        result = {"schema": self.schema}
         result.update(spec)
         return result
 

--- a/paramtools/tests/test_parameters.py
+++ b/paramtools/tests/test_parameters.py
@@ -196,6 +196,7 @@ class TestSchema:
             "label_to_extend": "mylabel",
             "uses_extend_func": False,
         }
+        assert params.dump()["schema"]["operators"] == params.operators
 
         Params1.array_first = True
         params = Params1()
@@ -206,6 +207,7 @@ class TestSchema:
             "label_to_extend": "somelabel",
             "uses_extend_func": False,
         }
+        assert params.dump()["schema"]["operators"] == params.operators
 
         class Params2(Parameters):
             defaults = {"schema": {"operators": {"array_first": True}}}
@@ -218,6 +220,7 @@ class TestSchema:
             "label_to_extend": None,
             "uses_extend_func": False,
         }
+        assert params.dump()["schema"]["operators"] == params.operators
 
         class Params3(Parameters):
             array_first = True
@@ -230,6 +233,10 @@ class TestSchema:
             "label_to_extend": None,
             "uses_extend_func": False,
         }
+        assert params.dump()["schema"]["operators"] == params.operators
+
+        params.array_first = True
+        assert params.dump()["schema"]["operators"] == params.operators
 
     def test_when_schema(self):
         class Params(Parameters):
@@ -977,7 +984,7 @@ class TestValidationMessages:
         assert params.warnings
         assert not params.errors
 
-        msg = [f"int_warn_param -1 < min 0 "]
+        msg = ["int_warn_param -1 < min 0 "]
         assert (
             json.loads(excinfo.value.args[0])["warnings"]["int_warn_param"]
             == msg


### PR DESCRIPTION
This fixes a bug that occurs when you update an operator attribute like `array_first` after creating the `Parameters` instance and then call `dump`. The "schema" object returned will not have the updated operators. 

Before:

```python
In [1]: from paramtools import Parameters

In [2]: class Params(Parameters):
   ...:     defaults = {"schema": {"operators": {"array_first": True}}}
   ...: 

In [3]: params = Params()

In [4]: params.array_first = False

In [5]: params.dump()
Out[5]: 
{'schema': {'labels': {},
  'operators': {'label_to_extend': None,
   'uses_extend_func': False,
   'array_first': True},                          # <=== this should be False!
  'additional_members': {}}}
```

After fix:

```python
In [1]: from paramtools import Parameters

In [2]: class Params(Parameters):
   ...:     defaults = {"schema": {"operators": {"array_first": True}}}
   ...: 

In [3]: params = Params()

In [4]: params.array_first = False

In [5]: params.dump()
Out[5]: 
{'schema': {'additional_members': {},
  'operators': {'uses_extend_func': False,
   'array_first': False,                          # <=== this is False now.
   'label_to_extend': None},
  'labels': {}}}
```