### PR TITLE
Fix bug with defer_validation and when validator interaction

### DIFF
--- a/paramtools/schema.py
+++ b/paramtools/schema.py
@@ -324,7 +324,12 @@ class BaseValidatorSchema(Schema):
                 raw_data,
                 validate_schema=validate_schema,
             )
+            # OK to skip validator if validate_schema is False
+            if validator is None and not validate_schema:
+                continue
+
             validators.append(validator)
+
         return validators
 
     def _get_when_validator(

--- a/paramtools/tests/test_parameters.py
+++ b/paramtools/tests/test_parameters.py
@@ -673,6 +673,17 @@ class TestAdjust:
         assert params.min_int_param == adjustment["min_int_param"]
         assert params.max_int_param == adjustment["max_int_param"]
 
+    def test_transaction_with_when_parameter(self, TestParams):
+        """
+        When validator returns None when validate_schema is False for performance
+        reasons.
+        """
+        params = TestParams()
+        with params.transaction(defer_validation=True):
+            params.adjust({"when_param": 2, "str_choice_param": "value1"})
+
+        assert params.when_param == [{"value": 2}]
+
     def test_adjust_many_labels(self, TestParams):
         """
         Adjust min_int_param above original max_int_param value at same time as


### PR DESCRIPTION
Fixes this bug:

```
    def validate_param(self, param_name, param_spec, raw_data):
        """
        Do range validation for a parameter.
        """
        validate_schema = not getattr(
            self.context["spec"], "_defer_validation", False
        )
        validators = self.validators(
            param_name, param_spec, raw_data, validate_schema=validate_schema
        )
        warnings = []
        errors = []
        for validator in validators:
            try:
>               validator(param_spec, is_value_object=True)
E               TypeError: 'NoneType' object is not callable

paramtools/schema.py:283: TypeError
```