### PR TITLE
Marshmallow 4 upgrades 

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -5,13 +5,13 @@ package:
 requirements:
   build:
     - python
-    - "marshmallow>=3.0.0rc4"
+    - "marshmallow>=4.0.0"
     - "numpy>=1.13"
     - "python-dateutil>=2.8.0"
 
   run:
     - python
-    - "marshmallow>=3.0.0rc4"
+    - "marshmallow>=4.0.0"
     - "numpy>=1.13"
     - "python-dateutil>=2.8.0"
 

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: paramtools-dev
 channels:
   - conda-forge
 dependencies:
-  - "marshmallow>=3.22.0"
+  - "marshmallow>=4.0.0"
   - "numpy>=2.1.0"
   - "python-dateutil>=2.8.0"
   - "pytest>=6.0.0"

--- a/paramtools/__init__.py
+++ b/paramtools/__init__.py
@@ -53,7 +53,7 @@ from paramtools.values import Values, Slice, QueryResult
 
 
 name = "paramtools"
-__version__ = "0.19.0"
+__version__ = "0.20.0"
 
 __all__ = [
     "SchemaFactory",

--- a/paramtools/parameters.py
+++ b/paramtools/parameters.py
@@ -101,7 +101,7 @@ class Parameters:
             else:
                 self._stateless_label_grid[name] = []
         self.label_grid = copy.deepcopy(self._stateless_label_grid)
-        self._validator_schema.context["spec"] = self
+        self._validator_schema.pt_context["spec"] = self
         self._warnings = {}
         self._errors = {}
         self._defer_validation = False
@@ -364,7 +364,7 @@ class Parameters:
                 for param, value in parsed_params.items():
                     self._update_param(param, value)
 
-        self._validator_schema.context["spec"] = self
+        self._validator_schema.pt_context["spec"] = self
 
         has_errors = bool(self._errors.get("messages"))
         has_warnings = bool(self._warnings.get("messages"))
@@ -525,7 +525,7 @@ class Parameters:
         if self.label_to_extend is not None and extend_adj:
             self.extend()
 
-        self._validator_schema.context["spec"] = self
+        self._validator_schema.pt_context["spec"] = self
 
         has_errors = bool(self._errors.get("messages"))
         has_warnings = bool(self._warnings.get("messages"))

--- a/paramtools/schema.py
+++ b/paramtools/schema.py
@@ -198,7 +198,7 @@ class BaseValidatorSchema(Schema):
             field_errors = bool(error_store.errors)
             self._invoke_schema_validators(
                 error_store=error_store,
-                pass_many=True,
+                pass_collection=True,
                 data=data,
                 original_data=data,
                 many=None,
@@ -207,7 +207,7 @@ class BaseValidatorSchema(Schema):
             )
             self._invoke_schema_validators(
                 error_store=error_store,
-                pass_many=False,
+                pass_collection=False,
                 data=data,
                 original_data=data,
                 many=None,

--- a/paramtools/schema.py
+++ b/paramtools/schema.py
@@ -7,6 +7,7 @@ from marshmallow import (
     validates_schema,
     ValidationError as MarshmallowValidationError,
     decorators,
+    RAISE as RAISEUNKNOWNOPTION,
 )
 from marshmallow.error_store import ErrorStore
 
@@ -204,6 +205,7 @@ class BaseValidatorSchema(Schema):
                 many=None,
                 partial=None,
                 field_errors=field_errors,
+                unknown=RAISEUNKNOWNOPTION,
             )
             self._invoke_schema_validators(
                 error_store=error_store,
@@ -213,6 +215,7 @@ class BaseValidatorSchema(Schema):
                 many=None,
                 partial=None,
                 field_errors=field_errors,
+                unknown=RAISEUNKNOWNOPTION,
             )
         errors = error_store.errors
         if errors:

--- a/paramtools/schema.py
+++ b/paramtools/schema.py
@@ -177,9 +177,8 @@ class BaseValidatorSchema(Schema):
         "when": "_get_when_validator",
     }
 
-    def __init__(self):
+    def __init__(self, data):
         self.context = {}
-        self.fields = {}
 
     def validate_only(self, data):
         """
@@ -187,6 +186,7 @@ class BaseValidatorSchema(Schema):
         from the marshmallow _do_load function:
         https://github.com/marshmallow-code/marshmallow/blob/3.5.2/src/marshmallow/schema.py#L807
         """
+        self.fields = data.keys()
         error_store = ErrorStore()
         # Run field-level validation
         self._invoke_field_validators(

--- a/paramtools/schema.py
+++ b/paramtools/schema.py
@@ -28,14 +28,14 @@ class RangeSchema(Schema):
     }
     """
 
-    _min = fields.Field(attribute="min", data_key="min")
-    _max = fields.Field(attribute="max", data_key="max")
-    step = fields.Field()
+    _min = fields.Raw(attribute="min", data_key="min")
+    _max = fields.Raw(attribute="max", data_key="max")
+    step = fields.Raw()
     level = fields.String(validate=[validate.OneOf(["warn", "error"])])
 
 
 class ChoiceSchema(Schema):
-    choices = fields.List(fields.Field)
+    choices = fields.List(fields.Raw)
     level = fields.String(validate=[validate.OneOf(["warn", "error"])])
 
 
@@ -53,9 +53,9 @@ class ValueValidatorSchema(Schema):
 
 
 class IsSchema(Schema):
-    equal_to = fields.Field(required=False)
-    greater_than = fields.Field(required=False)
-    less_than = fields.Field(required=False)
+    equal_to = fields.Raw(required=False)
+    greater_than = fields.Raw(required=False)
+    less_than = fields.Raw(required=False)
 
     @validates_schema
     def just_one(self, data, **kwargs):
@@ -107,14 +107,11 @@ class BaseParamSchema(Schema):
         data_key="type",
     )
     number_dims = fields.Integer(required=False, load_default=0)
-    value = fields.Field(required=True)  # will be specified later
+    value = fields.Raw(required=True)  # will be specified later
     validators = fields.Nested(
         ValueValidatorSchema(), required=False, load_default={}
     )
     indexed = fields.Boolean(required=False)
-
-    class Meta:
-        ordered = True
 
 
 class EmptySchema(Schema):
@@ -124,15 +121,6 @@ class EmptySchema(Schema):
     """
 
     pass
