### PR TITLE
Allow json comments

### DIFF
--- a/paramtools/tests/test_utils.py
+++ b/paramtools/tests/test_utils.py
@@ -13,16 +13,18 @@ from paramtools import (
 )
 
 
-@pytest.mark.network_bound
 class TestRead:
+    @pytest.mark.network_bound
     def test_read_s3(self):
         res = read_json("s3://paramtools-test/defaults.json", {"anon": True})
         assert isinstance(res, dict)
 
+    @pytest.mark.network_bound
     def test_read_gcp(self):
         res = read_json("gs://paramtools-dev/defaults.json", {"token": "anon"})
         assert isinstance(res, dict)
 
+    @pytest.mark.network_bound
     def test_read_http(self):
         http_path = (
             "https://raw.githubusercontent.com/PSLmodels/ParamTools/master/"
@@ -31,6 +33,7 @@ class TestRead:
         res = read_json(http_path)
         assert isinstance(res, dict)
 
+    @pytest.mark.network_bound
     def test_read_github(self):
         gh_path = "github://PSLmodels:ParamTools@master/paramtools/tests/defaults.json"
         res = read_json(gh_path)
@@ -58,6 +61,39 @@ class TestRead:
 
         with pytest.raises(TypeError):
             read_json(None)
+
+    def test_strip_comments_simple(self):
+        """test strip comment"""
+        params = """
+        // my comment
+        // another
+        {
+            "hello": "world"
+        }
+        """
+        assert read_json(params) == {"hello": "world"}
+
+    def test_strip_comments_multiline(self):
+        """test strip comment"""
+        params = """
+        /* my comment
+        another
+        */
+        {
+            "hello": "world"
+        }
+        """
+        assert read_json(params) == {"hello": "world"}
+
+    def test_strip_comments_ignores_url(self):
+        """test strips comment but doesn't affect http://..."""
+        params = """
+        // my comment
+        {
+            "hello": "http://world"
+        }
+        """
+        assert read_json(params) == {"hello": "http://world"}
 
 
 def test_get_leaves():

--- a/paramtools/utils.py
+++ b/paramtools/utils.py
@@ -1,9 +1,12 @@
 import json
+import re
 import os
 from collections import OrderedDict
 from typing import Optional, List, Dict, Any
+from urllib.parse import urlparse
 
 import fsspec
+from fsspec.registry import known_implementations
 
 from paramtools.typing import ValueObject, FileDictStringLike
 
@@ -25,18 +28,52 @@ def _read(
     if isinstance(params_or_path, str) and os.path.exists(params_or_path):
         with open(params_or_path, "r") as f:
             return f.read()
-    elif isinstance(params_or_path, str) and "://" in params_or_path:
-        with fsspec.open(params_or_path, "r", **(storage_options or {})) as f:
-            return f.read()
-    elif isinstance(params_or_path, str):
+
+    if isinstance(params_or_path, str):
+        uri = urlparse(params_or_path)
+        if uri.scheme in known_implementations:
+            with fsspec.open(
+                params_or_path, "r", **(storage_options or {})
+            ) as f:
+                return f.read()
+
+    if isinstance(params_or_path, str):
         return params_or_path
-    elif isinstance(params_or_path, dict):
+
+    if isinstance(params_or_path, dict):
         return params_or_path
+
     else:
         raise TypeError(
             f"Unable to read data of type: {type(params_or_path)}\n"
             "           Data must be a File Path, URL, String, or Dict."
         )
+
+
+def remove_comments(string):
+    """
+    Remove single and multiline comments from JSON.
+
+    StackOverflow magic:
+    https://stackoverflow.com/a/18381470/9100772
+    """
+    pattern = r"(\".*?\"|\'.*?\')|(/\*.*?\*/|//[^\r\n]*$)"
+    # first group captures quoted strings (double or single)
+    # second group captures comments (//single-line or /* multi-line */)
+    regex = re.compile(pattern, re.MULTILINE | re.DOTALL)
+
+    def _replacer(match):
+        # if the 2nd group (capturing comments) is not None,
+        # it means we have captured a non-quoted (real) comment string.
+        # breakpoint()
+        if match.group(2) is not None:
+            # print("match.group(2)", match.group(2))
+            return "\n"  # preserve line numbers
+        else:  # otherwise, we will return the 1st group
+            # print("match.group(1)", match.group(1))
+            return match.group(1)  # captured quoted-string
+
+    return regex.sub(_replacer, string)
 
 
 def read_json(
@@ -56,9 +93,9 @@ def read_json(
 
     """
     res = _read(params_or_path, storage_options)
-
     if isinstance(res, str):
         try:
+            res = remove_comments(res)
             return json.loads(res, object_pairs_hook=OrderedDict)
         except json.JSONDecodeError as je:
             if len(res) > 100:

--- a/paramtools/utils.py
+++ b/paramtools/utils.py
@@ -65,12 +65,9 @@ def remove_comments(string):
     def _replacer(match):
         # if the 2nd group (capturing comments) is not None,
         # it means we have captured a non-quoted (real) comment string.
-        # breakpoint()
         if match.group(2) is not None:
-            # print("match.group(2)", match.group(2))
             return "\n"  # preserve line numbers
         else:  # otherwise, we will return the 1st group
-            # print("match.group(1)", match.group(1))
             return match.group(1)  # captured quoted-string
 
     return regex.sub(_replacer, string)


### PR DESCRIPTION
Allow comments in JSON file like:

```json
// this is my json file
// more comments here
/*
multi line comments?
*/
{
    "hello": "world",
    "allows_urls": "http://double-slash-is-ok.com"
}
```

```python
In [1]: import paramtools                                                           

In [2]: s = """// this is my json file 
   ...: // more comments here 
   ...: /* 
   ...: multi line comments? 
   ...: */ 
   ...: { 
   ...:     "hello": "world", 
   ...:     "allows_urls": "http://double-slash-is-ok.com" 
   ...: }"""                                                                        

In [3]: paramtools.read_json(s)                                                     
Out[3]: 
OrderedDict([('hello', 'world'),
             ('allows_urls', 'http://double-slash-is-ok.com')])

```
