### PR TITLE
Use `load_defaults` rather than `missing`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10", "3.11", "3.12"]
 
     steps:
       - name: Checkout
@@ -21,7 +21,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Miniconda using Python ${{ matrix.python-version }}
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
           activate-environment: paramtools-dev
           environment-file: environment.yml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 
-name: Build Package and Test Source Code [Python 3.6, 3.7, 3.8]
+name: Build Package and Test Source Code [Python 3.9, 3.10, 3.11, 3.12]
 
 on:
   push:
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10", "3.11", "3.12"]
+        python-version: [3.9, "3.10", "3.11", "3.12"]
 
     steps:
       - name: Checkout

--- a/paramtools/schema.py
+++ b/paramtools/schema.py
@@ -106,10 +106,10 @@ class BaseParamSchema(Schema):
         attribute="type",
         data_key="type",
     )
-    number_dims = fields.Integer(required=False, missing=0)
+    number_dims = fields.Integer(required=False, load_default=0)
     value = fields.Field(required=True)  # will be specified later
     validators = fields.Nested(
-        ValueValidatorSchema(), required=False, missing={}
+        ValueValidatorSchema(), required=False, load_default={}
     )
     indexed = fields.Boolean(required=False)
 
@@ -580,9 +580,9 @@ class LabelSchema(Schema):
         attribute="type",
         data_key="type",
     )
-    number_dims = fields.Integer(required=False, missing=0)
+    number_dims = fields.Integer(required=False, load_default=0)
     validators = fields.Nested(
-        ValueValidatorSchema(), required=False, missing={}
+        ValueValidatorSchema(), required=False, load_default={}
     )
 
 
@@ -594,7 +594,7 @@ def make_additional_members(allowed_types):
             attribute="type",
             data_key="type",
         )
-        number_dims = fields.Integer(required=False, missing=0)
+        number_dims = fields.Integer(required=False, load_default=0)
 
     return AdditionalMembersSchema
 
@@ -611,13 +611,13 @@ def make_schema(allowed_types):
             keys=fields.Str(),
             values=fields.Nested(LabelSchema()),
             required=False,
-            missing={},
+            load_default={},
         )
         additional_members = fields.Dict(
             keys=fields.Str(),
             values=fields.Nested(make_additional_members(allowed_types)()),
             required=False,
-            missing={},
+            load_default={},
         )
         operators = fields.Nested(OperatorsSchema, required=False)
 


### PR DESCRIPTION
This PR updates calls to `marshmallow.fields` to use the `load_defaults` kwarg rather than the deprecated `missing` kwarg.

Addresses Issue #133.