### PR TITLE
Update to work with Marshmallow version 3.22

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: paramtools-dev
 channels:
   - conda-forge
 dependencies:
-  - "marshmallow>=3.0.0"
+  - "marshmallow>=3.22.0"
   - "numpy>=1.13"
   - "python-dateutil>=2.8.0"
   - "pytest>=6.0.0"

--- a/paramtools/schema.py
+++ b/paramtools/schema.py
@@ -204,7 +204,7 @@ class BaseValidatorSchema(Schema):
             error_store=error_store, data=data, many=None
         )
         # Run schema-level validation
-        if self._has_processors(decorators.VALIDATES_SCHEMA):
+        if self._hooks[decorators.VALIDATES_SCHEMA]:
             field_errors = bool(error_store.errors)
             self._invoke_schema_validators(
                 error_store=error_store,

--- a/paramtools/tests/test_parameters.py
+++ b/paramtools/tests/test_parameters.py
@@ -1017,7 +1017,7 @@ class TestValidationMessages:
             ]
         }
         params.adjust(adj, raise_errors=False)
-        exp = ["float_list_param[label0=zero, label1=1] [np.float64(-1.0), np.float64(1.0)] < min 0 "]
+        exp = ["float_list_param[label0=zero, label1=1] [-1.0, 1.0] < min 0 "]
 
         assert params.errors["float_list_param"] == exp
 


### PR DESCRIPTION
This PR addresses Issue #140 by changing `parameters.py` to call the new `_hook` method and not the deprecated `_has_processors` method.