### PR TITLE
Update to TOC for documentation, `setup.py`

### DIFF
--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -1,5 +1,7 @@
-- file: intro
-- part: API
+format: jb-book
+root: intro
+parts:
+- caption: API
   chapters:
     - file: api/guide
     - file: api/viewing-data
@@ -8,6 +10,6 @@
     - file: api/custom-adjust
     - file: api/custom-types
     - file: api/reference
-- part: Parameters
+- caption: Parameters
   chapters:
     - file: parameters

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as f:
 
 setuptools.setup(
     name="paramtools",
-    version=os.environ.get("VERSION", "0.0.0"),
+    version=os.environ.get("VERSION", "0.18.2"),
     author="Hank Doupe",
     author_email="henrymdoupe@gmail.com",
     description=(


### PR DESCRIPTION
This PR makes two small updates:

1. It includes the version number in `setup.py`, so when the package is built, it has the current version number.
2. The table of contents for the JupyterBook documentation is updated to work with the latest version of JB.