-
-
-class OrderedSchema(Schema):
-    """
-    Same as `EmptySchema`, but preserves the order of its fields.
-    """
-
-    class Meta:
-        ordered = True
 
 
 class ValueObject(fields.Nested):
@@ -181,9 +169,6 @@ class BaseValidatorSchema(Schema):
     `build_schema.SchemaBuilder` for how parameters are defined onto this
     class.
     """
-
-    class Meta:
-        ordered = True
 
     WRAPPER_MAP = {
         "range": "_get_range_validator",

--- a/paramtools/schema.py
+++ b/paramtools/schema.py
@@ -192,6 +192,9 @@ class BaseValidatorSchema(Schema):
         "when": "_get_when_validator",
     }
 
+    def __init__(self):
+        self.context = {}
+
     def validate_only(self, data):
         """
         Bypass deserialization and just run field validators. This is taken

--- a/paramtools/schema.py
+++ b/paramtools/schema.py
@@ -188,7 +188,6 @@ class BaseValidatorSchema(Schema):
         from the marshmallow _do_load function:
         https://github.com/marshmallow-code/marshmallow/blob/3.5.2/src/marshmallow/schema.py#L807
         """
-        # self.fields = data.keys()
         error_store = ErrorStore()
         # Run field-level validation
         self._invoke_field_validators(

--- a/paramtools/schema.py
+++ b/paramtools/schema.py
@@ -179,6 +179,7 @@ class BaseValidatorSchema(Schema):
 
     def __init__(self):
         self.context = {}
+        self.fields = {}
 
     def validate_only(self, data):
         """

--- a/paramtools/schema_factory.py
+++ b/paramtools/schema_factory.py
@@ -1,7 +1,6 @@
-from marshmallow import fields
+from marshmallow import fields, Schema
 
 from paramtools.schema import (
-    OrderedSchema,
     BaseValidatorSchema,
     ValueObject,
     get_type,
@@ -67,9 +66,7 @@ class SchemaFactory:
             # if not isinstance(v["value"], list):
             #     v["value"] = [{"value": v["value"]}]
 
-            validator_dict[k] = type(
-                "ValidatorItem", (OrderedSchema,), classattrs
-            )
+            validator_dict[k] = type("ValidatorItem", (Schema,), classattrs)
 
             classattrs = {"value": ValueObject(validator_dict[k], many=True)}
             param_dict[k] = type(
@@ -77,7 +74,7 @@ class SchemaFactory:
             )
 
         classattrs = {k: fields.Nested(v) for k, v in param_dict.items()}
-        DefaultsSchema = type("DefaultsSchema", (OrderedSchema,), classattrs)
+        DefaultsSchema = type("DefaultsSchema", (Schema,), classattrs)
         defaults_schema = DefaultsSchema()
 
         classattrs = {

--- a/paramtools/tests/test_parameters.py
+++ b/paramtools/tests/test_parameters.py
@@ -166,7 +166,6 @@ class TestSchema:
         assert params.hello_world == "hello world"
         assert params.label_grid == {"somelabel": [0, 1, 2, 3, 4, 5]}
 
-
     def test_schema_not_dropped(self, defaults_spec_path):
         with open(defaults_spec_path, "r") as f:
             defaults_ = json.loads(f.read())
@@ -378,14 +377,6 @@ class TestAccess:
         assert set(spec1.keys()) == set(exp.keys())
 
         assert spec1["min_int_param"] == exp["min_int_param"]["value"]
-
-    def test_is_ordered(self, TestParams):
-        params = TestParams()
-        spec1 = params.specification()
-        assert isinstance(spec1, OrderedDict)
-
-        spec2 = params.specification(meta_data=True, serializable=True)
-        assert isinstance(spec2, OrderedDict)
 
     def test_specification_query(self, TestParams):
         params = TestParams()

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setuptools.setup(
     url="https://github.com/hdoupe/ParamTools",
     packages=setuptools.find_packages(),
     install_requires=[
-        "marshmallow>=3.0.0",
+        "marshmallow>=4.0.0",
         "numpy",
         "python-dateutil>=2.8.0",
         "fsspec",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as f:
 
 setuptools.setup(
     name="paramtools",
-    version=os.environ.get("VERSION", "0.19.0"),
+    version=os.environ.get("VERSION", "0.20.0"),
     author="Hank Doupe",
     author_email="henrymdoupe@gmail.com",
     description=(


### PR DESCRIPTION
This PR addresses Issues #144 and #143 by making ParamTools compatible with Marshmallow 4.0.  The [Marshmallow guide](https://marshmallow.readthedocs.io/en/latest/upgrading.html#upgrading-to-newer-releases) (which doesn't have a lot of detail) summarizing the changes.