### PR TITLE
Add get_defaults method to allow sub-class to customize parameter loading

### DIFF
--- a/paramtools/__init__.py
+++ b/paramtools/__init__.py
@@ -89,6 +89,7 @@ __all__ = [
     "select_ne",
     "read_json",
     "get_example_paths",
+    "get_defaults",
     "LeafGetter",
     "get_leaves",
     "ravel",

--- a/paramtools/exceptions.py
+++ b/paramtools/exceptions.py
@@ -94,6 +94,7 @@ collision_list = [
     "to_dict",
     "_parse_validation_messages",
     "sel",
+    "get_defaults",
 ]
 
 

--- a/paramtools/parameters.py
+++ b/paramtools/parameters.py
@@ -80,7 +80,7 @@ class Parameters:
         sort_values: bool = True,
         **ops,
     ):
-        schemafactory = SchemaFactory(self.defaults)
+        schemafactory = SchemaFactory(self.get_defaults())
         (
             self._defaults_schema,
             self._validator_schema,
@@ -1403,3 +1403,15 @@ class Parameters:
                 )[param]
                 setattr(self, param, sorted_values)
         return data
+
+    def get_defaults(self):
+        """
+        Hook for implementing custom behavior for getting the default parameters.
+
+
+        **Returns**
+
+          - `params`: String if URL or file path. Dict if this is the loaded params
+            dict.
+        """
+        return utils.read_json(self.defaults)

--- a/paramtools/schema_factory.py
+++ b/paramtools/schema_factory.py
@@ -8,7 +8,6 @@ from paramtools.schema import (
     get_param_schema,
     ParamToolsSchema,
 )
-from paramtools import utils
 
 
 class SchemaFactory:
@@ -26,7 +25,6 @@ class SchemaFactory:
     """
 
     def __init__(self, defaults):
-        defaults = utils.read_json(defaults)
         self.defaults = {k: v for k, v in defaults.items() if k != "schema"}
         self.schema = ParamToolsSchema().load(defaults.get("schema", {}))
         (self.BaseParamSchema, self.label_validators) = get_param_schema(

--- a/paramtools/tests/test_parameters.py
+++ b/paramtools/tests/test_parameters.py
@@ -137,6 +137,36 @@ class TestSchema:
         assert params.hello_world == "hello world"
         assert params.label_grid == {}
 
+    def test_get_defaults_override(self):
+        class Params(Parameters):
+            array_first = True
+            defaults = {
+                "schema": {
+                    "labels": {
+                        "somelabel": {
+                            "type": "int",
+                            "validators": {"range": {"min": 0, "max": 2}},
+                        }
+                    }
+                },
+                "hello_world": {
+                    "title": "Hello, World!",
+                    "description": "Simplest config possible.",
+                    "type": "str",
+                    "value": "hello world",
+                },
+            }
+
+            def get_defaults(self):
+                label = self.defaults["schema"]["labels"]["somelabel"]
+                label["validators"]["range"]["max"] = 5
+                return self.defaults
+
+        params = Params()
+        assert params.hello_world == "hello world"
+        assert params.label_grid == {"somelabel": [0, 1, 2, 3, 4, 5]}
+
+
     def test_schema_not_dropped(self, defaults_spec_path):
         with open(defaults_spec_path, "r") as f:
             defaults_ = json.loads(f.read())


### PR DESCRIPTION
@jdebacker , let me know if this works for you. You can override the `get_defaults` class in `taxcalc.Parameters` and change this value in the JSON to use the new last year value.

https://github.com/PSLmodels/Tax-Calculator/blob/b41af537803488b6ac40beb0a0e0a7e81cfb6dbd/taxcalc/policy_current_law.json#L9